### PR TITLE
Fix local QR pairing startup

### DIFF
--- a/phodex-bridge/src/secure-device-state.js
+++ b/phodex-bridge/src/secure-device-state.js
@@ -38,7 +38,12 @@ function loadOrCreateBridgeDeviceState() {
   }
 
   if (keychainRecord.error) {
-    throw corruptedStateError("legacy Keychain bridge state", keychainRecord.error);
+    warnOnce(
+      "[remodex] Ignoring unreadable legacy Keychain pairing mirror; generating a fresh canonical device-state.json."
+    );
+    const nextState = createBridgeDeviceState();
+    writeBridgeDeviceState(nextState);
+    return nextState;
   }
 
   if (keychainRecord.state) {

--- a/phodex-bridge/test/secure-device-state.test.js
+++ b/phodex-bridge/test/secure-device-state.test.js
@@ -74,15 +74,23 @@ test("loadOrCreateBridgeDeviceState migrates a valid Keychain mirror into the ca
   });
 });
 
-test("loadOrCreateBridgeDeviceState throws when only the legacy Keychain mirror is corrupted", () => {
+test("loadOrCreateBridgeDeviceState replaces a corrupted legacy Keychain mirror with a fresh canonical state", () => {
   withTempDeviceStateEnv(({ keychainMirrorFile, canonicalStateFile }) => {
     fs.writeFileSync(keychainMirrorFile, "{ definitely-not-json", "utf8");
 
-    assert.throws(
-      () => loadOrCreateBridgeDeviceState(),
-      /saved Remodex pairing state in legacy Keychain bridge state is unreadable/i
+    const loadedState = loadOrCreateBridgeDeviceState();
+
+    assert.equal(loadedState.version, 1);
+    assert.ok(loadedState.macDeviceId);
+    assert.ok(loadedState.macIdentityPublicKey);
+    assert.ok(loadedState.macIdentityPrivateKey);
+    assert.deepEqual(loadedState.trustedPhones, {});
+    assert.deepEqual(readCanonicalStateFromDisk(), stripUndefined(loadedState));
+    assert.deepEqual(
+      JSON.parse(fs.readFileSync(keychainMirrorFile, "utf8")),
+      stripUndefined(loadedState)
     );
-    assert.equal(fs.existsSync(canonicalStateFile), false);
+    assert.equal(fs.existsSync(canonicalStateFile), true);
   });
 });
 

--- a/run-local-remodex.sh
+++ b/run-local-remodex.sh
@@ -18,7 +18,7 @@ RELAY_PORT="${RELAY_PORT:-9000}"
 RELAY_HOSTNAME="${RELAY_HOSTNAME:-}"
 RELAY_BRIDGE_HOST=""
 RELAY_PID=""
-BRIDGE_SERVICE_STARTED="false"
+BRIDGE_PID=""
 
 log() {
   echo "[run-local-remodex] $*"
@@ -124,11 +124,9 @@ healthcheck_host() {
 }
 
 cleanup() {
-  if [[ "${BRIDGE_SERVICE_STARTED}" == "true" ]]; then
-    (
-      cd "${BRIDGE_DIR}"
-      node ./bin/remodex.js stop >/dev/null 2>&1 || true
-    )
+  if [[ -n "${BRIDGE_PID}" ]] && kill -0 "${BRIDGE_PID}" 2>/dev/null; then
+    kill "${BRIDGE_PID}" 2>/dev/null || true
+    wait "${BRIDGE_PID}" 2>/dev/null || true
   fi
 
   if [[ -n "${RELAY_PID}" ]] && kill -0 "${RELAY_PID}" 2>/dev/null; then
@@ -298,16 +296,29 @@ EOF
 start_bridge() {
   log "Starting bridge"
   cd "${BRIDGE_DIR}"
-  # The bridge bakes REMODEX_RELAY into the pairing QR, so advertise the host
-  # the iPhone can actually reach instead of the loopback health-check host.
-  REMODEX_RELAY="ws://${RELAY_HOSTNAME}:${RELAY_PORT}/relay" node ./bin/remodex.js up
-  BRIDGE_SERVICE_STARTED="true"
+  # This local helper should print the QR in the current terminal immediately.
+  # Use the foreground bridge path instead of the macOS launchd wrapper so QR
+  # rendering does not depend on daemon state being written back first.
+  REMODEX_RELAY="ws://${RELAY_HOSTNAME}:${RELAY_PORT}/relay" node ./bin/remodex.js run &
+  BRIDGE_PID=$!
 }
 
 hold_open() {
   log "Local relay is ready. Keep this terminal open while testing."
   log "Press Ctrl+C to stop both the local relay and the Remodex bridge service."
-  wait "${RELAY_PID}"
+  while true; do
+    if [[ -n "${RELAY_PID}" ]] && ! kill -0 "${RELAY_PID}" 2>/dev/null; then
+      wait "${RELAY_PID}"
+      return $?
+    fi
+
+    if [[ -n "${BRIDGE_PID}" ]] && ! kill -0 "${BRIDGE_PID}" 2>/dev/null; then
+      wait "${BRIDGE_PID}"
+      return $?
+    fi
+
+    sleep 1
+  done
 }
 
 trap cleanup EXIT INT TERM


### PR DESCRIPTION
  ## Summary

  Fix local-first pairing startup so `./run-local-remodex.sh` reliably shows a QR code and does not crash when the legacy
  Keychain pairing mirror contains malformed JSON.

  ## Changes

  - run the local bridge in foreground mode from `run-local-remodex.sh` so QR rendering happens in the current terminal
  instead of depending on the macOS daemon pairing-session handoff
  - track and clean up the bridge PID directly in the local launcher
  - treat unreadable legacy Keychain pairing state as recoverable when no canonical `device-state.json` exists
  - generate and persist a fresh canonical device state instead of aborting startup
  - update the secure-device-state test to cover recovery from corrupted legacy mirror data

  ## Verification

  - `bash -n run-local-remodex.sh`
  - `node --test ./test/secure-device-state.test.js`
