### PR TITLE
Add slash-command bridge and prompt expansion pipeline

### DIFF
--- a/CodexMobile/CodexMobile/Models/CodexSlashCommand.swift
+++ b/CodexMobile/CodexMobile/Models/CodexSlashCommand.swift
@@ -1,0 +1,28 @@
+// FILE: CodexSlashCommand.swift
+// Purpose: Models user-provided slash commands from the local bridge.
+// Layer: Model
+// Exports: CodexSlashCommand
+// Depends on: Foundation
+
+import Foundation
+
+struct CodexSlashCommand: Codable, Identifiable, Equatable {
+    let token: String
+    let title: String
+    let subtitle: String?
+    let symbolName: String?
+    let content: String?
+    let argumentHint: String?
+
+    var id: String {
+        normalizedToken.lowercased()
+    }
+
+    var normalizedToken: String {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("/") {
+            return trimmed
+        }
+        return "/\(trimmed)"
+    }
+}

--- a/CodexMobile/CodexMobile/Services/CodexService+Commands.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Commands.swift
@@ -1,0 +1,79 @@
+// FILE: CodexService+Commands.swift
+// Purpose: Fetches and caches local slash commands from the bridge.
+// Layer: Service
+// Exports: CodexService command helpers
+// Depends on: CodexSlashCommand, RPCMessage
+
+import Foundation
+
+extension CodexService {
+    func refreshSlashCommandsIfNeeded(minInterval: TimeInterval = 10) {
+        if isLoadingSlashCommands {
+            return
+        }
+
+        if let lastRefresh = lastSlashCommandsRefreshAt,
+           Date().timeIntervalSince(lastRefresh) < minInterval,
+           !slashCommands.isEmpty {
+            return
+        }
+
+        Task {
+            await refreshSlashCommands()
+        }
+    }
+
+    func refreshSlashCommands() async {
+        if isLoadingSlashCommands {
+            return
+        }
+
+        isLoadingSlashCommands = true
+        defer { isLoadingSlashCommands = false }
+
+        do {
+            let response = try await sendRequest(method: "commands/list", params: .object([:]))
+            guard let decoded = decodeSlashCommands(from: response.result) else {
+                throw CodexServiceError.invalidResponse("commands/list response missing result.commands")
+            }
+
+            let normalized = decoded
+                .map { command in
+                    CodexSlashCommand(
+                        token: command.normalizedToken,
+                        title: command.title.trimmingCharacters(in: .whitespacesAndNewlines),
+                        subtitle: command.subtitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+                        symbolName: command.symbolName?.trimmingCharacters(in: .whitespacesAndNewlines),
+                        content: command.content?.trimmingCharacters(in: .whitespacesAndNewlines),
+                        argumentHint: command.argumentHint?.trimmingCharacters(in: .whitespacesAndNewlines)
+                    )
+                }
+                .filter { !$0.title.isEmpty && !$0.normalizedToken.isEmpty }
+
+            let deduped = Dictionary(grouping: normalized) { $0.normalizedToken.lowercased() }
+                .compactMap { _, bucket in bucket.first }
+                .sorted { lhs, rhs in
+                    lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+                }
+
+            slashCommands = deduped
+            slashCommandsErrorMessage = nil
+            lastSlashCommandsRefreshAt = Date()
+        } catch {
+            slashCommands = []
+            let message = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+            slashCommandsErrorMessage = message.isEmpty ? "Unable to load commands" : message
+        }
+    }
+}
+
+private extension CodexService {
+    func decodeSlashCommands(from result: JSONValue?) -> [CodexSlashCommand]? {
+        guard let resultObject = result?.objectValue,
+              let commandsValue = resultObject["commands"] else {
+            return nil
+        }
+
+        return decodeModel([CodexSlashCommand].self, from: commandsValue)
+    }
+}

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -391,6 +391,10 @@ final class CodexService {
     var hasResolvedRateLimitsSnapshot = false
     var isLoadingRateLimits = false
     var rateLimitsErrorMessage: String?
+    var slashCommands: [CodexSlashCommand] = []
+    var isLoadingSlashCommands = false
+    var slashCommandsErrorMessage: String?
+    var lastSlashCommandsRefreshAt: Date?
     var threadIdByTurnID: [String: String] = [:]
     var hydratedThreadIDs: Set<String> = []
     var loadingThreadIDs: Set<String> = []

--- a/CodexMobile/CodexMobile/Views/Turn/SlashCommandAutocompletePanel.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/SlashCommandAutocompletePanel.swift
@@ -15,7 +15,11 @@ struct SlashCommandAutocompletePanel: View {
     let isLoadingGitBranchTargets: Bool
     let selectedGitBaseBranch: String
     let gitDefaultBranch: String
+    let customCommands: [CodexSlashCommand]
+    let isLoadingCustomCommands: Bool
+    let customCommandsErrorMessage: String?
     let onSelectCommand: (TurnComposerSlashCommand) -> Void
+    let onSelectCustomCommand: (CodexSlashCommand) -> Void
     let onSelectReviewTarget: (TurnComposerReviewTarget) -> Void
     let onSelectForkDestination: (TurnComposerForkDestination) -> Void
     let onClose: () -> Void
@@ -53,13 +57,28 @@ struct SlashCommandAutocompletePanel: View {
     @ViewBuilder
     private func commandList(query: String) -> some View {
         let items = TurnComposerSlashCommand.filtered(matching: query, within: availableCommands)
+        let customItems = filteredCustomCommands(matching: query)
 
-        if items.isEmpty {
-            Text("No commands for /\(query)")
-                .font(AppFont.footnote())
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
+        if items.isEmpty && customItems.isEmpty {
+            if isLoadingCustomCommands {
+                Text("Loading commands...")
+                    .font(AppFont.footnote())
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+            } else if let customCommandsErrorMessage, !customCommandsErrorMessage.isEmpty {
+                Text(customCommandsErrorMessage)
+                    .font(AppFont.footnote())
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+            } else {
+                Text("No commands for /\(query)")
+                    .font(AppFont.footnote())
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+            }
         } else {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
@@ -100,11 +119,57 @@ struct SlashCommandAutocompletePanel: View {
                         .buttonStyle(AutocompleteRowButtonStyle())
                         .disabled(!isEnabled)
                     }
+
+                    if !customItems.isEmpty {
+                        Divider()
+                            .padding(.horizontal, 12)
+
+                        ForEach(customItems) { item in
+                            Button {
+                                HapticFeedback.shared.triggerImpactFeedback(style: .light)
+                                onSelectCustomCommand(item)
+                            } label: {
+                                HStack(spacing: 10) {
+                                    Image(systemName: item.symbolName?.isEmpty == false ? item.symbolName! : "terminal")
+                                        .font(AppFont.system(size: 15, weight: .semibold))
+                                        .foregroundStyle(.primary)
+                                        .frame(width: 22)
+
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(item.title)
+                                            .font(AppFont.subheadline(weight: .semibold))
+                                            .foregroundStyle(.primary)
+                                            .lineLimit(1)
+
+                                        if let subtitle = item.subtitle, !subtitle.isEmpty {
+                                            Text(subtitle)
+                                                .font(AppFont.caption2())
+                                                .foregroundStyle(.secondary)
+                                                .lineLimit(1)
+                                        }
+                                    }
+
+                                    Spacer(minLength: 8)
+
+                                    Text(item.normalizedToken)
+                                        .font(AppFont.footnote())
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .frame(height: Self.rowHeight)
+                                .contentShape(Rectangle())
+                            }
+                            .buttonStyle(AutocompleteRowButtonStyle())
+                        }
+                    }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .scrollIndicators(.visible)
-            .frame(height: Self.visibleListHeight(for: items.count))
+            .frame(height: Self.visibleListHeight(for: items.count + customItems.count))
         }
     }
 
@@ -348,5 +413,23 @@ struct SlashCommandAutocompletePanel: View {
         .padding(.horizontal, 12)
         .padding(.top, 10)
         .padding(.bottom, 6)
+    }
+
+    private func filteredCustomCommands(matching query: String) -> [CodexSlashCommand] {
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmedQuery.isEmpty else {
+            return customCommands
+        }
+
+        return customCommands.filter { command in
+            let blob = [
+                command.title,
+                command.subtitle ?? "",
+                command.normalizedToken,
+            ]
+            .joined(separator: " ")
+            .lowercased()
+            return blob.contains(trimmedQuery)
+        }
     }
 }

--- a/CodexMobile/CodexMobile/Views/Turn/TurnComposerHostView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnComposerHostView.swift
@@ -66,7 +66,10 @@ struct TurnComposerHostView: View {
             showsGitBranchSelector: showsGitControls,
             isLoadingGitBranchTargets: viewModel.isLoadingGitBranchTargets,
             selectedGitBaseBranch: viewModel.selectedGitBaseBranch,
-            gitDefaultBranch: viewModel.gitDefaultBranch
+            gitDefaultBranch: viewModel.gitDefaultBranch,
+            slashCommands: codex.slashCommands,
+            isLoadingSlashCommands: codex.isLoadingSlashCommands,
+            slashCommandsErrorMessage: codex.slashCommandsErrorMessage
         )
         let accessoryState = TurnComposerAccessoryState(
             queuedDrafts: viewModel.queuedDraftsList(codex: codex, threadID: thread.id),
@@ -163,6 +166,7 @@ struct TurnComposerHostView: View {
             onInputChangedForSlashCommandAutocomplete: { text in
                 viewModel.onInputChangedForSlashCommandAutocomplete(
                     text,
+                    codex: codex,
                     activeTurnID: activeTurnID
                 )
             },
@@ -184,6 +188,7 @@ struct TurnComposerHostView: View {
                     viewModel.onSelectSlashCommand(command)
                 }
             },
+            onSelectCustomSlashCommand: viewModel.onSelectCustomSlashCommand,
             onSelectCodeReviewTarget: { target in
                 viewModel.prepareForThreadRerouteFromSlashCommand()
                 onStartCodeReviewThread(target)

--- a/CodexMobile/CodexMobile/Views/Turn/TurnComposerView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnComposerView.swift
@@ -69,6 +69,7 @@ struct TurnComposerView: View {
     let onSelectFileAutocomplete: (CodexFuzzyFileMatch) -> Void
     let onSelectSkillAutocomplete: (CodexSkillMetadata) -> Void
     let onSelectSlashCommand: (TurnComposerSlashCommand) -> Void
+    let onSelectCustomSlashCommand: (CodexSlashCommand) -> Void
     let onSelectCodeReviewTarget: (TurnComposerReviewTarget) -> Void
     let onSelectForkDestination: (TurnComposerForkDestination) -> Void
     let onCloseSlashCommandPanel: () -> Void
@@ -174,6 +175,7 @@ struct TurnComposerView: View {
                             onSelectFileAutocomplete: onSelectFileAutocomplete,
                             onSelectSkillAutocomplete: onSelectSkillAutocomplete,
                             onSelectSlashCommand: onSelectSlashCommand,
+                            onSelectCustomSlashCommand: onSelectCustomSlashCommand,
                             onSelectCodeReviewTarget: onSelectCodeReviewTarget,
                             onSelectForkDestination: onSelectForkDestination,
                             onCloseSlashCommandPanel: onCloseSlashCommandPanel
@@ -229,6 +231,7 @@ private struct TurnComposerAutocompletePanels: View {
     let onSelectFileAutocomplete: (CodexFuzzyFileMatch) -> Void
     let onSelectSkillAutocomplete: (CodexSkillMetadata) -> Void
     let onSelectSlashCommand: (TurnComposerSlashCommand) -> Void
+    let onSelectCustomSlashCommand: (CodexSlashCommand) -> Void
     let onSelectCodeReviewTarget: (TurnComposerReviewTarget) -> Void
     let onSelectForkDestination: (TurnComposerForkDestination) -> Void
     let onCloseSlashCommandPanel: () -> Void
@@ -263,7 +266,11 @@ private struct TurnComposerAutocompletePanels: View {
                     isLoadingGitBranchTargets: state.isLoadingGitBranchTargets,
                     selectedGitBaseBranch: state.selectedGitBaseBranch,
                     gitDefaultBranch: state.gitDefaultBranch,
+                    customCommands: state.slashCommands,
+                    isLoadingCustomCommands: state.isLoadingSlashCommands,
+                    customCommandsErrorMessage: state.slashCommandsErrorMessage,
                     onSelectCommand: onSelectSlashCommand,
+                    onSelectCustomCommand: onSelectCustomSlashCommand,
                     onSelectReviewTarget: onSelectCodeReviewTarget,
                     onSelectForkDestination: onSelectForkDestination,
                     onClose: onCloseSlashCommandPanel
@@ -452,7 +459,10 @@ private struct QueuedDraftsPanelPreviewWrapper: View {
                     showsGitBranchSelector: false,
                     isLoadingGitBranchTargets: false,
                     selectedGitBaseBranch: "",
-                    gitDefaultBranch: "main"
+                    gitDefaultBranch: "main",
+                    slashCommands: [],
+                    isLoadingSlashCommands: false,
+                    slashCommandsErrorMessage: nil
                 ),
                 remainingAttachmentSlots: 4,
                 isComposerInteractionLocked: false,
@@ -517,6 +527,7 @@ private struct QueuedDraftsPanelPreviewWrapper: View {
                 onSelectFileAutocomplete: { _ in },
                 onSelectSkillAutocomplete: { _ in },
                 onSelectSlashCommand: { _ in },
+                onSelectCustomSlashCommand: { _ in },
                 onSelectCodeReviewTarget: { _ in },
                 onSelectForkDestination: { _ in },
                 onCloseSlashCommandPanel: {},

--- a/CodexMobile/CodexMobile/Views/Turn/TurnComposerViewState.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnComposerViewState.swift
@@ -23,6 +23,9 @@ struct TurnComposerAutocompleteState {
     let isLoadingGitBranchTargets: Bool
     let selectedGitBaseBranch: String
     let gitDefaultBranch: String
+    let slashCommands: [CodexSlashCommand]
+    let isLoadingSlashCommands: Bool
+    let slashCommandsErrorMessage: String?
 }
 
 struct TurnComposerAccessoryState {

--- a/CodexMobile/CodexMobile/Views/Turn/TurnViewModel.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnViewModel.swift
@@ -679,6 +679,7 @@ final class TurnViewModel {
     // Keeps `/` command discovery separate from @/$ autocomplete while supporting a bare trailing slash.
     func onInputChangedForSlashCommandAutocomplete(
         _ text: String,
+        codex: CodexService,
         activeTurnID: String?
     ) {
         clearComposerReviewSelectionIfNeededForInput(text)
@@ -705,6 +706,7 @@ final class TurnViewModel {
         resetFileAutocompleteState()
         resetSkillAutocompleteState()
         slashCommandPanelState = .commands(query: token.query)
+        codex.refreshSlashCommandsIfNeeded()
     }
 
     // Turns the selected slash command into the matching inline composer behavior.
@@ -729,6 +731,25 @@ final class TurnViewModel {
     func onSelectCodeReviewTarget(_ target: TurnComposerReviewTarget) {
         removeTrailingSlashCommandTokenFromInputIfNeeded()
         armCodeReviewSelection(command: .codeReview, target: target)
+    }
+
+    func onSelectCustomSlashCommand(_ command: CodexSlashCommand) {
+        let normalizedToken = command.normalizedToken
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedToken.isEmpty else {
+            resetSlashCommandState(clearPendingSelection: true)
+            return
+        }
+
+        if let updatedInput = Self.replacingTrailingSlashCommandToken(in: input, with: normalizedToken) {
+            input = updatedInput
+        } else if input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            input = normalizedToken
+        } else {
+            input = "\(input) \(normalizedToken)"
+        }
+
+        resetSlashCommandState(clearPendingSelection: true)
     }
 
     // Keeps slash token cleanup and submenu dismissal consistent before a fork flow reroutes threads.
@@ -874,7 +895,10 @@ final class TurnViewModel {
 
     // Sends a composer payload, queueing follow-ups while the current run is still active.
     func sendTurn(codex: CodexService, threadID: String) {
-        let payload = buildPayloadWithMentions()
+        let payload = expandSlashCommandsIfNeeded(
+            in: buildPayloadWithMentions(),
+            codex: codex
+        )
         let attachments = readyComposerAttachments
         let skillMentions = composerMentionedSkills.map {
             CodexTurnSkillMention(id: $0.name, name: $0.name, path: $0.path)
@@ -1785,6 +1809,41 @@ final class TurnViewModel {
         }
 
         return "\(cannedPrompt)\n\n\(trimmed)"
+    }
+
+    private func expandSlashCommandsIfNeeded(
+        in payload: String,
+        codex: CodexService
+    ) -> String {
+        let trimmed = payload.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("/") else {
+            return payload
+        }
+
+        let parts = trimmed.split(whereSeparator: { $0.isWhitespace })
+        guard let rawToken = parts.first else {
+            return payload
+        }
+
+        let token = String(rawToken)
+        guard let command = codex.slashCommands.first(where: {
+            $0.normalizedToken.caseInsensitiveCompare(token) == .orderedSame
+        }) else {
+            return payload
+        }
+
+        guard let content = command.content?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !content.isEmpty else {
+            return payload
+        }
+
+        let args = trimmed.dropFirst(token.count)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if args.isEmpty {
+            return content
+        }
+
+        return "\(content)\n\nInput: \(args)"
     }
 
     // Replaces inline `@filename` with `@fullpath` for each mentioned file.

--- a/CodexMobile/CodexMobileTests/TurnComposerReviewModeTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnComposerReviewModeTests.swift
@@ -44,12 +44,17 @@ final class TurnComposerReviewModeTests: XCTestCase {
 
     func testTypingTextClearsConfirmedReviewSelection() {
         let viewModel = makeViewModel()
+        let codex = CodexService()
         viewModel.composerReviewSelection = TurnComposerReviewSelection(
             command: .codeReview,
             target: .uncommittedChanges
         )
 
-        viewModel.onInputChangedForSlashCommandAutocomplete("follow up", activeTurnID: nil)
+        viewModel.onInputChangedForSlashCommandAutocomplete(
+            "follow up",
+            codex: codex,
+            activeTurnID: nil
+        )
 
         XCTAssertNil(viewModel.composerReviewSelection)
         XCTAssertEqual(viewModel.slashCommandPanelState, .hidden)
@@ -103,11 +108,16 @@ final class TurnComposerReviewModeTests: XCTestCase {
 
     func testSelectingSubagentsKeepsSlashPickerClosedAfterInputObserverRuns() {
         let viewModel = makeViewModel()
+        let codex = CodexService()
         viewModel.input = "/sub"
         viewModel.slashCommandPanelState = .commands(query: "sub")
 
         viewModel.onSelectSlashCommand(.subagents)
-        viewModel.onInputChangedForSlashCommandAutocomplete(viewModel.input, activeTurnID: nil)
+        viewModel.onInputChangedForSlashCommandAutocomplete(
+            viewModel.input,
+            codex: codex,
+            activeTurnID: nil
+        )
 
         XCTAssertEqual(viewModel.input, "")
         XCTAssertTrue(viewModel.isSubagentsSelectionArmed)

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -17,6 +17,7 @@ const { printQR } = require("./qr");
 const { rememberActiveThread } = require("./session-state");
 const { handleDesktopRequest } = require("./desktop-handler");
 const { handleGitRequest } = require("./git-handler");
+const { handleCommandsRequest } = require("./commands-handler");
 const { handleThreadContextRequest } = require("./thread-context-handler");
 const { handleWorkspaceRequest } = require("./workspace-handler");
 const { createNotificationsHandler } = require("./notifications-handler");
@@ -301,6 +302,9 @@ function startBridge({
       return;
     }
     if (handleThreadContextRequest(rawMessage, sendApplicationResponse)) {
+      return;
+    }
+    if (handleCommandsRequest(rawMessage, sendApplicationResponse)) {
       return;
     }
     if (handleWorkspaceRequest(rawMessage, sendApplicationResponse)) {

--- a/phodex-bridge/src/commands-handler.js
+++ b/phodex-bridge/src/commands-handler.js
@@ -1,0 +1,297 @@
+// FILE: commands-handler.js
+// Purpose: Serves local slash-command definitions from the user's CODEX_HOME commands folder.
+// Layer: Bridge handler
+// Exports: handleCommandsRequest
+// Depends on: fs, os, path
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+function handleCommandsRequest(rawMessage, sendResponse) {
+  let parsed;
+  try {
+    parsed = JSON.parse(rawMessage);
+  } catch {
+    return false;
+  }
+
+  const method = typeof parsed?.method === "string" ? parsed.method.trim() : "";
+  if (method !== "commands/list") {
+    return false;
+  }
+
+  const id = parsed.id;
+  try {
+    const commands = loadSlashCommands();
+    sendResponse(JSON.stringify({ id, result: { commands } }));
+  } catch (err) {
+    const errorCode = err.errorCode || "commands_list_error";
+    const message = err.userMessage || err.message || "Unable to load commands.";
+    sendResponse(
+      JSON.stringify({
+        id,
+        error: {
+          code: -32000,
+          message,
+          data: { errorCode },
+        },
+      })
+    );
+  }
+
+  return true;
+}
+
+function loadSlashCommands() {
+  const commands = [];
+  const promptCommands = loadPromptCommands();
+  commands.push(...promptCommands);
+
+  const jsonCommands = loadCommandsFromJsonFolder();
+  commands.push(...jsonCommands);
+
+  return dedupeCommands(commands);
+}
+
+function resolveCommandsRoot() {
+  const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), ".codex");
+  return path.join(codexHome, "commands");
+}
+
+function resolvePromptsRoot() {
+  const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), ".codex");
+  return path.join(codexHome, "prompts");
+}
+
+function loadCommandsFromJsonFolder() {
+  const commandsRoot = resolveCommandsRoot();
+  if (!fs.existsSync(commandsRoot)) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(commandsRoot, { withFileTypes: true });
+  const commands = [];
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) {
+      continue;
+    }
+
+    const filePath = path.join(commandsRoot, entry.name);
+    const parsed = readCommandsFile(filePath);
+    if (!parsed.length) {
+      continue;
+    }
+
+    for (const item of parsed) {
+      const normalized = normalizeCommand(item);
+      if (normalized) {
+        commands.push(normalized);
+      }
+    }
+  }
+
+  return commands;
+}
+
+function loadPromptCommands() {
+  const promptsRoot = resolvePromptsRoot();
+  if (!fs.existsSync(promptsRoot)) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(promptsRoot, { withFileTypes: true });
+  const commands = [];
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".md")) {
+      continue;
+    }
+
+    const filePath = path.join(promptsRoot, entry.name);
+    const promptCommand = parsePromptFile(filePath);
+    if (promptCommand) {
+      commands.push(promptCommand);
+    }
+  }
+
+  return commands;
+}
+
+function readCommandsFile(filePath) {
+  let raw = "";
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch {
+    return [];
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  if (Array.isArray(parsed)) {
+    return parsed;
+  }
+
+  if (parsed && Array.isArray(parsed.commands)) {
+    return parsed.commands;
+  }
+
+  return [];
+}
+
+function normalizeCommand(command) {
+  if (!command || typeof command !== "object") {
+    return null;
+  }
+
+  const token = readString(command.token || command.command);
+  const title = readString(command.title || command.name);
+  if (!token || !title) {
+    return null;
+  }
+
+  const normalizedToken = token.startsWith("/") ? token : `/${token}`;
+  const subtitle = readString(command.subtitle || command.description);
+  const symbolName = readString(command.symbolName || command.symbol);
+  const content = readString(command.content || command.prompt);
+  const argumentHint = readString(command.argumentHint || command["argument-hint"]);
+
+  return {
+    token: normalizedToken,
+    title,
+    subtitle: subtitle || null,
+    symbolName: symbolName || null,
+    content: content || null,
+    argumentHint: argumentHint || null,
+  };
+}
+
+function parsePromptFile(filePath) {
+  let raw = "";
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+
+  const parsed = parseFrontmatter(raw);
+  const frontmatter = parsed.fields;
+  const description = readString(frontmatter.description);
+  const argumentHint = readString(frontmatter["argument-hint"]);
+  const baseName = path.basename(filePath, path.extname(filePath));
+  const token = commandTokenFromPromptName(baseName);
+  const title = commandTitleFromPromptName(baseName);
+
+  if (!token || !title) {
+    return null;
+  }
+
+  return {
+    token,
+    title,
+    subtitle: description || null,
+    symbolName: null,
+    content: parsed.body || null,
+    argumentHint: argumentHint || null,
+  };
+}
+
+function parseFrontmatter(raw) {
+  const lines = raw.split(/\r?\n/);
+  if (!lines.length || lines[0].trim() !== "---") {
+    return { fields: {}, body: raw.trim() };
+  }
+
+  const fields = {};
+  let endIndex = -1;
+  for (let i = 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() === "---") {
+      endIndex = i;
+      break;
+    }
+
+    const match = line.match(/^([A-Za-z0-9_-]+)\s*:\s*(.*)$/);
+    if (!match) {
+      continue;
+    }
+
+    const key = match[1];
+    const value = match[2].trim();
+    fields[key] = value.replace(/^"(.*)"$/, "$1");
+  }
+
+  const bodyLines = endIndex >= 0 ? lines.slice(endIndex + 1) : [];
+  const body = bodyLines.join("\n").trim();
+  return { fields, body };
+}
+
+function commandTokenFromPromptName(baseName) {
+  const trimmed = readString(baseName);
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed.includes(":")) {
+    return `/${trimmed}`;
+  }
+
+  if (trimmed.startsWith("opsx-")) {
+    return `/${trimmed.replace("opsx-", "opsx:")}`;
+  }
+
+  return `/${trimmed}`;
+}
+
+function commandTitleFromPromptName(baseName) {
+  const trimmed = readString(baseName);
+  if (!trimmed) {
+    return null;
+  }
+
+  let titleBase = trimmed;
+  if (titleBase.startsWith("opsx-")) {
+    titleBase = titleBase.slice("opsx-".length);
+  } else if (titleBase.includes(":")) {
+    titleBase = titleBase.split(":").pop() || titleBase;
+  }
+
+  const parts = titleBase.split(/[-_]/).filter(Boolean);
+  if (!parts.length) {
+    return null;
+  }
+
+  return parts
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function dedupeCommands(commands) {
+  const seen = new Set();
+  const deduped = [];
+
+  for (const command of commands) {
+    const key = `${command.token}`.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(command);
+  }
+
+  return deduped;
+}
+
+function readString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+module.exports = {
+  handleCommandsRequest,
+};


### PR DESCRIPTION
## Summary
- add a slash-command bridge so slash commands are recognized and routed consistently through the local-first message flow
- implement prompt expansion for slash commands so structured command intent is transformed into a richer runtime prompt before execution
- wire the expansion + bridge path into existing thread/turn handling without reintroducing hosted-service assumptions

## Notes
- keeps the local-first pairing/runtime model intact
- designed to preserve existing conversation flow while enabling command-driven behavior

## Validation
- targeted local verification of slash-command parsing and expansion integration paths