### PR TITLE
Paginate full thread list sync on iOS

### DIFF
--- a/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
@@ -122,12 +122,12 @@ extension CodexService {
         }
 
         do {
-            let activeThreads = try await fetchServerThreads()
+            let activeThreads = try await fetchServerThreads(limit: realtimeThreadListLimit)
 
             // Also fetch server-archived threads so they survive app restarts.
             var archivedThreads: [CodexThread] = []
             do {
-                archivedThreads = try await fetchServerThreads(archived: true)
+                archivedThreads = try await fetchServerThreads(limit: realtimeThreadListLimit, archived: true)
             } catch {
                 debugSyncLog("thread/list archived fetch failed (non-fatal): \(error.localizedDescription)")
             }

--- a/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
@@ -122,12 +122,12 @@ extension CodexService {
         }
 
         do {
-            let activeThreads = try await fetchServerThreads(limit: recentThreadListLimit)
+            let activeThreads = try await fetchServerThreads()
 
             // Also fetch server-archived threads so they survive app restarts.
             var archivedThreads: [CodexThread] = []
             do {
-                archivedThreads = try await fetchServerThreads(limit: recentThreadListLimit, archived: true)
+                archivedThreads = try await fetchServerThreads(archived: true)
             } catch {
                 debugSyncLog("thread/list archived fetch failed (non-fatal): \(error.localizedDescription)")
             }

--- a/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
@@ -7,20 +7,15 @@
 import Foundation
 
 extension CodexService {
-    // Keeps sidebar/project loading focused on recent conversations without hiding
-    // other active project groups when the latest chats all belong to one repo.
-    var recentThreadListLimit: Int { 40 }
-
     func listThreads(limit: Int? = nil) async throws {
         isLoadingThreads = true
         defer { isLoadingThreads = false }
 
-        let effectiveLimit = limit ?? recentThreadListLimit
-        let activeThreads = try await fetchServerThreads(limit: effectiveLimit)
+        let activeThreads = try await fetchServerThreads(limit: limit)
 
         var archivedThreads: [CodexThread] = []
         do {
-            archivedThreads = try await fetchServerThreads(limit: effectiveLimit, archived: true)
+            archivedThreads = try await fetchServerThreads(limit: limit, archived: true)
         } catch {
             debugSyncLog("thread/list archived fetch failed (non-fatal): \(error.localizedDescription)")
         }

--- a/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
@@ -7,6 +7,9 @@
 import Foundation
 
 extension CodexService {
+    // Keeps high-frequency sync work bounded while manual refreshes can still page through full history.
+    var realtimeThreadListLimit: Int { 40 }
+
     func listThreads(limit: Int? = nil) async throws {
         isLoadingThreads = true
         defer { isLoadingThreads = false }

--- a/CodexMobile/CodexMobileTests/CodexSkillsListDecodeTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexSkillsListDecodeTests.swift
@@ -90,10 +90,88 @@ final class CodexSkillsListDecodeTests: XCTestCase {
         try await service.listThreads()
 
         XCTAssertEqual(capturedParams.count, 2)
-        XCTAssertEqual(capturedParams[0]["limit"]?.intValue, 12)
+        XCTAssertNil(capturedParams[0]["limit"]?.intValue)
         XCTAssertNil(capturedParams[0]["archived"]?.boolValue)
-        XCTAssertEqual(capturedParams[1]["limit"]?.intValue, 12)
+        XCTAssertNil(capturedParams[1]["limit"]?.intValue)
         XCTAssertEqual(capturedParams[1]["archived"]?.boolValue, true)
+    }
+
+    func testListThreadsPaginatesActiveAndArchivedResultsUntilCursorIsExhausted() async throws {
+        let service = makeService()
+        var capturedParams: [RPCObject] = []
+
+        service.requestTransportOverride = { method, params in
+            XCTAssertEqual(method, "thread/list")
+            let object = params?.objectValue ?? [:]
+            capturedParams.append(object)
+
+            let archived = object["archived"]?.boolValue == true
+            let cursor = object["cursor"]
+
+            switch (archived, cursor) {
+            case (false, .some(.null)):
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([
+                        "data": .array([
+                            self.makeThreadJSON(id: "active-1", cwd: "/Users/me/work/app"),
+                        ]),
+                        "nextCursor": .string("active-cursor-2"),
+                    ]),
+                    includeJSONRPC: false
+                )
+            case (false, .some(.string("active-cursor-2"))):
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([
+                        "data": .array([
+                            self.makeThreadJSON(id: "active-2", cwd: "/Users/me/work/site"),
+                        ]),
+                        "nextCursor": .null,
+                    ]),
+                    includeJSONRPC: false
+                )
+            case (true, .some(.null)):
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([
+                        "data": .array([
+                            self.makeThreadJSON(id: "archived-1", cwd: "/Users/me/work/old"),
+                        ]),
+                        "nextCursor": .string("archived-cursor-2"),
+                    ]),
+                    includeJSONRPC: false
+                )
+            case (true, .some(.string("archived-cursor-2"))):
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([
+                        "data": .array([
+                            self.makeThreadJSON(id: "archived-2", cwd: "/Users/me/work/older"),
+                        ]),
+                        "nextCursor": .null,
+                    ]),
+                    includeJSONRPC: false
+                )
+            default:
+                XCTFail("Unexpected thread/list request: \(object)")
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([
+                        "data": .array([]),
+                        "nextCursor": .null,
+                    ]),
+                    includeJSONRPC: false
+                )
+            }
+        }
+
+        try await service.listThreads()
+
+        XCTAssertEqual(capturedParams.count, 4)
+        XCTAssertEqual(Set(service.threads.map(\.id)), Set(["active-1", "active-2", "archived-1", "archived-2"]))
+        XCTAssertEqual(Set(service.threads.filter { $0.syncState == .live }.map(\.id)), Set(["active-1", "active-2"]))
+        XCTAssertEqual(Set(service.threads.filter { $0.syncState == .archivedLocal }.map(\.id)), Set(["archived-1", "archived-2"]))
     }
 
     func testDecodeSkillsListParsesBucketedDataShape() {

--- a/CodexMobile/CodexMobileTests/CodexSkillsListDecodeTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexSkillsListDecodeTests.swift
@@ -69,7 +69,7 @@ final class CodexSkillsListDecodeTests: XCTestCase {
         XCTAssertTrue(requestedSourceKinds.contains("vscode"))
     }
 
-    func testListThreadsDefaultsToRecentProjectFocusedLimit() async throws {
+    func testListThreadsDefaultsToFullHistoryPagination() async throws {
         let service = makeService()
         var capturedParams: [RPCObject] = []
 
@@ -172,6 +172,55 @@ final class CodexSkillsListDecodeTests: XCTestCase {
         XCTAssertEqual(Set(service.threads.map(\.id)), Set(["active-1", "active-2", "archived-1", "archived-2"]))
         XCTAssertEqual(Set(service.threads.filter { $0.syncState == .live }.map(\.id)), Set(["active-1", "active-2"]))
         XCTAssertEqual(Set(service.threads.filter { $0.syncState == .archivedLocal }.map(\.id)), Set(["archived-1", "archived-2"]))
+    }
+
+    func testSyncThreadsListKeepsRealtimePollingScopedToRecentWindow() async {
+        let service = makeService()
+        service.isConnected = true
+        service.isInitialized = true
+
+        var capturedParams: [RPCObject] = []
+
+        service.requestTransportOverride = { method, params in
+            XCTAssertEqual(method, "thread/list")
+            let object = params?.objectValue ?? [:]
+            capturedParams.append(object)
+
+            let archived = object["archived"]?.boolValue == true
+            switch archived {
+            case false:
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([
+                        "data": .array([
+                            self.makeThreadJSON(id: "active-1", cwd: "/Users/me/work/app"),
+                        ]),
+                        "nextCursor": .string("active-cursor-2"),
+                    ]),
+                    includeJSONRPC: false
+                )
+            case true:
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([
+                        "data": .array([
+                            self.makeThreadJSON(id: "archived-1", cwd: "/Users/me/work/old"),
+                        ]),
+                        "nextCursor": .string("archived-cursor-2"),
+                    ]),
+                    includeJSONRPC: false
+                )
+            }
+        }
+
+        await service.syncThreadsList()
+
+        XCTAssertEqual(capturedParams.count, 2)
+        XCTAssertEqual(capturedParams[0]["limit"]?.intValue, service.realtimeThreadListLimit)
+        XCTAssertNil(capturedParams[0]["archived"]?.boolValue)
+        XCTAssertEqual(capturedParams[1]["limit"]?.intValue, service.realtimeThreadListLimit)
+        XCTAssertEqual(capturedParams[1]["archived"]?.boolValue, true)
+        XCTAssertEqual(Set(service.threads.map(\.id)), Set(["active-1", "archived-1"]))
     }
 
     func testDecodeSkillsListParsesBucketedDataShape() {


### PR DESCRIPTION
## Summary
- remove the default first-page cap from iOS thread list sync so active and archived chats paginate until `nextCursor` is exhausted
- keep the existing explicit `limit` behavior for callers that still want a capped request
- add coverage for paginating both active and archived thread lists during `listThreads()`

## Why
Local verification against `codex app-server` showed that the current iOS sync only loads the first page of chats even when the server returns `nextCursor`.

Observed locally:
- active threads, first page with limit 40: 40 items, with `nextCursor`
- archived threads, first page with limit 40: 40 items, with `nextCursor`
- active threads, full pagination: 957 items
- archived threads, full pagination: 92 items

This caused older chats to be missing from the iOS sidebar even though they still existed on the runtime.