### PR TITLE
Fix false active-turn detection from stale older turns

### DIFF
--- a/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
@@ -1257,31 +1257,27 @@ extension CodexService {
         }
 
         let turnObjects = threadObject["turns"]?.arrayValue?.compactMap { $0.objectValue } ?? []
-        var latestTurnID: String?
-        var hasInterruptibleTurnWithoutID = false
-
-        for turnObject in turnObjects.reversed() {
-            let turnID = normalizedInterruptIdentifier(
-                turnObject["id"]?.stringValue
-                    ?? turnObject["turnId"]?.stringValue
-                    ?? turnObject["turn_id"]?.stringValue
-            )
-            if latestTurnID == nil, let turnID {
-                latestTurnID = turnID
-            }
-
-            guard isInterruptibleTurnStatus(normalizedInterruptTurnStatus(from: turnObject)) else {
-                continue
-            }
-
-            if let turnID {
-                return (turnID, false, latestTurnID)
-            }
-
-            hasInterruptibleTurnWithoutID = true
+        guard let latestTurnObject = turnObjects.last else {
+            return (nil, false, nil)
         }
 
-        return (nil, hasInterruptibleTurnWithoutID, latestTurnID)
+        let latestTurnID = normalizedInterruptIdentifier(
+            latestTurnObject["id"]?.stringValue
+                ?? latestTurnObject["turnId"]?.stringValue
+                ?? latestTurnObject["turn_id"]?.stringValue
+        )
+        let latestStatus = normalizedInterruptTurnStatus(from: latestTurnObject)
+
+        guard let latestStatus,
+              isInterruptibleTurnStatus(latestStatus) else {
+            return (nil, false, latestTurnID)
+        }
+
+        if let latestTurnID {
+            return (latestTurnID, false, latestTurnID)
+        }
+
+        return (nil, true, latestTurnID)
     }
 
     // Retries after refreshing turn id when local activeTurn cache is stale.

--- a/CodexMobile/CodexMobileTests/TurnViewModelQueueTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnViewModelQueueTests.swift
@@ -357,6 +357,43 @@ final class TurnViewModelQueueTests: XCTestCase {
         XCTAssertEqual(service.activeTurnID(for: "thread-queue"), "turn-new")
     }
 
+    func testRefreshInFlightTurnStateDoesNotUseOlderInterruptibleTurn() async {
+        let service = makeService()
+        service.isConnected = true
+        service.isInitialized = true
+        service.runningThreadIDs.insert("thread-queue")
+        service.activeTurnIdByThread["thread-queue"] = "turn-old"
+        service.activeTurnId = "turn-old"
+
+        service.requestTransportOverride = { method, _ in
+            XCTAssertEqual(method, "thread/read")
+            return RPCMessage(
+                id: .string(UUID().uuidString),
+                result: .object([
+                    "thread": .object([
+                        "turns": .array([
+                            .object([
+                                "id": .string("turn-old"),
+                                "status": .string("in_progress"),
+                            ]),
+                            .object([
+                                "id": .string("turn-latest"),
+                                "status": .string("completed"),
+                            ]),
+                        ])
+                    ])
+                ]),
+                includeJSONRPC: false
+            )
+        }
+
+        let didRefresh = await service.refreshInFlightTurnState(threadId: "thread-queue")
+
+        XCTAssertTrue(didRefresh)
+        XCTAssertFalse(service.runningThreadIDs.contains("thread-queue"))
+        XCTAssertNil(service.activeTurnIdByThread["thread-queue"])
+    }
+
     func testSteerQueuedDraftIsNoOpWhenThreadIsNotRunning() async {
         let service = makeService()
         service.isConnected = true


### PR DESCRIPTION
## Problem
In some threads, mobile marked a turn as active even when there was no steerable active turn.

The bad path came from `readThreadTurnStateSnapshot`: it scanned older turns and could pick an older `in_progress` turn while the latest turn was already terminal. This made the composer treat the thread as running and show Steer incorrectly.

## Root Cause
`readThreadTurnStateSnapshot` searched all turns (reverse iteration) and accepted the first interruptible status it found, even if it belonged to an older turn.

## Fix
- Make snapshot hydration use the latest turn as the source of truth for running/interruptible state.
- If the latest turn is not interruptible, return no active interruptible turn.
- Keep latest turn id in the snapshot for callers that still need latest metadata.

## Tests
Added regression test:
- `testRefreshInFlightTurnStateDoesNotUseOlderInterruptibleTurn`

This test verifies that when latest turn is completed but an older turn is in progress, refresh does **not** keep the thread in running state.
