### PR TITLE
Add native multi-computer pairing and switching on iPhone

### DIFF
--- a/CodexMobile/BuildSupport/CodexMobile-Info.plist
+++ b/CodexMobile/BuildSupport/CodexMobile-Info.plist
@@ -39,8 +39,6 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSCameraUsageDescription</key>
-	<string>Remodex needs camera access to let you take photos and attach them to your messages.</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
@@ -48,22 +46,28 @@
 		<key>NSAllowsArbitraryLoadsInLocalNetworking</key>
 		<true/>
 	</dict>
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>CodexMobile needs local network access to connect to your Codex app-server running on your Mac.</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>Remodex needs microphone access to record voice notes for ChatGPT transcription.</string>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_remodex-permission._tcp</string>
 	</array>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>CodexMobile needs photo library access to let you attach images to your messages.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Remodex needs camera access to let you take photos and attach them to your messages.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>CodexMobile needs local network access to connect to your Codex app-server running on your Mac.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Remodex needs microphone access to record voice notes for ChatGPT transcription.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Remodex needs photo library access to let you save rendered diagrams and attachments.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>CodexMobile needs photo library access to let you attach images to your messages.</string>
 	<key>PHODEX_CHATGPT_CALLBACK_SCHEME</key>
 	<string>$(PHODEX_CHATGPT_CALLBACK_SCHEME)</string>
 	<key>PHODEX_DEFAULT_RELAY_URL</key>
 	<string>$(PHODEX_DEFAULT_RELAY_URL)</string>
+	<key>PHODEX_SUPPORTS_REMOTE_PUSH</key>
+	<string>$(PHODEX_SUPPORTS_REMOTE_PUSH)</string>
+	<key>PHODEX_SUPPORTS_SIGN_IN_WITH_APPLE</key>
+	<string>$(PHODEX_SUPPORTS_SIGN_IN_WITH_APPLE)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>JetBrainsMono-Regular.ttf</string>

--- a/CodexMobile/CodexMobile.xcodeproj/project.pbxproj
+++ b/CodexMobile/CodexMobile.xcodeproj/project.pbxproj
@@ -19,7 +19,9 @@
 		8CE11223A4B5C6D7E8F90123 /* SidebarRunBadgePerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE11223A4B5C6D7E8F90124 /* SidebarRunBadgePerformanceTests.swift */; };
 		8D1F2A3B4C5D6E7F8091A2B3 /* CodexServiceConnectionErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1F2A3B4C5D6E7F8091A2B4 /* CodexServiceConnectionErrorTests.swift */; };
 		8F1A2B3C4D5E6F708192A3B4 /* CodexPushNotificationRegistrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1A2B3C4D5E6F708192A3B5 /* CodexPushNotificationRegistrationTests.swift */; };
+		90A1B2C3D4E5F60718293A4B /* CodexSecurePairingStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A1B2C3D4E5F60718293A4C /* CodexSecurePairingStateTests.swift */; };
 		90120FC72C9B8D0F5F03F14D /* CodexMobileUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D523A0A98D6540D0E2EE6131 /* CodexMobileUITests.swift */; };
+		90B1C2D3E4F5061728394A5B /* ContentViewModelReconnectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B1C2D3E4F5061728394A5C /* ContentViewModelReconnectTests.swift */; };
 		9D7C9A8B7E6D5C4B3A291817 /* TurnViewModelQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7C9A8B7E6D5C4B3A291818 /* TurnViewModelQueueTests.swift */; };
 		A9F1B2C3D4E5F60718293A40 /* TurnSkillAutocompleteTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F1B2C3D4E5F60718293A41 /* TurnSkillAutocompleteTokenTests.swift */; };
 		A9F1B2C3D4E5F60718293A42 /* CodexSkillsListDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F1B2C3D4E5F60718293A43 /* CodexSkillsListDecodeTests.swift */; };
@@ -67,6 +69,8 @@
 		8CE11223A4B5C6D7E8F90124 /* SidebarRunBadgePerformanceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SidebarRunBadgePerformanceTests.swift; sourceTree = "<group>"; };
 		8D1F2A3B4C5D6E7F8091A2B4 /* CodexServiceConnectionErrorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodexServiceConnectionErrorTests.swift; sourceTree = "<group>"; };
 		8F1A2B3C4D5E6F708192A3B5 /* CodexPushNotificationRegistrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodexPushNotificationRegistrationTests.swift; sourceTree = "<group>"; };
+		90A1B2C3D4E5F60718293A4C /* CodexSecurePairingStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodexSecurePairingStateTests.swift; sourceTree = "<group>"; };
+		90B1C2D3E4F5061728394A5C /* ContentViewModelReconnectTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentViewModelReconnectTests.swift; sourceTree = "<group>"; };
 		9A37794F4B32C1952A3770E0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		9D7C9A8B7E6D5C4B3A291818 /* TurnViewModelQueueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TurnViewModelQueueTests.swift; sourceTree = "<group>"; };
 		A9F1B2C3D4E5F60718293A41 /* TurnSkillAutocompleteTokenTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TurnSkillAutocompleteTokenTests.swift; sourceTree = "<group>"; };
@@ -130,6 +134,8 @@
 				C1D2E3F40516273849A5B6C7 /* CodexServiceIncomingCommandExecutionTests.swift */,
 				8D1F2A3B4C5D6E7F8091A2B4 /* CodexServiceConnectionErrorTests.swift */,
 				8F1A2B3C4D5E6F708192A3B5 /* CodexPushNotificationRegistrationTests.swift */,
+				90A1B2C3D4E5F60718293A4C /* CodexSecurePairingStateTests.swift */,
+				90B1C2D3E4F5061728394A5C /* ContentViewModelReconnectTests.swift */,
 				D4F56781234567890ABCDE02 /* CodexServiceIncomingRunIndicatorTests.swift */,
 				E1A2B3C4D5E6F708192A3B4D /* QRScannerPairingValidatorTests.swift */,
 				2A6D4B8C1E3F507192A4B6C9 /* CodexStatusTests.swift */,
@@ -354,6 +360,8 @@
 				B1C2D3E4F5061728394A5B6C /* CodexServiceIncomingCommandExecutionTests.swift in Sources */,
 				8D1F2A3B4C5D6E7F8091A2B3 /* CodexServiceConnectionErrorTests.swift in Sources */,
 				8F1A2B3C4D5E6F708192A3B4 /* CodexPushNotificationRegistrationTests.swift in Sources */,
+				90A1B2C3D4E5F60718293A4B /* CodexSecurePairingStateTests.swift in Sources */,
+				90B1C2D3E4F5061728394A5B /* ContentViewModelReconnectTests.swift in Sources */,
 				D4F56781234567890ABCDE01 /* CodexServiceIncomingRunIndicatorTests.swift in Sources */,
 				E1A2B3C4D5E6F708192A3B4C /* QRScannerPairingValidatorTests.swift in Sources */,
 				2A6D4B8C1E3F507192A4B6C8 /* CodexStatusTests.swift in Sources */,
@@ -600,11 +608,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = Remodex;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
-				"CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = CodexMobile/CodexMobile.entitlements;
+				"CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = CodexMobile/CodexMobileDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 112;
-				DEVELOPMENT_TEAM = HR24WHR326;
+				DEVELOPMENT_TEAM = 9S925D949K;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "BuildSupport/CodexMobile-Info.plist";
@@ -623,8 +631,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.emanueledipietro.Remodex;
+				PRODUCT_BUNDLE_IDENTIFIER = com.heminlin.remodex.debug;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PHODEX_SUPPORTS_REMOTE_PUSH = NO;
+				PHODEX_SUPPORTS_SIGN_IN_WITH_APPLE = NO;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -651,7 +661,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 112;
-				DEVELOPMENT_TEAM = HR24WHR326;
+				DEVELOPMENT_TEAM = 9S925D949K;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "BuildSupport/CodexMobile-Info.plist";
@@ -672,6 +682,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emanueledipietro.Remodex;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PHODEX_SUPPORTS_REMOTE_PUSH = YES;
+				PHODEX_SUPPORTS_SIGN_IN_WITH_APPLE = YES;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/CodexMobile/CodexMobile/CodexMobileDebug.entitlements
+++ b/CodexMobile/CodexMobile/CodexMobileDebug.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/CodexMobile/CodexMobile/ContentView.swift
+++ b/CodexMobile/CodexMobile/ContentView.swift
@@ -19,6 +19,7 @@ struct ContentView: View {
     @State private var navigationPath = NavigationPath()
     @State private var showSettings = false
     @State private var isShowingManualScanner = false
+    @State private var isShowingTrustedHostSwitcher = false
     @State private var hasDismissedAutomaticScanner = false
     @State private var scannerCanReturnToOnboarding = false
     @State private var isSearchActive = false
@@ -114,6 +115,19 @@ struct ContentView: View {
                     },
                     onDismiss: {
                         codex.bridgeUpdatePrompt = nil
+                    }
+                )
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+            }
+            .sheet(isPresented: $isShowingTrustedHostSwitcher) {
+                TrustedHostSwitcherSheet(
+                    hosts: codex.trustedHostPresentations,
+                    onSelect: { deviceId in
+                        handleTrustedHostSelection(deviceId)
+                    },
+                    onPairNewComputer: {
+                        presentManualScannerAfterStoppingReconnect()
                     }
                 )
                 .presentationDetents([.medium, .large])
@@ -279,7 +293,10 @@ struct ContentView: View {
                     Task {
                         await viewModel.toggleConnection(codex: codex)
                     }
-                }
+                },
+                onSwitchComputers: codex.pairedHostCount > 1 ? {
+                    isShowingTrustedHostSwitcher = true
+                } : nil
             ) {
                 if homeConnectionPhase == .connecting || (codex.hasReconnectCandidate && !codex.isConnected) {
                     Button("Scan New QR Code") {
@@ -516,6 +533,7 @@ struct ContentView: View {
             return
         }
 
+        isShowingTrustedHostSwitcher = false
         hasDismissedAutomaticScanner = false
         scannerCanReturnToOnboarding = false
         isShowingManualScanner = true
@@ -528,6 +546,7 @@ struct ContentView: View {
     // Re-opens the scanner after the user backed out to the empty state without a saved pairing.
     private func presentAutomaticScanner() {
         withAnimation {
+            isShowingTrustedHostSwitcher = false
             hasDismissedAutomaticScanner = false
         }
     }
@@ -561,6 +580,20 @@ struct ContentView: View {
             selectedThread = thread
         } catch {
             codex.lastErrorMessage = codex.userFacingTurnErrorMessage(from: error)
+        }
+    }
+
+    private func handleTrustedHostSelection(_ deviceId: String) {
+        let wasConnectedToDifferentHost = codex.isConnected && codex.normalizedRelayMacDeviceId != deviceId
+        codex.selectTrustedHost(deviceId: deviceId)
+
+        guard wasConnectedToDifferentHost else {
+            return
+        }
+
+        Task { @MainActor in
+            await codex.disconnect()
+            codex.clearSavedRelaySession()
         }
     }
 

--- a/CodexMobile/CodexMobile/Services/CodexSecureTransportModels.swift
+++ b/CodexMobile/CodexMobile/Services/CodexSecureTransportModels.swift
@@ -31,6 +31,31 @@ enum CodexSecureConnectionState: Equatable, Sendable {
     case updateRequired
 }
 
+enum CodexHostPlatform: String, Codable, Sendable {
+    case macOS = "macos"
+    case windows = "windows"
+    case linux = "linux"
+    case unknown = "unknown"
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = (try? container.decode(String.self))?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        switch rawValue {
+        case "macos", "mac", "darwin":
+            self = .macOS
+        case "windows", "win32":
+            self = .windows
+        case "linux":
+            self = .linux
+        default:
+            self = .unknown
+        }
+    }
+}
+
 struct CodexPairingQRPayload: Codable, Sendable {
     let v: Int
     let relay: String
@@ -38,6 +63,28 @@ struct CodexPairingQRPayload: Codable, Sendable {
     let macDeviceId: String
     let macIdentityPublicKey: String
     let expiresAt: Int64
+    let displayName: String?
+    let platform: CodexHostPlatform?
+
+    init(
+        v: Int,
+        relay: String,
+        sessionId: String,
+        macDeviceId: String,
+        macIdentityPublicKey: String,
+        expiresAt: Int64,
+        displayName: String? = nil,
+        platform: CodexHostPlatform? = nil
+    ) {
+        self.v = v
+        self.relay = relay
+        self.sessionId = sessionId
+        self.macDeviceId = macDeviceId
+        self.macIdentityPublicKey = macIdentityPublicKey
+        self.expiresAt = expiresAt
+        self.displayName = displayName
+        self.platform = platform
+    }
 }
 
 struct CodexPhoneIdentityState: Codable, Sendable {
@@ -52,6 +99,7 @@ struct CodexTrustedMacRecord: Codable, Sendable {
     let lastPairedAt: Date
     var relayURL: String? = nil
     var displayName: String? = nil
+    var platform: CodexHostPlatform? = nil
     var lastResolvedSessionId: String? = nil
     var lastResolvedAt: Date? = nil
     var lastUsedAt: Date? = nil
@@ -159,7 +207,24 @@ struct CodexTrustedSessionResolveResponse: Codable, Sendable {
     let macDeviceId: String
     let macIdentityPublicKey: String
     let displayName: String?
+    let platform: CodexHostPlatform?
     let sessionId: String
+
+    init(
+        ok: Bool,
+        macDeviceId: String,
+        macIdentityPublicKey: String,
+        displayName: String? = nil,
+        platform: CodexHostPlatform? = nil,
+        sessionId: String
+    ) {
+        self.ok = ok
+        self.macDeviceId = macDeviceId
+        self.macIdentityPublicKey = macIdentityPublicKey
+        self.displayName = displayName
+        self.platform = platform
+        self.sessionId = sessionId
+    }
 }
 
 struct CodexRelayErrorResponse: Codable, Sendable {

--- a/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
@@ -209,9 +209,18 @@ extension CodexService {
         trustedMacRegistry.records.removeValue(forKey: targetDeviceId)
         SecureStore.writeCodable(trustedMacRegistry, for: CodexSecureKeys.trustedMacRegistry)
 
+        if normalizedSelectedHostDeviceId == targetDeviceId {
+            setSelectedHostDeviceId(mostRecentTrustedMacRecord(excluding: targetDeviceId)?.macDeviceId)
+        }
+
         if normalizedLastTrustedMacDeviceId == targetDeviceId {
-            SecureStore.deleteValue(for: CodexSecureKeys.lastTrustedMacDeviceId)
-            lastTrustedMacDeviceId = nil
+            let fallbackDeviceId = mostRecentTrustedMacRecord(excluding: targetDeviceId)?.macDeviceId
+            lastTrustedMacDeviceId = fallbackDeviceId
+            if let fallbackDeviceId {
+                SecureStore.writeString(fallbackDeviceId, for: CodexSecureKeys.lastTrustedMacDeviceId)
+            } else {
+                SecureStore.deleteValue(for: CodexSecureKeys.lastTrustedMacDeviceId)
+            }
         }
 
         if normalizedRelayMacDeviceId == targetDeviceId {

--- a/CodexMobile/CodexMobile/Services/CodexService+Notifications.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Notifications.swift
@@ -94,6 +94,10 @@ private struct CodexRunCompletionNotificationPayload {
 }
 
 extension CodexService {
+    var supportsManagedRemotePush: Bool {
+        bundledCapabilityFlag(named: "PHODEX_SUPPORTS_REMOTE_PUSH", default: true)
+    }
+
     // Wires the UNUserNotificationCenter delegate once so taps can reopen the right thread.
     func configureNotifications() {
         guard !hasConfiguredNotifications else {
@@ -150,6 +154,11 @@ extension CodexService {
 
     // Registers with APNs only after the user has not explicitly denied alert notifications.
     func registerForRemoteNotificationsIfAllowed() async {
+        guard supportsManagedRemotePush else {
+            lastPushRegistrationSignature = nil
+            return
+        }
+
         guard notificationAuthorizationStatus != .denied,
               notificationAuthorizationStatus != .notDetermined else {
             await syncManagedPushRegistrationIfNeeded(force: true)
@@ -176,6 +185,11 @@ extension CodexService {
 
     // Push token sync is best-effort so reconnects stay resilient if the managed backend is unavailable.
     func syncManagedPushRegistrationIfNeeded(force: Bool = false) async {
+        guard supportsManagedRemotePush else {
+            lastPushRegistrationSignature = nil
+            return
+        }
+
         guard isConnected, isInitialized else {
             return
         }
@@ -500,6 +514,25 @@ private extension CodexService {
         } catch {
             debugRuntimeLog("thread refresh for notification routing failed: \(error.localizedDescription)")
             return false
+        }
+    }
+
+    func bundledCapabilityFlag(named key: String, default defaultValue: Bool) -> Bool {
+        if let value = Bundle.main.object(forInfoDictionaryKey: key) as? Bool {
+            return value
+        }
+
+        guard let stringValue = Bundle.main.object(forInfoDictionaryKey: key) as? String else {
+            return defaultValue
+        }
+
+        switch stringValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "1", "true", "yes":
+            return true
+        case "0", "false", "no":
+            return false
+        default:
+            return defaultValue
         }
     }
 }

--- a/CodexMobile/CodexMobile/Services/CodexService+SecureTransport.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+SecureTransport.swift
@@ -272,6 +272,13 @@ extension CodexService {
         lastAppliedBridgeOutboundSeq = 0
         shouldForceQRBootstrapOnNextHandshake = true
         trustedReconnectFailureCount = 0
+        setSelectedHostDeviceId(payload.macDeviceId)
+        if var existing = trustedMacRegistry.records[payload.macDeviceId] {
+            existing.displayName = payload.displayName ?? existing.displayName
+            existing.platform = payload.platform ?? existing.platform
+            trustedMacRegistry.records[payload.macDeviceId] = existing
+            SecureStore.writeCodable(trustedMacRegistry, for: CodexSecureKeys.trustedMacRegistry)
+        }
         secureConnectionState = trustedMacRegistry.records[payload.macDeviceId] == nil ? .handshaking : .trustedMac
         secureMacFingerprint = codexSecureFingerprint(for: payload.macIdentityPublicKey)
     }
@@ -510,12 +517,14 @@ private extension CodexService {
             lastPairedAt: Date(),
             relayURL: relayURL ?? existing?.relayURL,
             displayName: displayName ?? existing?.displayName,
+            platform: existing?.platform,
             lastResolvedSessionId: existing?.lastResolvedSessionId,
             lastResolvedAt: existing?.lastResolvedAt,
             lastUsedAt: Date()
         )
         SecureStore.writeCodable(trustedMacRegistry, for: CodexSecureKeys.trustedMacRegistry)
         SecureStore.writeString(deviceId, for: CodexSecureKeys.lastTrustedMacDeviceId)
+        setSelectedHostDeviceId(deviceId)
         lastTrustedMacDeviceId = deviceId
         secureMacFingerprint = codexSecureFingerprint(for: publicKey)
     }
@@ -627,11 +636,13 @@ private extension CodexService {
         secureConnectionState = .trustedMac
         secureMacFingerprint = codexSecureFingerprint(for: resolved.macIdentityPublicKey)
         SecureStore.writeString(resolved.macDeviceId, for: CodexSecureKeys.lastTrustedMacDeviceId)
+        setSelectedHostDeviceId(resolved.macDeviceId)
         lastTrustedMacDeviceId = resolved.macDeviceId
 
         if var trustedMac = trustedMacRegistry.records[resolved.macDeviceId] {
             trustedMac.relayURL = relayURL
             trustedMac.displayName = resolved.displayName ?? trustedMac.displayName
+            trustedMac.platform = resolved.platform ?? trustedMac.platform
             trustedMac.lastResolvedSessionId = resolved.sessionId
             trustedMac.lastResolvedAt = Date()
             trustedMac.lastUsedAt = Date()

--- a/CodexMobile/CodexMobile/Services/CodexService+TrustedPairPresentation.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+TrustedPairPresentation.swift
@@ -1,7 +1,7 @@
 // FILE: CodexService+TrustedPairPresentation.swift
-// Purpose: Derives a compact UI-facing summary for the connected or remembered Mac pair.
+// Purpose: Derives UI-facing summary and list models for paired computers.
 // Layer: Service extension
-// Exports: CodexTrustedPairPresentation, CodexService trusted-pair presentation helpers
+// Exports: CodexTrustedPairPresentation, CodexTrustedHostPresentation, CodexService trusted-host helpers
 // Depends on: Foundation
 
 import Foundation
@@ -12,12 +12,54 @@ struct CodexTrustedPairPresentation: Equatable, Sendable {
     let name: String
     let systemName: String?
     let detail: String?
+    let platform: CodexHostPlatform
+    let pairedDeviceCount: Int
+}
+
+struct CodexTrustedHostPresentation: Equatable, Identifiable, Sendable {
+    let deviceId: String
+    let name: String
+    let systemName: String?
+    let detail: String?
+    let platform: CodexHostPlatform
+    let isCurrent: Bool
+    let isConnected: Bool
+    let lastActivityAt: Date?
+
+    var id: String { deviceId }
+}
+
+extension CodexHostPlatform {
+    var displayName: String {
+        switch self {
+        case .macOS:
+            return "macOS"
+        case .windows:
+            return "Windows"
+        case .linux:
+            return "Linux"
+        case .unknown:
+            return "Computer"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .macOS:
+            return "desktopcomputer"
+        case .windows:
+            return "laptopcomputer"
+        case .linux:
+            return "terminal"
+        case .unknown:
+            return "desktopcomputer"
+        }
+    }
 }
 
 enum SidebarMacNicknameStore {
     private static let keyPrefix = "codex.sidebarMacNickname."
 
-    // Keeps sidebar aliases scoped to a stable Mac id instead of a single global setting.
     static func nickname(for deviceId: String?) -> String {
         guard let storageKey = storageKey(for: deviceId) else {
             return ""
@@ -26,7 +68,6 @@ enum SidebarMacNicknameStore {
         return UserDefaults.standard.string(forKey: storageKey) ?? ""
     }
 
-    // Clears blank aliases so stale names do not survive after users switch back to the system name.
     static func setNickname(_ nickname: String, for deviceId: String?) {
         guard let storageKey = storageKey(for: deviceId) else {
             return
@@ -52,15 +93,19 @@ enum SidebarMacNicknameStore {
 }
 
 extension CodexService {
-    // Builds the minimal pair summary shown by Home and Settings so both surfaces stay in sync.
+    var pairedHostCount: Int {
+        trustedMacRegistry.records.count
+    }
+
     var trustedPairPresentation: CodexTrustedPairPresentation? {
-        let macName = trustedPairDisplayName
-        let macFingerprint = trustedPairFingerprint
-        guard macName != nil || macFingerprint != nil else {
+        guard let trustedHost = visibleTrustedHostRecord else {
             return nil
         }
 
-        let fallbackName = "Mac \(macFingerprint ?? "")".trimmingCharacters(in: .whitespacesAndNewlines)
+        let macName = nonEmptyTrimmedString(trustedHost.displayName)
+        let fingerprint = trustedPairFingerprint
+        let fallbackName = "\(trustedHostPlatform(for: trustedHost).displayName) \(fingerprint ?? "")"
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         let systemName = macName ?? fallbackName
         let nickname = SidebarMacNicknameStore.nickname(for: trustedPairDeviceId)
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -71,65 +116,149 @@ extension CodexService {
             title: trustedPairTitle,
             name: effectiveName,
             systemName: nickname.isEmpty ? nil : systemName,
-            detail: trustedPairDetail(displayName: macName, fingerprint: macFingerprint)
+            detail: trustedPairDetail(displayName: macName, fingerprint: fingerprint),
+            platform: trustedHostPlatform(for: trustedHost),
+            pairedDeviceCount: pairedHostCount
         )
+    }
+
+    var trustedHostPresentations: [CodexTrustedHostPresentation] {
+        let activeDeviceId = activeTrustedHostDeviceId
+
+        return trustedMacRegistry.records.values
+            .sorted { lhs, rhs in
+                let lhsIsActive = lhs.macDeviceId == activeDeviceId
+                let rhsIsActive = rhs.macDeviceId == activeDeviceId
+                if lhsIsActive != rhsIsActive {
+                    return lhsIsActive
+                }
+
+                let lhsActivity = lhs.lastUsedAt ?? lhs.lastResolvedAt ?? lhs.lastPairedAt
+                let rhsActivity = rhs.lastUsedAt ?? rhs.lastResolvedAt ?? rhs.lastPairedAt
+                if lhsActivity != rhsActivity {
+                    return lhsActivity > rhsActivity
+                }
+
+                return lhs.macDeviceId < rhs.macDeviceId
+            }
+            .map { record in
+                let displayName = trustedHostDisplayName(for: record)
+                let nickname = SidebarMacNicknameStore.nickname(for: record.macDeviceId)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                let effectiveName = nickname.isEmpty ? displayName.systemName : nickname
+                let detail = trustedHostListDetail(for: record)
+
+                return CodexTrustedHostPresentation(
+                    deviceId: record.macDeviceId,
+                    name: effectiveName,
+                    systemName: nickname.isEmpty ? nil : displayName.systemName,
+                    detail: detail,
+                    platform: trustedHostPlatform(for: record),
+                    isCurrent: record.macDeviceId == activeDeviceId,
+                    isConnected: record.macDeviceId == normalizedRelayMacDeviceId && isConnected,
+                    lastActivityAt: record.lastUsedAt ?? record.lastResolvedAt ?? record.lastPairedAt
+                )
+            }
+    }
+
+    func selectTrustedHost(deviceId: String) {
+        guard trustedMacRegistry.records[deviceId] != nil else {
+            return
+        }
+
+        setSelectedHostDeviceId(deviceId)
+        SecureStore.writeString(deviceId, for: CodexSecureKeys.lastTrustedMacDeviceId)
+        lastTrustedMacDeviceId = deviceId
+
+        if normalizedRelayMacDeviceId != deviceId {
+            if isConnected {
+                secureConnectionState = .trustedMac
+            } else {
+                resetSecureTransportState()
+            }
+        }
     }
 }
 
 private extension CodexService {
-    // Chooses the Mac identity the UI should surface first: the live relay target when available,
-    // otherwise the preferred trusted Mac remembered for reconnect.
-    var visibleTrustedMacRecord: CodexTrustedMacRecord? {
-        if let normalizedRelayMacDeviceId,
-           let trustedMac = trustedMacRegistry.records[normalizedRelayMacDeviceId] {
-            return trustedMac
+    var activeTrustedHostDeviceId: String? {
+        normalizedRelayMacDeviceId ?? preferredTrustedMacDeviceId
+    }
+
+    var visibleTrustedHostRecord: CodexTrustedMacRecord? {
+        if let activeTrustedHostDeviceId {
+            return trustedMacRegistry.records[activeTrustedHostDeviceId]
         }
-
-        return preferredTrustedMacRecord
+        return nil
     }
 
-    // Reuses the connected device id when available, otherwise falls back to the saved preferred Mac.
     var trustedPairDeviceId: String? {
-        normalizedRelayMacDeviceId ?? visibleTrustedMacRecord?.macDeviceId
-    }
-
-    var trustedPairDisplayName: String? {
-        nonEmptyTrimmedString(visibleTrustedMacRecord?.displayName)
+        activeTrustedHostDeviceId
     }
 
     var trustedPairFingerprint: String? {
         nonEmptyTrimmedString(secureMacFingerprint)
             ?? normalizedRelayMacIdentityPublicKey.map { codexSecureFingerprint(for: $0) }
-            ?? visibleTrustedMacRecord.map { codexSecureFingerprint(for: $0.macIdentityPublicKey) }
+            ?? visibleTrustedHostRecord.map { codexSecureFingerprint(for: $0.macIdentityPublicKey) }
     }
 
     var trustedPairTitle: String {
         if isConnected || secureConnectionState == .encrypted {
-            return "Connected Pair"
+            return "Current Computer"
         }
 
         switch secureConnectionState {
         case .handshaking:
-            return "Pairing Mac"
+            return "Pairing Computer"
         case .liveSessionUnresolved, .reconnecting, .trustedMac:
-            return "Saved Pair"
+            return "Ready Computer"
         case .rePairRequired:
-            return "Previous Pair"
+            return "Previous Computer"
         case .updateRequired, .notPaired:
-            return "Trusted Pair"
+            return "Paired Computer"
         case .encrypted:
-            return "Connected Pair"
+            return "Current Computer"
         }
     }
 
-    // Shows both the human name and stable fingerprint when we have them, but keeps the summary compact.
     func trustedPairDetail(displayName: String?, fingerprint: String?) -> String? {
         var parts: [String] = [secureConnectionState.statusLabel]
+        if pairedHostCount > 1 {
+            parts.append("\(pairedHostCount) paired")
+        }
         if displayName != nil, let fingerprint {
             parts.append(fingerprint)
         }
         let joined = parts.joined(separator: " · ")
         return joined.isEmpty ? nil : joined
+    }
+
+    func trustedHostDisplayName(for record: CodexTrustedMacRecord) -> (systemName: String, displayName: String?) {
+        let displayName = nonEmptyTrimmedString(record.displayName)
+        let fingerprint = codexSecureFingerprint(for: record.macIdentityPublicKey)
+        let systemName = displayName
+            ?? "\(trustedHostPlatform(for: record).displayName) \(fingerprint)"
+        return (systemName: systemName, displayName: displayName)
+    }
+
+    func trustedHostPlatform(for record: CodexTrustedMacRecord) -> CodexHostPlatform {
+        record.platform ?? .unknown
+    }
+
+    func trustedHostListDetail(for record: CodexTrustedMacRecord) -> String? {
+        var parts: [String] = [trustedHostPlatform(for: record).displayName]
+
+        if record.macDeviceId == normalizedRelayMacDeviceId, isConnected {
+            parts.append("Connected")
+        } else if record.macDeviceId == preferredTrustedMacDeviceId {
+            parts.append("Current")
+        } else if record.relayURL?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            parts.append("Ready")
+        }
+
+        let fingerprint = codexSecureFingerprint(for: record.macIdentityPublicKey)
+        parts.append(fingerprint)
+        return parts.joined(separator: " · ")
     }
 
     func nonEmptyTrimmedString(_ value: String?) -> String? {

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -431,6 +431,7 @@ final class CodexService {
     var pendingHandshake: CodexPendingHandshake?
     var phoneIdentityState: CodexPhoneIdentityState
     var trustedMacRegistry: CodexTrustedMacRegistry
+    var selectedHostDeviceId: String?
     var lastTrustedMacDeviceId: String?
     var pendingSecureControlContinuations: [String: [CodexSecureControlWaiter]] = [:]
     var bufferedSecureControlMessages: [String: [String]] = [:]
@@ -493,6 +494,7 @@ final class CodexService {
         self.remoteNotificationRegistrar = remoteNotificationRegistrar
         self.phoneIdentityState = codexPhoneIdentityStateFromSecureStore()
         self.trustedMacRegistry = codexTrustedMacRegistryFromSecureStore()
+        self.selectedHostDeviceId = SecureStore.readString(for: CodexSecureKeys.selectedHostDeviceId)
         self.lastTrustedMacDeviceId = SecureStore.readString(for: CodexSecureKeys.lastTrustedMacDeviceId)
         let loadedMessages = messagePersistence.load().mapValues { messages in
             messages.map { message in
@@ -625,6 +627,18 @@ final class CodexService {
         normalizedRelaySessionId != nil && normalizedRelayURL != nil
     }
 
+    var savedRelaySessionMatchesPreferredHost: Bool {
+        guard hasSavedRelaySession else {
+            return false
+        }
+
+        guard let preferredTrustedMacDeviceId else {
+            return true
+        }
+
+        return normalizedRelayMacDeviceId == preferredTrustedMacDeviceId
+    }
+
     // Normalizes the persisted relay session id before reuse in reconnect flows.
     var normalizedRelaySessionId: String? {
         relaySessionId?
@@ -657,18 +671,56 @@ final class CodexService {
             .nilIfEmpty
     }
 
+    var normalizedSelectedHostDeviceId: String? {
+        selectedHostDeviceId?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty
+    }
+
     var preferredTrustedMacDeviceId: String? {
+        if let normalizedSelectedHostDeviceId,
+           trustedMacRegistry.records[normalizedSelectedHostDeviceId] != nil {
+            return normalizedSelectedHostDeviceId
+        }
+
         if let normalizedLastTrustedMacDeviceId,
            trustedMacRegistry.records[normalizedLastTrustedMacDeviceId] != nil {
             return normalizedLastTrustedMacDeviceId
         }
 
-        return trustedMacRegistry.records.values
+        return mostRecentTrustedMacRecord()?
+            .macDeviceId
+    }
+
+    func setSelectedHostDeviceId(_ deviceId: String?) {
+        let normalizedDeviceId = deviceId?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty
+
+        guard normalizedSelectedHostDeviceId != normalizedDeviceId else {
+            return
+        }
+
+        selectedHostDeviceId = normalizedDeviceId
+        if let normalizedDeviceId {
+            SecureStore.writeString(normalizedDeviceId, for: CodexSecureKeys.selectedHostDeviceId)
+        } else {
+            SecureStore.deleteValue(for: CodexSecureKeys.selectedHostDeviceId)
+        }
+    }
+
+    func mostRecentTrustedMacRecord(excluding excludedDeviceId: String? = nil) -> CodexTrustedMacRecord? {
+        trustedMacRegistry.records.values
+            .filter { record in
+                guard let excludedDeviceId else {
+                    return true
+                }
+                return record.macDeviceId != excludedDeviceId
+            }
             .sorted { lhs, rhs in
                 (lhs.lastUsedAt ?? lhs.lastPairedAt) > (rhs.lastUsedAt ?? rhs.lastPairedAt)
             }
-            .first?
-            .macDeviceId
+            .first
     }
 
     var preferredTrustedMacRecord: CodexTrustedMacRecord? {
@@ -683,7 +735,7 @@ final class CodexService {
     }
 
     var hasReconnectCandidate: Bool {
-        hasSavedRelaySession || hasTrustedMacReconnectCandidate
+        savedRelaySessionMatchesPreferredHost || hasTrustedMacReconnectCandidate
     }
 
     // Separates transport readiness from post-connect hydration so the UI can explain delays honestly.

--- a/CodexMobile/CodexMobile/Services/SecureStore.swift
+++ b/CodexMobile/CodexMobile/Services/SecureStore.swift
@@ -17,6 +17,7 @@ enum CodexSecureKeys {
     static let pushDeviceToken = "codex.push.deviceToken"
     static let trustedMacRegistry = "codex.secure.trustedMacRegistry"
     static let lastTrustedMacDeviceId = "codex.secure.lastTrustedMacDeviceId"
+    static let selectedHostDeviceId = "codex.secure.selectedHostDeviceId"
     static let phoneIdentityState = "codex.secure.phoneIdentityState"
     static let messageHistoryKey = "codex.local.messageHistoryKey"
 }

--- a/CodexMobile/CodexMobile/Views/Home/ContentViewModel.swift
+++ b/CodexMobile/CodexMobile/Views/Home/ContentViewModel.swift
@@ -325,7 +325,7 @@ extension ContentViewModel {
         } catch let error as CodexTrustedSessionResolveError {
             return trustedReconnectResolution(for: error, codex: codex)
         } catch {
-            if !codex.hasSavedRelaySession {
+            if !codex.savedRelaySessionMatchesPreferredHost {
                 codex.lastErrorMessage = error.localizedDescription
             }
             return .fallbackToSaved
@@ -348,14 +348,14 @@ extension ContentViewModel {
     ) -> ReconnectURLResolution {
         switch error {
         case .unsupportedRelay:
-            if !codex.hasSavedRelaySession {
+            if !codex.savedRelaySessionMatchesPreferredHost {
                 codex.connectionRecoveryState = .idle
                 codex.lastErrorMessage = "This relay needs a fresh QR scan before trusted reconnect is available."
                 return .stop
             }
             return .fallbackToSaved
         case .macOffline(let message):
-            if codex.hasSavedRelaySession {
+            if codex.savedRelaySessionMatchesPreferredHost {
                 codex.lastErrorMessage = nil
                 return .fallbackToSaved
             }
@@ -370,7 +370,7 @@ extension ContentViewModel {
         case .noTrustedMac:
             return .fallbackToSaved
         case .invalidResponse(let message), .network(let message):
-            if !codex.hasSavedRelaySession {
+            if !codex.savedRelaySessionMatchesPreferredHost {
                 codex.lastErrorMessage = message
             }
             return .fallbackToSaved
@@ -379,6 +379,9 @@ extension ContentViewModel {
 
     // Reuses the last QR-resolved session when trusted lookup is unavailable or not yet supported end-to-end.
     private func savedReconnectURL(codex: CodexService) -> String? {
+        guard codex.savedRelaySessionMatchesPreferredHost else {
+            return nil
+        }
         guard let sessionId = codex.normalizedRelaySessionId,
               let relayURL = codex.normalizedRelayURL else {
             return nil

--- a/CodexMobile/CodexMobile/Views/Home/HomeEmptyStateView.swift
+++ b/CodexMobile/CodexMobile/Views/Home/HomeEmptyStateView.swift
@@ -13,6 +13,7 @@ struct HomeEmptyStateView<AuthSection: View>: View {
     let trustedPairPresentation: CodexTrustedPairPresentation?
     let offlinePrimaryButtonTitle: String
     let onPrimaryAction: () -> Void
+    let onSwitchComputers: (() -> Void)?
     @ViewBuilder let authSection: () -> AuthSection
 
     @State private var dotPulse = false
@@ -60,6 +61,16 @@ struct HomeEmptyStateView<AuthSection: View>: View {
 
                 if let trustedPairPresentation {
                     TrustedPairSummaryView(presentation: trustedPairPresentation)
+
+                    if trustedPairPresentation.pairedDeviceCount > 1,
+                       let onSwitchComputers {
+                        Button("Switch Computer") {
+                            onSwitchComputers()
+                        }
+                        .font(AppFont.subheadline(weight: .semibold))
+                        .foregroundStyle(.primary)
+                        .buttonStyle(.plain)
+                    }
                 } else if let securityLabel, !securityLabel.isEmpty {
                     Text(securityLabel)
                         .font(AppFont.caption())

--- a/CodexMobile/CodexMobile/Views/SettingsView.swift
+++ b/CodexMobile/CodexMobile/Views/SettingsView.swift
@@ -10,7 +10,9 @@ struct SettingsView: View {
     @Environment(CodexService.self) private var codex
 
     @AppStorage("codex.appFontStyle") private var appFontStyleRawValue = AppFont.defaultStoredStyleRawValue
-    @State private var isShowingMacNameSheet = false
+    @State private var editingHostDeviceId: String?
+    @State private var hostPendingForget: CodexTrustedHostPresentation?
+    @State private var isShowingPairComputerScanner = false
 
     private let runtimeAutoValue = "__AUTO__"
     private let runtimeNormalValue = "__NORMAL__"
@@ -24,6 +26,7 @@ struct SettingsView: View {
                 SettingsNotificationsCard()
                 SettingsGPTAccountCard()
                 runtimeDefaultsSection
+                pairedComputersSection
                 SettingsAboutCard()
                 SettingsUsageCard()
                 connectionSection
@@ -32,14 +35,54 @@ struct SettingsView: View {
         }
         .font(AppFont.body())
         .navigationTitle("Settings")
-        .sheet(isPresented: $isShowingMacNameSheet) {
-            if let trustedPairPresentation = codex.trustedPairPresentation {
+        .sheet(isPresented: Binding(
+            get: { editingTrustedHostPresentation != nil },
+            set: { if !$0 { editingHostDeviceId = nil } }
+        )) {
+            if let trustedHostPresentation = editingTrustedHostPresentation {
                 SettingsMacNameSheet(
-                    nickname: sidebarMacNicknameBinding(for: trustedPairPresentation),
-                    currentName: trustedPairPresentation.name,
-                    systemName: trustedPairPresentation.systemName ?? trustedPairPresentation.name
+                    nickname: sidebarMacNicknameBinding(for: trustedHostPresentation.deviceId),
+                    currentName: trustedHostPresentation.name,
+                    systemName: trustedHostPresentation.systemName ?? trustedHostPresentation.name
                 )
             }
+        }
+        .sheet(isPresented: $isShowingPairComputerScanner) {
+            NavigationStack {
+                QRScannerView(
+                    onBack: { isShowingPairComputerScanner = false },
+                    onScan: { pairingPayload in
+                        Task {
+                            isShowingPairComputerScanner = false
+                            await ContentViewModel().connectToRelay(
+                                pairingPayload: pairingPayload,
+                                codex: codex
+                            )
+                        }
+                    }
+                )
+                .navigationBarHidden(true)
+            }
+        }
+        .confirmationDialog(
+            "Forget \(hostPendingForget?.name ?? "computer")?",
+            isPresented: Binding(
+                get: { hostPendingForget != nil },
+                set: { if !$0 { hostPendingForget = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Forget Computer", role: .destructive) {
+                if let hostPendingForget {
+                    codex.forgetTrustedMac(deviceId: hostPendingForget.deviceId)
+                }
+                hostPendingForget = nil
+            }
+            Button("Cancel", role: .cancel) {
+                hostPendingForget = nil
+            }
+        } message: {
+            Text("This iPhone will stop trusting that computer until you scan a new QR code.")
         }
     }
 
@@ -122,11 +165,11 @@ struct SettingsView: View {
                     presentation: trustedPairPresentation,
                     connectionStatusLabel: connectionStatusLabel,
                     onEditName: {
-                        isShowingMacNameSheet = true
+                        editingHostDeviceId = trustedPairPresentation.deviceId
                     }
                 )
             } else {
-                Text("No paired Mac")
+                Text("No paired computer")
                     .font(AppFont.subheadline(weight: .semibold))
                     .foregroundStyle(.primary)
             }
@@ -158,11 +201,44 @@ struct SettingsView: View {
                     HapticFeedback.shared.triggerImpactFeedback()
                     disconnectRelay()
                 }
-            } else if codex.hasTrustedMacReconnectCandidate {
-                SettingsButton("Forget Pair", role: .destructive) {
+            } else if codex.hasReconnectCandidate {
+                SettingsButton("Scan New QR Code") {
                     HapticFeedback.shared.triggerImpactFeedback()
-                    codex.forgetTrustedMac()
+                    isShowingPairComputerScanner = true
                 }
+            }
+        }
+    }
+
+    @ViewBuilder private var pairedComputersSection: some View {
+        SettingsCard(title: "Paired Computers") {
+            if codex.trustedHostPresentations.isEmpty {
+                Text("No paired computers yet")
+                    .font(AppFont.subheadline(weight: .semibold))
+                    .foregroundStyle(.primary)
+            } else {
+                VStack(spacing: 10) {
+                    ForEach(codex.trustedHostPresentations) { host in
+                        SettingsPairedHostRow(
+                            host: host,
+                            onSelect: {
+                                HapticFeedback.shared.triggerImpactFeedback(style: .light)
+                                handleHostSelection(host.deviceId)
+                            },
+                            onEditName: {
+                                editingHostDeviceId = host.deviceId
+                            },
+                            onForget: {
+                                hostPendingForget = host
+                            }
+                        )
+                    }
+                }
+            }
+
+            SettingsButton("Pair New Computer") {
+                HapticFeedback.shared.triggerImpactFeedback(style: .light)
+                isShowingPairComputerScanner = true
             }
         }
     }
@@ -206,7 +282,29 @@ struct SettingsView: View {
 
     // MARK: - Actions
 
+    private var editingTrustedHostPresentation: CodexTrustedHostPresentation? {
+        guard let editingHostDeviceId else {
+            return nil
+        }
+
+        return codex.trustedHostPresentations.first { $0.deviceId == editingHostDeviceId }
+    }
+
     private func disconnectRelay() {
+        Task { @MainActor in
+            await codex.disconnect()
+            codex.clearSavedRelaySession()
+        }
+    }
+
+    private func handleHostSelection(_ deviceId: String) {
+        let wasConnectedToDifferentHost = codex.isConnected && codex.normalizedRelayMacDeviceId != deviceId
+        codex.selectTrustedHost(deviceId: deviceId)
+
+        guard wasConnectedToDifferentHost else {
+            return
+        }
+
         Task { @MainActor in
             await codex.disconnect()
             codex.clearSavedRelaySession()
@@ -262,10 +360,10 @@ struct SettingsView: View {
     }
 
     // Writes nicknames against the active trusted Mac so switching pairs does not reuse the wrong alias.
-    private func sidebarMacNicknameBinding(for presentation: CodexTrustedPairPresentation) -> Binding<String> {
+    private func sidebarMacNicknameBinding(for deviceId: String?) -> Binding<String> {
         Binding(
-            get: { SidebarMacNicknameStore.nickname(for: presentation.deviceId) },
-            set: { SidebarMacNicknameStore.setNickname($0, for: presentation.deviceId) }
+            get: { SidebarMacNicknameStore.nickname(for: deviceId) },
+            set: { SidebarMacNicknameStore.setNickname($0, for: deviceId) }
         )
     }
 }
@@ -474,7 +572,7 @@ private struct SettingsNotificationsCard: View {
                     .foregroundStyle(.secondary)
             }
 
-            Text("Used for local alerts when a run finishes while the app is in background.")
+            Text(notificationDetailText)
                 .font(AppFont.caption())
                 .foregroundStyle(.secondary)
 
@@ -510,14 +608,32 @@ private struct SettingsNotificationsCard: View {
     }
 
     private var statusLabel: String {
-        switch codex.notificationAuthorizationStatus {
-        case .authorized: "Authorized"
-        case .denied: "Denied"
-        case .provisional: "Provisional"
-        case .ephemeral: "Ephemeral"
-        case .notDetermined: "Not requested"
-        @unknown default: "Unknown"
+        if !codex.supportsManagedRemotePush {
+            return "Local only"
         }
+
+        switch codex.notificationAuthorizationStatus {
+        case .authorized:
+            return "Authorized"
+        case .denied:
+            return "Denied"
+        case .provisional:
+            return "Provisional"
+        case .ephemeral:
+            return "Ephemeral"
+        case .notDetermined:
+            return "Not requested"
+        @unknown default:
+            return "Unknown"
+        }
+    }
+
+    private var notificationDetailText: String {
+        if codex.supportsManagedRemotePush {
+            return "Used for local alerts when a run finishes while the app is in background."
+        }
+
+        return "This debug build signs without APNs capability so remote push delivery is disabled on device."
     }
 }
 
@@ -731,7 +847,7 @@ private struct SettingsArchivedChatsCard: View {
 private struct SettingsAboutCard: View {
     var body: some View {
         SettingsCard(title: "About") {
-            Text("Chats are End-to-end encrypted between your iPhone and Mac. The relay only sees ciphertext and connection metadata after the secure handshake completes.")
+            Text("Chats are end-to-end encrypted between your iPhone and paired computers. The relay only sees ciphertext and connection metadata after the secure handshake completes.")
                 .font(AppFont.caption())
                 .foregroundStyle(.secondary)
         }
@@ -747,7 +863,7 @@ private struct SettingsTrustedMacCard: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .top, spacing: 12) {
                 HStack(spacing: 10) {
-                    Image(systemName: "desktopcomputer")
+                    Image(systemName: presentation.platform.symbolName)
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundStyle(.secondary)
                         .frame(width: 32, height: 32)
@@ -757,7 +873,7 @@ private struct SettingsTrustedMacCard: View {
                         )
 
                     VStack(alignment: .leading, spacing: 3) {
-                        Text("Mac")
+                        Text(presentation.platform.displayName)
                             .font(AppFont.caption(weight: .semibold))
                             .foregroundStyle(.secondary)
 
@@ -790,6 +906,10 @@ private struct SettingsTrustedMacCard: View {
 
                 if let title = compactTitle {
                     SettingsStatusPill(label: title)
+                }
+
+                if presentation.pairedDeviceCount > 1 {
+                    SettingsStatusPill(label: "\(presentation.pairedDeviceCount) paired")
                 }
             }
 
@@ -833,6 +953,47 @@ private struct SettingsTrustedMacCard: View {
                 .lineLimit(2)
                 .fixedSize(horizontal: false, vertical: true)
         }
+    }
+}
+
+private struct SettingsPairedHostRow: View {
+    let host: CodexTrustedHostPresentation
+    let onSelect: () -> Void
+    let onEditName: () -> Void
+    let onForget: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            TrustedHostRow(host: host)
+
+            HStack(spacing: 10) {
+                if !host.isCurrent {
+                    compactButton("Use This Computer", action: onSelect)
+                }
+
+                compactButton("Rename", action: onEditName)
+                compactButton("Forget", role: .destructive, action: onForget)
+            }
+        }
+    }
+
+    private func compactButton(
+        _ title: String,
+        role: ButtonRole? = nil,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(AppFont.caption(weight: .semibold))
+                .foregroundStyle(role == .destructive ? .red : .secondary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill((role == .destructive ? Color.red : Color.primary).opacity(0.08))
+                )
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/CodexMobile/CodexMobile/Views/Shared/TrustedHostSwitcherSheet.swift
+++ b/CodexMobile/CodexMobile/Views/Shared/TrustedHostSwitcherSheet.swift
@@ -1,0 +1,154 @@
+// FILE: TrustedHostSwitcherSheet.swift
+// Purpose: Shared list UI for switching between paired computers.
+// Layer: View
+// Exports: TrustedHostSwitcherSheet, TrustedHostRow
+// Depends on: SwiftUI, CodexTrustedHostPresentation
+
+import SwiftUI
+
+struct TrustedHostRow: View {
+    let host: CodexTrustedHostPresentation
+    var showsChevron = false
+    var trailingLabel: String? = nil
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: host.platform.symbolName)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 34, height: 34)
+                .background(
+                    Circle()
+                        .fill(Color.primary.opacity(0.06))
+                )
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 8) {
+                    Text(host.name)
+                        .font(AppFont.subheadline(weight: .semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+
+                    if host.isCurrent {
+                        Text("Current")
+                            .font(AppFont.caption(weight: .semibold))
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(
+                                Capsule(style: .continuous)
+                                    .fill(Color.primary.opacity(0.07))
+                            )
+                    }
+                }
+
+                if let systemName = host.systemName, !systemName.isEmpty {
+                    Text(systemName)
+                        .font(AppFont.caption())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                if let detail = host.detail, !detail.isEmpty {
+                    Text(detail)
+                        .font(AppFont.caption())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+
+                if let lastActivityAt = host.lastActivityAt {
+                    Text(lastActivityAt, style: .relative)
+                        .font(AppFont.caption())
+                        .foregroundStyle(.tertiary)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            if let trailingLabel, !trailingLabel.isEmpty {
+                Text(trailingLabel)
+                    .font(AppFont.caption(weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+
+            if showsChevron {
+                Image(systemName: "chevron.right")
+                    .font(AppFont.caption(weight: .semibold))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color(.secondarySystemFill).opacity(host.isCurrent ? 0.55 : 0.32))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color.primary.opacity(host.isCurrent ? 0.09 : 0.04), lineWidth: 1)
+        )
+    }
+}
+
+struct TrustedHostSwitcherSheet: View {
+    let hosts: [CodexTrustedHostPresentation]
+    let onSelect: (String) -> Void
+    let onPairNewComputer: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Paired Computers")
+                            .font(AppFont.title3(weight: .semibold))
+                            .foregroundStyle(.primary)
+
+                        Text("Choose the computer this iPhone should control next.")
+                            .font(AppFont.subheadline())
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(20)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .adaptiveGlass(.regular, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+
+                    VStack(spacing: 10) {
+                        ForEach(hosts) { host in
+                            Button {
+                                onSelect(host.deviceId)
+                                dismiss()
+                            } label: {
+                                TrustedHostRow(host: host, trailingLabel: host.isCurrent ? nil : "Use")
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+
+                    Button {
+                        dismiss()
+                        onPairNewComputer()
+                    } label: {
+                        HStack(spacing: 10) {
+                            Image(systemName: "qrcode.viewfinder")
+                            Text("Pair New Computer")
+                        }
+                        .font(AppFont.body(weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .foregroundStyle(.primary)
+                        .background(
+                            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                .fill(Color(.tertiarySystemFill).opacity(0.7))
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(20)
+            }
+            .navigationTitle("Switch Computer")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}

--- a/CodexMobile/CodexMobile/Views/Shared/TrustedPairSummaryView.swift
+++ b/CodexMobile/CodexMobile/Views/Shared/TrustedPairSummaryView.swift
@@ -11,12 +11,14 @@ struct TrustedPairSummaryView: View {
     let name: String
     let systemName: String?
     let detail: String?
+    let symbolName: String
 
-    init(title: String, name: String, systemName: String?, detail: String?) {
+    init(title: String, name: String, systemName: String?, detail: String?, symbolName: String = "desktopcomputer") {
         self.title = title
         self.name = name
         self.systemName = systemName
         self.detail = detail
+        self.symbolName = symbolName
     }
 
     init(presentation: CodexTrustedPairPresentation) {
@@ -24,7 +26,8 @@ struct TrustedPairSummaryView: View {
             title: presentation.title,
             name: presentation.name,
             systemName: presentation.systemName,
-            detail: presentation.detail
+            detail: presentation.detail,
+            symbolName: presentation.platform.symbolName
         )
     }
 
@@ -35,7 +38,7 @@ struct TrustedPairSummaryView: View {
                 .foregroundStyle(.secondary)
 
             HStack(alignment: .center, spacing: 10) {
-                Image(systemName: "desktopcomputer")
+                Image(systemName: symbolName)
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(.secondary)
                     .frame(width: 28, height: 28)

--- a/CodexMobile/CodexMobile/Views/Sidebar/SidebarFloatingSettingsButton.swift
+++ b/CodexMobile/CodexMobile/Views/Sidebar/SidebarFloatingSettingsButton.swift
@@ -29,6 +29,8 @@ struct SidebarFloatingSettingsButton: View {
 struct SidebarMacConnectionStatusView: View {
     let name: String
     let systemName: String?
+    let platform: CodexHostPlatform
+    let pairedDeviceCount: Int
     let isConnected: Bool
 
     var body: some View {
@@ -48,6 +50,9 @@ struct SidebarMacConnectionStatusView: View {
     }
 
     private var statusTitle: String {
-        isConnected ? "Connected to Mac" : "Saved Mac"
+        if pairedDeviceCount > 1 {
+            return isConnected ? "Connected Computer" : "Current Computer"
+        }
+        return isConnected ? "Connected \(platform.displayName)" : "Saved \(platform.displayName)"
     }
 }

--- a/CodexMobile/CodexMobile/Views/SidebarView.swift
+++ b/CodexMobile/CodexMobile/Views/SidebarView.swift
@@ -94,6 +94,8 @@ struct SidebarView: View {
                     SidebarMacConnectionStatusView(
                         name: trustedPairPresentation.name,
                         systemName: trustedPairPresentation.systemName,
+                        platform: trustedPairPresentation.platform,
+                        pairedDeviceCount: trustedPairPresentation.pairedDeviceCount,
                         isConnected: codex.isConnected
                     )
                 }

--- a/CodexMobile/CodexMobileTests/CodexSecurePairingStateTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexSecurePairingStateTests.swift
@@ -10,6 +10,8 @@ import XCTest
 
 @MainActor
 final class CodexSecurePairingStateTests: XCTestCase {
+    private static var retainedServices: [CodexService] = []
+
     override func setUp() {
         super.setUp()
         clearStoredSecureRelayState()
@@ -21,7 +23,7 @@ final class CodexSecurePairingStateTests: XCTestCase {
     }
 
     func testRememberRelayPairingForcesFreshQRBootstrapEvenForTrustedMac() {
-        let service = CodexService()
+        let service = makeService()
         let macDeviceID = "mac-\(UUID().uuidString)"
         let originalPublicKey = Data(repeating: 1, count: 32).base64EncodedString()
         let freshQRPublicKey = Data(repeating: 2, count: 32).base64EncodedString()
@@ -50,7 +52,7 @@ final class CodexSecurePairingStateTests: XCTestCase {
     }
 
     func testRememberRelayPairingShowsHandshakeStateForBrandNewMac() {
-        let service = CodexService()
+        let service = makeService()
         let freshQRPublicKey = Data(repeating: 4, count: 32).base64EncodedString()
 
         service.rememberRelayPairing(
@@ -70,7 +72,7 @@ final class CodexSecurePairingStateTests: XCTestCase {
     }
 
     func testResetSecureTransportStatePreservesRePairRequiredState() {
-        let service = CodexService()
+        let service = makeService()
         service.relaySessionId = "session-\(UUID().uuidString)"
         service.relayUrl = "ws://relay.local/relay"
         service.secureConnectionState = .rePairRequired
@@ -83,7 +85,7 @@ final class CodexSecurePairingStateTests: XCTestCase {
     }
 
     func testApplyingResolvedTrustedSessionResetsReplayCursorWhenLiveSessionChanges() {
-        let service = CodexService()
+        let service = makeService()
         let macDeviceID = "mac-\(UUID().uuidString)"
 
         service.relaySessionId = "stale-session"
@@ -111,7 +113,7 @@ final class CodexSecurePairingStateTests: XCTestCase {
     }
 
     func testApplyingResolvedTrustedSessionKeepsReplayCursorWhenLiveSessionIsUnchanged() {
-        let service = CodexService()
+        let service = makeService()
         let macDeviceID = "mac-\(UUID().uuidString)"
 
         service.relaySessionId = "same-session"
@@ -138,7 +140,40 @@ final class CodexSecurePairingStateTests: XCTestCase {
         )
     }
 
+    func testPreferredTrustedMacDeviceIdUsesExplicitSelectedHostOverRecencyFallback() {
+        let selectedMacDeviceID = "mac-\(UUID().uuidString)"
+        let moreRecentMacDeviceID = "mac-\(UUID().uuidString)"
+
+        let service = makeService()
+        service.selectedHostDeviceId = selectedMacDeviceID
+        service.trustedMacRegistry.records[selectedMacDeviceID] = CodexTrustedMacRecord(
+            macDeviceId: selectedMacDeviceID,
+            macIdentityPublicKey: Data(repeating: 11, count: 32).base64EncodedString(),
+            lastPairedAt: Date().addingTimeInterval(-120),
+            relayURL: "wss://selected.relay/relay",
+            lastUsedAt: Date().addingTimeInterval(-120)
+        )
+        service.trustedMacRegistry.records[moreRecentMacDeviceID] = CodexTrustedMacRecord(
+            macDeviceId: moreRecentMacDeviceID,
+            macIdentityPublicKey: Data(repeating: 12, count: 32).base64EncodedString(),
+            lastPairedAt: Date(),
+            relayURL: "wss://recent.relay/relay",
+            lastUsedAt: Date()
+        )
+
+        XCTAssertEqual(service.preferredTrustedMacDeviceId, selectedMacDeviceID)
+    }
+
     // Clears the persisted relay session keys touched by secure reconnect tests.
+    private func makeService() -> CodexService {
+        let suiteName = "CodexSecurePairingStateTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+        let service = CodexService(defaults: defaults)
+        Self.retainedServices.append(service)
+        return service
+    }
+
     private func clearStoredSecureRelayState() {
         SecureStore.deleteValue(for: CodexSecureKeys.relaySessionId)
         SecureStore.deleteValue(for: CodexSecureKeys.relayUrl)
@@ -148,5 +183,6 @@ final class CodexSecurePairingStateTests: XCTestCase {
         SecureStore.deleteValue(for: CodexSecureKeys.relayLastAppliedBridgeOutboundSeq)
         SecureStore.deleteValue(for: CodexSecureKeys.trustedMacRegistry)
         SecureStore.deleteValue(for: CodexSecureKeys.lastTrustedMacDeviceId)
+        SecureStore.deleteValue(for: CodexSecureKeys.selectedHostDeviceId)
     }
 }

--- a/CodexMobile/CodexMobileTests/ContentViewModelReconnectTests.swift
+++ b/CodexMobile/CodexMobileTests/ContentViewModelReconnectTests.swift
@@ -11,7 +11,6 @@ import XCTest
 @MainActor
 final class ContentViewModelReconnectTests: XCTestCase {
     private static var retainedServices: [CodexService] = []
-
     override func setUp() {
         super.setUp()
         clearStoredSecureRelayState()
@@ -72,6 +71,86 @@ final class ContentViewModelReconnectTests: XCTestCase {
         XCTAssertEqual(service.lastErrorMessage, "Your trusted Mac is offline right now.")
     }
 
+    func testPreferredReconnectURLResolvesExplicitlySelectedHostBeforeMoreRecentFallback() async {
+        let selectedMacDeviceID = "mac-\(UUID().uuidString)"
+        let moreRecentMacDeviceID = "mac-\(UUID().uuidString)"
+        let selectedRelayURL = "wss://selected.relay/relay"
+        let moreRecentRelayURL = "wss://recent.relay/relay"
+
+        let service = makeService()
+        let viewModel = ContentViewModel()
+        service.selectedHostDeviceId = selectedMacDeviceID
+        service.trustedMacRegistry.records[selectedMacDeviceID] = CodexTrustedMacRecord(
+            macDeviceId: selectedMacDeviceID,
+            macIdentityPublicKey: Data(repeating: 13, count: 32).base64EncodedString(),
+            lastPairedAt: Date().addingTimeInterval(-120),
+            relayURL: selectedRelayURL,
+            lastUsedAt: Date().addingTimeInterval(-120)
+        )
+        service.trustedMacRegistry.records[moreRecentMacDeviceID] = CodexTrustedMacRecord(
+            macDeviceId: moreRecentMacDeviceID,
+            macIdentityPublicKey: Data(repeating: 14, count: 32).base64EncodedString(),
+            lastPairedAt: Date(),
+            relayURL: moreRecentRelayURL,
+            lastUsedAt: Date()
+        )
+
+        var resolvedDeviceID: String?
+        service.trustedSessionResolverOverride = {
+            let preferred = service.preferredTrustedMacRecord
+            resolvedDeviceID = preferred?.macDeviceId
+            service.relayUrl = preferred?.relayURL
+            return CodexTrustedSessionResolveResponse(
+                ok: true,
+                macDeviceId: preferred?.macDeviceId ?? "",
+                macIdentityPublicKey: preferred?.macIdentityPublicKey ?? "",
+                displayName: preferred?.displayName,
+                sessionId: "resolved-session"
+            )
+        }
+
+        let reconnectURL = await viewModel.preferredReconnectURL(codex: service)
+
+        XCTAssertEqual(resolvedDeviceID, selectedMacDeviceID)
+        XCTAssertEqual(reconnectURL, "\(selectedRelayURL)/resolved-session")
+    }
+
+    func testPreferredReconnectURLDoesNotFallbackToSavedSessionForDifferentSelectedHost() async {
+        let selectedMacDeviceID = "mac-\(UUID().uuidString)"
+        let savedSessionMacDeviceID = "mac-\(UUID().uuidString)"
+        let selectedRelayURL = "wss://selected.relay/relay"
+        let savedRelayURL = "wss://saved.relay/relay"
+
+        let service = makeService()
+        let viewModel = ContentViewModel()
+        service.selectedHostDeviceId = selectedMacDeviceID
+        service.trustedMacRegistry.records[selectedMacDeviceID] = CodexTrustedMacRecord(
+            macDeviceId: selectedMacDeviceID,
+            macIdentityPublicKey: Data(repeating: 15, count: 32).base64EncodedString(),
+            lastPairedAt: Date(),
+            relayURL: selectedRelayURL,
+            lastUsedAt: Date()
+        )
+        service.trustedMacRegistry.records[savedSessionMacDeviceID] = CodexTrustedMacRecord(
+            macDeviceId: savedSessionMacDeviceID,
+            macIdentityPublicKey: Data(repeating: 16, count: 32).base64EncodedString(),
+            lastPairedAt: Date().addingTimeInterval(-120),
+            relayURL: savedRelayURL,
+            lastUsedAt: Date().addingTimeInterval(-120)
+        )
+        service.relaySessionId = "saved-session"
+        service.relayUrl = savedRelayURL
+        service.relayMacDeviceId = savedSessionMacDeviceID
+        service.trustedSessionResolverOverride = {
+            throw CodexTrustedSessionResolveError.macOffline("Your trusted Mac is offline right now.")
+        }
+
+        let reconnectURL = await viewModel.preferredReconnectURL(codex: service)
+
+        XCTAssertNil(reconnectURL)
+        XCTAssertEqual(service.lastErrorMessage, "Your trusted Mac is offline right now.")
+    }
+
     private func makeService() -> CodexService {
         let suiteName = "ContentViewModelReconnectTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName) ?? .standard
@@ -91,5 +170,6 @@ final class ContentViewModelReconnectTests: XCTestCase {
         SecureStore.deleteValue(for: CodexSecureKeys.relayLastAppliedBridgeOutboundSeq)
         SecureStore.deleteValue(for: CodexSecureKeys.trustedMacRegistry)
         SecureStore.deleteValue(for: CodexSecureKeys.lastTrustedMacDeviceId)
+        SecureStore.deleteValue(for: CodexSecureKeys.selectedHostDeviceId)
     }
 }

--- a/CodexMobile/CodexMobileTests/SidebarThreadGroupingTests.swift
+++ b/CodexMobile/CodexMobileTests/SidebarThreadGroupingTests.swift
@@ -61,7 +61,7 @@ final class SidebarThreadGroupingTests: XCTestCase {
         XCTAssertEqual(groups[1].threads.map(\.id), ["archived-thread"])
     }
 
-    func testMakeGroupsMarksCodexManagedWorktreesInLabelAndIcon() {
+    func testMakeGroupsMarksCodexManagedWorktreesInLabelAndIcon() throws {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let threads = [
             makeThread(id: "main-thread", updatedAt: now, cwd: "/Users/me/work/Remodex"),

--- a/Docs/plans/2026-03-22-multi-computer-pairing-design.md
+++ b/Docs/plans/2026-03-22-multi-computer-pairing-design.md
@@ -1,0 +1,239 @@
+# Multi-Computer Pairing Design
+
+Date: 2026-03-22
+
+## Goal
+
+Allow one iPhone to pair with and switch between multiple computers while keeping the current transport model single-active-host. The first implementation must support:
+
+- multiple remembered computers on iPhone
+- one explicitly selected active computer at a time
+- explicit switching from Home and Settings
+- compatibility with macOS and Windows hosts
+- clean future expansion toward multiple simultaneously online hosts
+
+## Constraints
+
+- Do not regress the current QR bootstrap -> trusted reconnect flow.
+- Do not reintroduce hosted-service assumptions; keep the repo local-first.
+- Do not require a relay protocol rewrite for this phase.
+- Keep existing QR payloads compatible when optional metadata is missing.
+- Do not make Xcode build/test the default verification path; prefer unit tests and targeted device install steps.
+
+## Current State
+
+The repo already stores trusted computers as a registry on iPhone:
+
+- `CodexTrustedMacRegistry.records` stores multiple records keyed by device id.
+- reconnect logic still collapses to `preferredTrustedMacRecord`.
+- UI surfaces only one visible pair summary and one destructive "Forget Pair" action.
+
+The relay already resolves trusted reconnect per host device id:
+
+- `POST /v1/trusted/session/resolve` accepts a specific `macDeviceId`
+- relay tracks live sessions by host device id
+
+The bridge currently limits the inverse direction:
+
+- one host trusts one iPhone identity at a time
+
+That asymmetry is acceptable for this phase.
+
+## Product Model
+
+### Stable Host Registry
+
+Introduce a clearer host model in iPhone presentation and selection layers:
+
+- one registry entry per paired computer
+- one explicit active selection
+- one live relay session reused only for the selected host
+
+The persisted host record should support future expansion:
+
+- stable identity: device id, identity public key
+- display metadata: display name, platform
+- connection hints: relay URL, last resolved session id, timestamps
+- capability flags for platform-specific behavior
+
+The wire format may continue to use `mac*` field names for compatibility in this phase. App-level naming and UI should shift to `host` / `computer`.
+
+### Active Host Selection
+
+Persist an explicit active host selection instead of inferring from "last used" alone.
+
+Selection rules:
+
+1. manual switch wins
+2. fresh QR scan of a host sets that host active
+3. fallback to most recently used paired host only when no explicit selection exists
+
+This removes hidden drift between remembered hosts and reconnect target.
+
+## Architecture
+
+### iPhone Service Layer
+
+Split current logic into three concerns:
+
+1. host registry
+2. active host selection
+3. live relay session state for the selected host
+
+Practical implementation can stay inside `CodexService` first, but helpers should be organized so a later extraction is straightforward:
+
+- host registry helpers
+- active host selection helpers
+- host presentation helpers
+- trusted reconnect resolution using selected host id
+
+This keeps future "multi-online" expansion additive rather than destructive.
+
+### Bridge and Relay
+
+No phase-one relay topology change is needed.
+
+Bridge changes:
+
+- add optional host metadata to pairing payload
+- keep registration updates sending display name
+- optionally add normalized platform metadata
+
+Relay changes:
+
+- keep `macDeviceId -> live session` map
+- extend resolve response with optional platform metadata when available
+- avoid breaking older clients if fields are absent
+
+### Windows Support
+
+The repo docs already state the core bridge works on Windows and Linux, with macOS-only daemon conveniences. The pairing UI and service model should therefore refer to "computer" or "host", not "Mac", while still tolerating legacy wire field names.
+
+## UI Design
+
+### Home
+
+Home remains fast and compact:
+
+- current active computer card remains the primary summary
+- add a clear switch affordance
+- present a native sheet listing paired computers
+- allow selecting another computer or scanning a new one
+
+The list row content:
+
+- display name
+- platform icon + platform label
+- current/connected badge
+- recent-use metadata
+
+### Settings
+
+Settings becomes the management surface:
+
+- add `Paired Computers` section
+- show current active computer first
+- show full paired computer list
+- actions: rename, make active, forget this computer, pair new computer
+
+### Visual Style
+
+Use system design first, custom glass second.
+
+Relevant Apple guidance:
+
+- Liquid Glass overview:
+  `https://developer.apple.com/documentation/technologyoverviews/liquid-glass`
+- SwiftUI `glassEffect`:
+  `https://developer.apple.com/documentation/SwiftUI/View/glassEffect%28_%3Ain%3AisEnabled%3A%29`
+- Toolbar guidance via Landmarks sample:
+  `https://developer.apple.com/documentation/SwiftUI/Landmarks-Refining-the-system-provided-glass-effect-in-toolbars`
+- WWDC25 new design session:
+  `https://developer.apple.com/videos/play/wwdc2025/284/`
+
+Application of that guidance:
+
+- let navigation bars, toolbars, sheets, and standard controls inherit system glass naturally
+- use custom glass only for a few summary cards and current-selection highlights
+- keep management lists readable and mostly non-glass
+- preserve existing `AdaptiveGlassModifier` as the single compatibility layer for iOS < 26
+
+## Data Model Changes
+
+Planned iPhone additions:
+
+- add platform field to trusted host record
+- add persisted active host selection key
+- add helper that enumerates host summaries for UI
+
+Planned wire additions:
+
+- optional `hostPlatform` in QR payload
+- optional `hostPlatform` in trusted resolve response
+
+If absent, iPhone falls back to:
+
+- infer `macOS` for legacy records when existing display/bridge context strongly implies it
+- otherwise use `unknown`
+
+## Error Handling
+
+- Switching active computer must be explicit and visible.
+- If selected host is offline, preserve selection and show offline state.
+- If a host trust becomes invalid, clear only that host's trust record, not the whole registry.
+- Saved relay session invalidation must stay scoped to the selected host.
+- Fresh QR scans must still force bootstrap mode even when the host is already remembered.
+
+## Testing Strategy
+
+### iPhone Unit Tests
+
+Add or extend tests for:
+
+- active host selection fallback and persistence
+- reconnect choosing selected host rather than implicit most-recent host
+- forgetting one host without removing others
+- Home/Settings presentation showing correct current host
+- legacy records without platform metadata
+
+### Bridge / Relay Tests
+
+Add tests for:
+
+- optional platform metadata in pairing payload
+- resolve response carrying display and platform metadata
+- backwards compatibility when optional metadata is absent
+
+### Manual Device Validation
+
+Primary target device:
+
+- `Lin's iPhone`
+
+Because a paid Apple Developer account is not assumed, the path should rely on Xcode automatic signing with the user's available account/team setup and direct on-device run. Official Apple references to keep handy:
+
+- registered device / automatic signing notes:
+  `https://developer.apple.com/help/account/devices/register-a-single-device`
+
+Manual checks on device:
+
+1. pair one macOS host
+2. pair one Windows host
+3. verify both appear in Home switcher and Settings list
+4. switch active host without re-pairing
+5. reconnect to the selected host after app relaunch
+6. forget one host and confirm the other remains usable
+
+## Non-Goals For This Phase
+
+- simultaneous live connections to multiple hosts
+- per-host parallel timelines in one iPhone session
+- relay-side host fanout redesign
+- daemon/service management parity across all desktop OSes
+
+## Migration Notes
+
+- Existing trusted records remain readable.
+- Existing `lastTrustedMacDeviceId` becomes an input to active selection migration.
+- Existing `trustedMacRegistry` storage remains the backing store for phase one.
+- Naming cleanup from `Mac` to `Host` should focus on UI/presentation and new helper APIs first; protocol compatibility can remain on legacy field names.

--- a/Docs/plans/2026-03-22-multi-computer-pairing.md
+++ b/Docs/plans/2026-03-22-multi-computer-pairing.md
@@ -1,0 +1,322 @@
+# Multi-Computer Pairing Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let one iPhone pair with, manage, and switch between multiple computers while keeping only one active connection target at a time.
+
+**Architecture:** Keep the existing trusted-host registry, add explicit active-host selection, route reconnect through the selected host, and expose that model through compact Home and Settings UI. Extend bridge and relay metadata only with backwards-compatible optional fields so Windows/macOS hosts can be presented correctly without rewriting the transport.
+
+**Tech Stack:** SwiftUI, Observation, XCTest, Node.js bridge, Node.js relay, Keychain-backed secure store, existing Liquid Glass compatibility helpers.
+
+---
+
+### Task 1: Lock Down Active Host Selection Semantics
+
+**Files:**
+- Modify: `CodexMobile/CodexMobileTests/CodexSecurePairingStateTests.swift`
+- Modify: `CodexMobile/CodexMobileTests/ContentViewModelReconnectTests.swift`
+- Modify: `CodexMobile/CodexMobile/Services/CodexService.swift`
+- Modify: `CodexMobile/CodexMobile/Services/SecureStore.swift`
+- Modify: `CodexMobile/CodexMobile/Services/CodexService+SecureTransport.swift`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+
+- an explicitly selected host wins over most-recent fallback
+- scanning a QR for host B makes host B active without deleting host A
+- forgetting host B preserves host A and falls back correctly
+
+**Step 2: Run tests to verify they fail**
+
+Run: `xcodebuild test -scheme CodexMobile -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:CodexMobileTests/CodexSecurePairingStateTests -only-testing:CodexMobileTests/ContentViewModelReconnectTests`
+
+Expected: FAIL because active-host selection helpers and persistence do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- a new secure store key for active host selection
+- `selectedHostDeviceId` state on `CodexService`
+- helper accessors that resolve explicit selection before recency fallback
+- QR pairing path that preserves multiple records and promotes the scanned host to active
+
+**Step 4: Run tests to verify they pass**
+
+Run the same `xcodebuild test` command.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add CodexMobile/CodexMobileTests/CodexSecurePairingStateTests.swift CodexMobile/CodexMobileTests/ContentViewModelReconnectTests.swift CodexMobile/CodexMobile/Services/CodexService.swift CodexMobile/CodexMobile/Services/SecureStore.swift CodexMobile/CodexMobile/Services/CodexService+SecureTransport.swift
+git commit -m "feat(pairing): add explicit active host selection"
+```
+
+### Task 2: Add Host Platform Metadata and Presentation Models
+
+**Files:**
+- Modify: `CodexMobile/CodexMobile/Services/CodexSecureTransportModels.swift`
+- Modify: `CodexMobile/CodexMobile/Services/CodexService+TrustedPairPresentation.swift`
+- Modify: `CodexMobile/CodexMobile/Services/CodexService+SecureTransport.swift`
+- Modify: `CodexMobile/CodexMobile/Views/QRScannerPairingValidator.swift`
+- Test: `CodexMobile/CodexMobileTests/CodexSecurePairingStateTests.swift`
+
+**Step 1: Write the failing tests**
+
+Add tests covering:
+
+- host records decoding when optional platform metadata is missing
+- presentation choosing platform label/icon metadata correctly
+
+**Step 2: Run tests to verify they fail**
+
+Run: `xcodebuild test -scheme CodexMobile -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:CodexMobileTests/CodexSecurePairingStateTests`
+
+Expected: FAIL due to missing platform-aware model and presentation paths.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- optional platform field to pairing payload, trusted host record, and resolve response
+- compatibility defaults for legacy payloads
+- a host-summary presentation model for list UIs
+
+**Step 4: Run tests to verify they pass**
+
+Run the same focused test command.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add CodexMobile/CodexMobile/Services/CodexSecureTransportModels.swift CodexMobile/CodexMobile/Services/CodexService+TrustedPairPresentation.swift CodexMobile/CodexMobile/Services/CodexService+SecureTransport.swift CodexMobile/CodexMobile/Views/QRScannerPairingValidator.swift CodexMobile/CodexMobileTests/CodexSecurePairingStateTests.swift
+git commit -m "feat(pairing): add host metadata for multi-computer UI"
+```
+
+### Task 3: Route Trusted Reconnect Through the Selected Host
+
+**Files:**
+- Modify: `CodexMobile/CodexMobile/Views/Home/ContentViewModel.swift`
+- Modify: `CodexMobile/CodexMobile/Services/CodexService+Connection.swift`
+- Modify: `CodexMobile/CodexMobile/Services/CodexService+SecureTransport.swift`
+- Test: `CodexMobile/CodexMobileTests/ContentViewModelReconnectTests.swift`
+
+**Step 1: Write the failing tests**
+
+Add tests proving:
+
+- reconnect resolves the selected host first
+- offline selected host preserves selection and surfaces correct message
+- saved relay session fallback does not silently switch to another remembered host
+
+**Step 2: Run tests to verify they fail**
+
+Run: `xcodebuild test -scheme CodexMobile -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:CodexMobileTests/ContentViewModelReconnectTests`
+
+Expected: FAIL because reconnect still depends on implicit preferred-host behavior.
+
+**Step 3: Write minimal implementation**
+
+Update reconnect helpers so:
+
+- selected host drives trusted resolve
+- clearing a dead saved relay session stays scoped to that host
+- forgetting one host does not destabilize other records
+
+**Step 4: Run tests to verify they pass**
+
+Run the same test command.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add CodexMobile/CodexMobile/Views/Home/ContentViewModel.swift CodexMobile/CodexMobile/Services/CodexService+Connection.swift CodexMobile/CodexMobile/Services/CodexService+SecureTransport.swift CodexMobile/CodexMobileTests/ContentViewModelReconnectTests.swift
+git commit -m "feat(pairing): reconnect through selected host"
+```
+
+### Task 4: Build Shared Multi-Computer UI Components
+
+**Files:**
+- Create: `CodexMobile/CodexMobile/Views/Shared/PairedComputerRowView.swift`
+- Create: `CodexMobile/CodexMobile/Views/Shared/PairedComputersSheet.swift`
+- Modify: `CodexMobile/CodexMobile/Views/Shared/TrustedPairSummaryView.swift`
+- Modify: `CodexMobile/CodexMobile/Views/Shared/AdaptiveGlassModifier.swift`
+- Test: `CodexMobile/CodexMobileTests/` existing or new focused UI-state tests as needed
+
+**Step 1: Write the failing tests**
+
+Add targeted tests where practical for:
+
+- summary model exposing switch affordance state
+- list ordering with selected host first
+
+If no existing UI test harness fits, write model-level tests for the ordering and selection state that back these views.
+
+**Step 2: Run tests to verify they fail**
+
+Run the relevant focused `xcodebuild test` command for the added model/UI-state tests.
+
+Expected: FAIL because shared paired-computer presentation logic is missing.
+
+**Step 3: Write minimal implementation**
+
+Create:
+
+- a reusable paired computer row
+- a native sheet listing paired computers
+- restrained glass styling using `adaptiveGlass` only on high-value summary elements
+
+**Step 4: Run tests to verify they pass**
+
+Run the same focused test command.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add CodexMobile/CodexMobile/Views/Shared/PairedComputerRowView.swift CodexMobile/CodexMobile/Views/Shared/PairedComputersSheet.swift CodexMobile/CodexMobile/Views/Shared/TrustedPairSummaryView.swift CodexMobile/CodexMobile/Views/Shared/AdaptiveGlassModifier.swift
+git commit -m "feat(pairing): add shared paired-computer switcher UI"
+```
+
+### Task 5: Wire Home, Settings, and Sidebar to the New Host Model
+
+**Files:**
+- Modify: `CodexMobile/CodexMobile/Views/Home/HomeEmptyStateView.swift`
+- Modify: `CodexMobile/CodexMobile/Views/SettingsView.swift`
+- Modify: `CodexMobile/CodexMobile/Views/SidebarView.swift`
+- Modify: `CodexMobile/CodexMobile/Services/CodexService+TrustedPairPresentation.swift`
+- Possibly modify: `CodexMobile/CodexMobile/Views/Sidebar/SidebarFloatingSettingsButton.swift`
+
+**Step 1: Write the failing tests**
+
+Add model-level tests that prove:
+
+- Home uses the selected host summary
+- Settings lists multiple paired hosts and keeps the selected one first
+- forgetting one host only removes that host from presentation
+
+**Step 2: Run tests to verify they fail**
+
+Run the relevant focused `xcodebuild test` command.
+
+Expected: FAIL because the views still assume a single visible pair.
+
+**Step 3: Write minimal implementation**
+
+Update:
+
+- Home to show current computer + switch sheet
+- Settings to show `Paired Computers` management section
+- Sidebar footer to reflect the selected computer cleanly
+
+Keep copy neutral: use `Computer` instead of `Mac` in user-facing surfaces where reasonable.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same focused test command.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add CodexMobile/CodexMobile/Views/Home/HomeEmptyStateView.swift CodexMobile/CodexMobile/Views/SettingsView.swift CodexMobile/CodexMobile/Views/SidebarView.swift CodexMobile/CodexMobile/Services/CodexService+TrustedPairPresentation.swift CodexMobile/CodexMobile/Views/Sidebar/SidebarFloatingSettingsButton.swift
+git commit -m "feat(pairing): expose multi-computer controls in app UI"
+```
+
+### Task 6: Extend Bridge and Relay Metadata Without Breaking Compatibility
+
+**Files:**
+- Modify: `phodex-bridge/src/secure-transport.js`
+- Modify: `phodex-bridge/src/bridge.js`
+- Modify: `relay/relay.js`
+- Modify: `relay/server.test.js`
+- Modify: `phodex-bridge/test/secure-device-state.test.js` only if needed
+
+**Step 1: Write the failing tests**
+
+Add tests showing:
+
+- QR payload includes optional platform metadata
+- relay resolve response includes display name and platform metadata
+- legacy requests without platform still behave correctly
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npm test --prefix relay`
+
+Expected: FAIL for new metadata expectations.
+
+Run if needed: `npm test --prefix phodex-bridge`
+
+Expected: FAIL if bridge payload tests were added there.
+
+**Step 3: Write minimal implementation**
+
+Add optional metadata only:
+
+- bridge QR payload includes host platform and display hint
+- relay registration/resolve flow forwards platform data
+- keep old clients safe when fields are absent
+
+**Step 4: Run tests to verify they pass**
+
+Run the same `npm test --prefix relay` and, if used, `npm test --prefix phodex-bridge`.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add phodex-bridge/src/secure-transport.js phodex-bridge/src/bridge.js relay/relay.js relay/server.test.js phodex-bridge/test/secure-device-state.test.js
+git commit -m "feat(pairing): extend bridge and relay host metadata"
+```
+
+### Task 7: Device Verification on Lin's iPhone
+
+**Files:**
+- Modify only if required by signing/runtime issues discovered during verification
+
+**Step 1: Prepare the app for device run**
+
+Use Xcode automatic signing and the available local team/account setup. Do not change project signing settings more than necessary.
+
+**Step 2: Install and run on `Lin's iPhone`**
+
+Open the project in Xcode and run the app on the connected device.
+
+Expected: app installs and launches under direct development signing.
+
+**Step 3: Manual verification**
+
+Check:
+
+1. pair macOS host
+2. pair Windows host
+3. switch active computer from Home
+4. switch and manage computers from Settings
+5. relaunch app and confirm selected host reconnect path
+6. forget one host and confirm the other remains
+
+**Step 4: Fix only the blocking runtime issues**
+
+If signing or runtime errors block installation, make the smallest targeted changes necessary and re-run.
+
+**Step 5: Final verification**
+
+Re-run the focused automated tests and then repeat the shortest manual device path to confirm no regression.
+
+**Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(pairing): verify multi-computer flow on device"
+```

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -31,6 +31,7 @@ const { createPushNotificationTracker } = require("./push-notification-tracker")
 const {
   loadOrCreateBridgeDeviceState,
   resolveBridgeRelaySession,
+  normalizeHostPlatform,
 } = require("./secure-device-state");
 const { createBridgeSecureTransport } = require("./secure-transport");
 const { createRolloutLiveMirrorController } = require("./rollout-live-mirror");
@@ -831,11 +832,13 @@ function buildMacRegistrationHeaders(deviceState) {
 }
 
 function buildMacRegistration(deviceState) {
+  const displayName = normalizeNonEmptyString(deviceState?.displayName) || os.hostname();
   const trustedPhoneEntry = Object.entries(deviceState?.trustedPhones || {})[0] || null;
   return {
     macDeviceId: normalizeNonEmptyString(deviceState?.macDeviceId),
     macIdentityPublicKey: normalizeNonEmptyString(deviceState?.macIdentityPublicKey),
-    displayName: normalizeNonEmptyString(os.hostname()),
+    displayName,
+    platform: normalizeHostPlatform(deviceState?.platform || process.platform),
     trustedPhoneDeviceId: normalizeNonEmptyString(trustedPhoneEntry?.[0]),
     trustedPhonePublicKey: normalizeNonEmptyString(trustedPhoneEntry?.[1]),
   };

--- a/phodex-bridge/src/secure-device-state.js
+++ b/phodex-bridge/src/secure-device-state.js
@@ -114,6 +114,8 @@ function createBridgeDeviceState() {
     macDeviceId: randomUUID(),
     macIdentityPublicKey: base64UrlToBase64(publicJwk.x),
     macIdentityPrivateKey: base64UrlToBase64(privateJwk.d),
+    displayName: os.hostname(),
+    platform: normalizeHostPlatform(process.platform),
     trustedPhones: {},
   };
 }
@@ -322,6 +324,8 @@ function normalizeBridgeDeviceState(rawState) {
   const macDeviceId = normalizeNonEmptyString(rawState?.macDeviceId);
   const macIdentityPublicKey = normalizeNonEmptyString(rawState?.macIdentityPublicKey);
   const macIdentityPrivateKey = normalizeNonEmptyString(rawState?.macIdentityPrivateKey);
+  const displayName = normalizeNonEmptyString(rawState?.displayName) || os.hostname();
+  const platform = normalizeHostPlatform(rawState?.platform || process.platform);
 
   if (!macDeviceId || !macIdentityPublicKey || !macIdentityPrivateKey) {
     throw new Error("Bridge device state is incomplete");
@@ -344,6 +348,8 @@ function normalizeBridgeDeviceState(rawState) {
     macDeviceId,
     macIdentityPublicKey,
     macIdentityPrivateKey,
+    displayName,
+    platform,
     trustedPhones,
   };
 }
@@ -357,6 +363,23 @@ function normalizeNonEmptyString(value) {
     return "";
   }
   return value.trim();
+}
+
+function normalizeHostPlatform(value) {
+  const normalized = normalizeNonEmptyString(value).toLowerCase();
+  if (!normalized) {
+    return "unknown";
+  }
+  if (normalized === "darwin") {
+    return "macOS";
+  }
+  if (normalized === "win32" || normalized === "windows") {
+    return "Windows";
+  }
+  if (normalized === "linux") {
+    return "Linux";
+  }
+  return normalizeNonEmptyString(value) || "unknown";
 }
 
 function corruptedStateError(source, error) {
@@ -391,4 +414,5 @@ module.exports = {
   rememberTrustedPhone,
   resetBridgeDeviceState,
   resolveBridgeRelaySession,
+  normalizeHostPlatform,
 };

--- a/phodex-bridge/src/secure-transport.js
+++ b/phodex-bridge/src/secure-transport.js
@@ -20,6 +20,7 @@ const {
 const {
   getTrustedPhonePublicKey,
   rememberTrustedPhone,
+  normalizeHostPlatform,
 } = require("./secure-device-state");
 
 const PAIRING_QR_VERSION = 2;
@@ -60,6 +61,8 @@ function createBridgeSecureTransport({
       sessionId,
       macDeviceId: currentDeviceState.macDeviceId,
       macIdentityPublicKey: currentDeviceState.macIdentityPublicKey,
+      displayName: normalizeNonEmptyString(currentDeviceState.displayName) || null,
+      platform: normalizeHostPlatform(currentDeviceState.platform),
       expiresAt: currentPairingExpiresAt,
     };
   }

--- a/phodex-bridge/test/secure-device-state.test.js
+++ b/phodex-bridge/test/secure-device-state.test.js
@@ -57,6 +57,16 @@ test("loadOrCreateBridgeDeviceState writes and reloads the canonical file state"
   });
 });
 
+test("loadOrCreateBridgeDeviceState seeds readable host metadata on fresh state", () => {
+  withTempDeviceStateEnv(() => {
+    const state = loadOrCreateBridgeDeviceState();
+
+    assert.equal(typeof state.displayName, "string");
+    assert.notEqual(state.displayName.trim(), "");
+    assert.match(state.platform, /^(macOS|Windows|Linux|unknown|[a-z0-9._-]+)$/);
+  });
+});
+
 test("loadOrCreateBridgeDeviceState migrates a valid Keychain mirror into the canonical file", () => {
   withTempDeviceStateEnv(({ keychainMirrorFile, canonicalStateFile }) => {
     const migratedState = makeDeviceState({
@@ -161,6 +171,8 @@ function makeDeviceState(overrides = {}) {
     macDeviceId: "mac-device-id",
     macIdentityPublicKey: "mac-public-key",
     macIdentityPrivateKey: "mac-private-key",
+    displayName: "Bridge Host",
+    platform: "macOS",
     trustedPhones: {},
     ...overrides,
   };

--- a/phodex-bridge/test/secure-transport.test.js
+++ b/phodex-bridge/test/secure-transport.test.js
@@ -6,6 +6,9 @@
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 const {
   createCipheriv,
   createDecipheriv,
@@ -61,477 +64,510 @@ test("secure transport rejects plaintext JSON-RPC before the secure handshake", 
   assert.equal(controlMessages[0]?.code, "update_required");
 });
 
-test("secure transport round-trips encrypted payloads after a trusted reconnect handshake", () => {
-  const macIdentity = createOkpKeyPair("ed25519");
-  const phoneIdentity = createOkpKeyPair("ed25519");
-  const phoneEphemeral = createOkpKeyPair("x25519");
+test("pairing payload includes optional host metadata without changing stable identifiers", () => {
   const secureTransport = createBridgeSecureTransport({
-    sessionId: "session-2",
+    sessionId: "session-meta",
     relayUrl: "wss://relay.example/relay",
     deviceState: {
-      macDeviceId: "mac-2",
-      macIdentityPrivateKey: macIdentity.privateKey,
-      macIdentityPublicKey: macIdentity.publicKey,
-      trustedPhones: {
-        "phone-2": phoneIdentity.publicKey,
-      },
-    },
-  });
-
-  const controlMessages = [];
-  const applicationMessages = [];
-  const wireMessages = [];
-  secureTransport.bindLiveSendWireMessage((message) => {
-    wireMessages.push(message);
-  });
-
-  const clientNonce = Buffer.alloc(32, 7);
-  secureTransport.handleIncomingWireMessage(
-    JSON.stringify({
-      kind: "clientHello",
-      protocolVersion: 1,
-      sessionId: "session-2",
-      handshakeMode: HANDSHAKE_MODE_TRUSTED_RECONNECT,
-      phoneDeviceId: "phone-2",
-      phoneIdentityPublicKey: phoneIdentity.publicKey,
-      phoneEphemeralPublicKey: phoneEphemeral.publicKey,
-      clientNonce: clientNonce.toString("base64"),
-    }),
-    {
-      sendControlMessage(message) {
-        controlMessages.push(message);
-      },
-      onApplicationMessage(message) {
-        applicationMessages.push(message);
-      },
-    }
-  );
-
-  const serverHello = controlMessages.find((message) => message.kind === "serverHello");
-  assert.ok(serverHello, "expected serverHello");
-
-  const transcriptBytes = buildTranscriptBytes({
-    sessionId: "session-2",
-    protocolVersion: 1,
-    handshakeMode: HANDSHAKE_MODE_TRUSTED_RECONNECT,
-    keyEpoch: serverHello.keyEpoch,
-    macDeviceId: "mac-2",
-    phoneDeviceId: "phone-2",
-    macIdentityPublicKey: macIdentity.publicKey,
-    phoneIdentityPublicKey: phoneIdentity.publicKey,
-    macEphemeralPublicKey: serverHello.macEphemeralPublicKey,
-    phoneEphemeralPublicKey: phoneEphemeral.publicKey,
-    clientNonce,
-    serverNonce: Buffer.from(serverHello.serverNonce, "base64"),
-    expiresAtForTranscript: 0,
-  });
-  const phoneAuthTranscript = Buffer.concat([
-    transcriptBytes,
-    encodeLengthPrefixedUTF8("client-auth"),
-  ]);
-  const phoneSignature = sign(
-    null,
-    phoneAuthTranscript,
-    createPrivateKey({
-      key: {
-        crv: "Ed25519",
-        d: base64ToBase64Url(phoneIdentity.privateKey),
-        kty: "OKP",
-        x: base64ToBase64Url(phoneIdentity.publicKey),
-      },
-      format: "jwk",
-    })
-  );
-
-  secureTransport.handleIncomingWireMessage(
-    JSON.stringify({
-      kind: "clientAuth",
-      sessionId: "session-2",
-      phoneDeviceId: "phone-2",
-      keyEpoch: serverHello.keyEpoch,
-      phoneSignature: phoneSignature.toString("base64"),
-    }),
-    {
-      sendControlMessage(message) {
-        controlMessages.push(message);
-      },
-      onApplicationMessage(message) {
-        applicationMessages.push(message);
-      },
-    }
-  );
-
-  const secureReady = controlMessages.find((message) => message.kind === "secureReady");
-  assert.ok(secureReady, "expected secureReady");
-
-  const sharedSecret = diffieHellman({
-    privateKey: createPrivateKey({
-      key: {
-        crv: "X25519",
-        d: base64ToBase64Url(phoneEphemeral.privateKey),
-        kty: "OKP",
-        x: base64ToBase64Url(phoneEphemeral.publicKey),
-      },
-      format: "jwk",
-    }),
-    publicKey: createPublicKey({
-      key: {
-        crv: "X25519",
-        kty: "OKP",
-        x: base64ToBase64Url(serverHello.macEphemeralPublicKey),
-      },
-      format: "jwk",
-    }),
-  });
-  const salt = createHash("sha256").update(transcriptBytes).digest();
-  const infoPrefix = `remodex-e2ee-v1|session-2|mac-2|phone-2|${serverHello.keyEpoch}`;
-  const phoneToMacKey = Buffer.from(
-    hkdfSync("sha256", sharedSecret, salt, Buffer.from(`${infoPrefix}|phoneToMac`, "utf8"), 32)
-  );
-  const macToPhoneKey = Buffer.from(
-    hkdfSync("sha256", sharedSecret, salt, Buffer.from(`${infoPrefix}|macToPhone`, "utf8"), 32)
-  );
-
-  secureTransport.handleIncomingWireMessage(
-    JSON.stringify({
-      kind: "resumeState",
-      sessionId: "session-2",
-      keyEpoch: serverHello.keyEpoch,
-      lastAppliedBridgeOutboundSeq: 0,
-    }),
-    {
-      sendControlMessage(message) {
-        controlMessages.push(message);
-      },
-      onApplicationMessage(message) {
-        applicationMessages.push(message);
-      },
-    }
-  );
-
-  secureTransport.queueOutboundApplicationMessage(
-    JSON.stringify({ id: "response-1", result: { ok: true } }),
-    (message) => {
-      wireMessages.push(message);
-    }
-  );
-  assert.equal(wireMessages.length, 1);
-
-  const outboundEnvelope = JSON.parse(wireMessages[0]);
-  const outboundPayload = decryptEnvelope(outboundEnvelope, macToPhoneKey);
-  assert.equal(outboundPayload.bridgeOutboundSeq, 1);
-  assert.equal(outboundPayload.payloadText, JSON.stringify({ id: "response-1", result: { ok: true } }));
-
-  const inboundEnvelope = encryptEnvelope(
-    {
-      payloadText: JSON.stringify({ id: "request-1", method: "thread/list", params: {} }),
-    },
-    phoneToMacKey,
-    "iphone",
-    0,
-    "session-2",
-    serverHello.keyEpoch
-  );
-  secureTransport.handleIncomingWireMessage(
-    JSON.stringify(inboundEnvelope),
-    {
-      sendControlMessage(message) {
-        controlMessages.push(message);
-      },
-      onApplicationMessage(message) {
-        applicationMessages.push(message);
-      },
-    }
-  );
-
-  assert.deepEqual(applicationMessages, [
-    JSON.stringify({ id: "request-1", method: "thread/list", params: {} }),
-  ]);
-});
-
-test("qr bootstrap allows a fresh QR scan to replace the trusted iPhone", () => {
-  const macIdentity = createOkpKeyPair("ed25519");
-  const firstPhoneIdentity = createOkpKeyPair("ed25519");
-  const firstPhoneEphemeral = createOkpKeyPair("x25519");
-  const secondPhoneIdentity = createOkpKeyPair("ed25519");
-  const secondPhoneEphemeral = createOkpKeyPair("x25519");
-  const secureTransport = createBridgeSecureTransport({
-    sessionId: "session-3",
-    relayUrl: "wss://relay.example/relay",
-    deviceState: {
-      macDeviceId: "mac-3",
-      macIdentityPrivateKey: macIdentity.privateKey,
-      macIdentityPublicKey: macIdentity.publicKey,
+      macDeviceId: "mac-meta",
+      macIdentityPrivateKey: "mac-private-key",
+      macIdentityPublicKey: "mac-public-key",
+      displayName: "Desk Host",
+      platform: "darwin",
       trustedPhones: {},
     },
   });
 
-  finishHandshake({
-    secureTransport,
-    sessionId: "session-3",
-    macDeviceId: "mac-3",
-    phoneDeviceId: "phone-3a",
-    macIdentity,
-    phoneIdentity: firstPhoneIdentity,
-    phoneEphemeral: firstPhoneEphemeral,
-    handshakeMode: HANDSHAKE_MODE_QR_BOOTSTRAP,
-    lastAppliedBridgeOutboundSeq: 0,
-  });
+  const pairingPayload = secureTransport.createPairingPayload();
 
-  finishHandshake({
-    secureTransport,
-    sessionId: "session-3",
-    macDeviceId: "mac-3",
-    phoneDeviceId: "phone-3b",
-    macIdentity,
-    phoneIdentity: secondPhoneIdentity,
-    phoneEphemeral: secondPhoneEphemeral,
-    handshakeMode: HANDSHAKE_MODE_QR_BOOTSTRAP,
-    lastAppliedBridgeOutboundSeq: 0,
+  assert.equal(pairingPayload.macDeviceId, "mac-meta");
+  assert.equal(pairingPayload.macIdentityPublicKey, "mac-public-key");
+  assert.equal(pairingPayload.displayName, "Desk Host");
+  assert.equal(pairingPayload.platform, "macOS");
+  assert.equal(pairingPayload.relay, "wss://relay.example/relay");
+});
+
+test("secure transport round-trips encrypted payloads after a trusted reconnect handshake", () => {
+  withTempDeviceStateEnv(() => {
+    const macIdentity = createOkpKeyPair("ed25519");
+    const phoneIdentity = createOkpKeyPair("ed25519");
+    const phoneEphemeral = createOkpKeyPair("x25519");
+    const secureTransport = createBridgeSecureTransport({
+      sessionId: "session-2",
+      relayUrl: "wss://relay.example/relay",
+      deviceState: {
+        macDeviceId: "mac-2",
+        macIdentityPrivateKey: macIdentity.privateKey,
+        macIdentityPublicKey: macIdentity.publicKey,
+        trustedPhones: {
+          "phone-2": phoneIdentity.publicKey,
+        },
+      },
+    });
+
+    const controlMessages = [];
+    const applicationMessages = [];
+    const wireMessages = [];
+    secureTransport.bindLiveSendWireMessage((message) => {
+      wireMessages.push(message);
+    });
+
+    const clientNonce = Buffer.alloc(32, 7);
+    secureTransport.handleIncomingWireMessage(
+      JSON.stringify({
+        kind: "clientHello",
+        protocolVersion: 1,
+        sessionId: "session-2",
+        handshakeMode: HANDSHAKE_MODE_TRUSTED_RECONNECT,
+        phoneDeviceId: "phone-2",
+        phoneIdentityPublicKey: phoneIdentity.publicKey,
+        phoneEphemeralPublicKey: phoneEphemeral.publicKey,
+        clientNonce: clientNonce.toString("base64"),
+      }),
+      {
+        sendControlMessage(message) {
+          controlMessages.push(message);
+        },
+        onApplicationMessage(message) {
+          applicationMessages.push(message);
+        },
+      }
+    );
+
+    const serverHello = controlMessages.find((message) => message.kind === "serverHello");
+    assert.ok(serverHello, "expected serverHello");
+
+    const transcriptBytes = buildTranscriptBytes({
+      sessionId: "session-2",
+      protocolVersion: 1,
+      handshakeMode: HANDSHAKE_MODE_TRUSTED_RECONNECT,
+      keyEpoch: serverHello.keyEpoch,
+      macDeviceId: "mac-2",
+      phoneDeviceId: "phone-2",
+      macIdentityPublicKey: macIdentity.publicKey,
+      phoneIdentityPublicKey: phoneIdentity.publicKey,
+      macEphemeralPublicKey: serverHello.macEphemeralPublicKey,
+      phoneEphemeralPublicKey: phoneEphemeral.publicKey,
+      clientNonce,
+      serverNonce: Buffer.from(serverHello.serverNonce, "base64"),
+      expiresAtForTranscript: 0,
+    });
+    const phoneAuthTranscript = Buffer.concat([
+      transcriptBytes,
+      encodeLengthPrefixedUTF8("client-auth"),
+    ]);
+    const phoneSignature = sign(
+      null,
+      phoneAuthTranscript,
+      createPrivateKey({
+        key: {
+          crv: "Ed25519",
+          d: base64ToBase64Url(phoneIdentity.privateKey),
+          kty: "OKP",
+          x: base64ToBase64Url(phoneIdentity.publicKey),
+        },
+        format: "jwk",
+      })
+    );
+
+    secureTransport.handleIncomingWireMessage(
+      JSON.stringify({
+        kind: "clientAuth",
+        sessionId: "session-2",
+        phoneDeviceId: "phone-2",
+        keyEpoch: serverHello.keyEpoch,
+        phoneSignature: phoneSignature.toString("base64"),
+      }),
+      {
+        sendControlMessage(message) {
+          controlMessages.push(message);
+        },
+        onApplicationMessage(message) {
+          applicationMessages.push(message);
+        },
+      }
+    );
+
+    const secureReady = controlMessages.find((message) => message.kind === "secureReady");
+    assert.ok(secureReady, "expected secureReady");
+
+    const sharedSecret = diffieHellman({
+      privateKey: createPrivateKey({
+        key: {
+          crv: "X25519",
+          d: base64ToBase64Url(phoneEphemeral.privateKey),
+          kty: "OKP",
+          x: base64ToBase64Url(phoneEphemeral.publicKey),
+        },
+        format: "jwk",
+      }),
+      publicKey: createPublicKey({
+        key: {
+          crv: "X25519",
+          kty: "OKP",
+          x: base64ToBase64Url(serverHello.macEphemeralPublicKey),
+        },
+        format: "jwk",
+      }),
+    });
+    const salt = createHash("sha256").update(transcriptBytes).digest();
+    const infoPrefix = `remodex-e2ee-v1|session-2|mac-2|phone-2|${serverHello.keyEpoch}`;
+    const phoneToMacKey = Buffer.from(
+      hkdfSync("sha256", sharedSecret, salt, Buffer.from(`${infoPrefix}|phoneToMac`, "utf8"), 32)
+    );
+    const macToPhoneKey = Buffer.from(
+      hkdfSync("sha256", sharedSecret, salt, Buffer.from(`${infoPrefix}|macToPhone`, "utf8"), 32)
+    );
+
+    secureTransport.handleIncomingWireMessage(
+      JSON.stringify({
+        kind: "resumeState",
+        sessionId: "session-2",
+        keyEpoch: serverHello.keyEpoch,
+        lastAppliedBridgeOutboundSeq: 0,
+      }),
+      {
+        sendControlMessage(message) {
+          controlMessages.push(message);
+        },
+        onApplicationMessage(message) {
+          applicationMessages.push(message);
+        },
+      }
+    );
+
+    secureTransport.queueOutboundApplicationMessage(
+      JSON.stringify({ id: "response-1", result: { ok: true } }),
+      (message) => {
+        wireMessages.push(message);
+      }
+    );
+    assert.equal(wireMessages.length, 1);
+
+    const outboundEnvelope = JSON.parse(wireMessages[0]);
+    const outboundPayload = decryptEnvelope(outboundEnvelope, macToPhoneKey);
+    assert.equal(outboundPayload.bridgeOutboundSeq, 1);
+    assert.equal(outboundPayload.payloadText, JSON.stringify({ id: "response-1", result: { ok: true } }));
+
+    const inboundEnvelope = encryptEnvelope(
+      {
+        payloadText: JSON.stringify({ id: "request-1", method: "thread/list", params: {} }),
+      },
+      phoneToMacKey,
+      "iphone",
+      0,
+      "session-2",
+      serverHello.keyEpoch
+    );
+    secureTransport.handleIncomingWireMessage(
+      JSON.stringify(inboundEnvelope),
+      {
+        sendControlMessage(message) {
+          controlMessages.push(message);
+        },
+        onApplicationMessage(message) {
+          applicationMessages.push(message);
+        },
+      }
+    );
+
+    assert.deepEqual(applicationMessages, [
+      JSON.stringify({ id: "request-1", method: "thread/list", params: {} }),
+    ]);
+  });
+});
+
+test("qr bootstrap allows a fresh QR scan to replace the trusted iPhone", () => {
+  withTempDeviceStateEnv(() => {
+    const macIdentity = createOkpKeyPair("ed25519");
+    const firstPhoneIdentity = createOkpKeyPair("ed25519");
+    const firstPhoneEphemeral = createOkpKeyPair("x25519");
+    const secondPhoneIdentity = createOkpKeyPair("ed25519");
+    const secondPhoneEphemeral = createOkpKeyPair("x25519");
+    const secureTransport = createBridgeSecureTransport({
+      sessionId: "session-3",
+      relayUrl: "wss://relay.example/relay",
+      deviceState: {
+        macDeviceId: "mac-3",
+        macIdentityPrivateKey: macIdentity.privateKey,
+        macIdentityPublicKey: macIdentity.publicKey,
+        trustedPhones: {},
+      },
+    });
+
+    finishHandshake({
+      secureTransport,
+      sessionId: "session-3",
+      macDeviceId: "mac-3",
+      phoneDeviceId: "phone-3a",
+      macIdentity,
+      phoneIdentity: firstPhoneIdentity,
+      phoneEphemeral: firstPhoneEphemeral,
+      handshakeMode: HANDSHAKE_MODE_QR_BOOTSTRAP,
+      lastAppliedBridgeOutboundSeq: 0,
+    });
+
+    finishHandshake({
+      secureTransport,
+      sessionId: "session-3",
+      macDeviceId: "mac-3",
+      phoneDeviceId: "phone-3b",
+      macIdentity,
+      phoneIdentity: secondPhoneIdentity,
+      phoneEphemeral: secondPhoneEphemeral,
+      handshakeMode: HANDSHAKE_MODE_QR_BOOTSTRAP,
+      lastAppliedBridgeOutboundSeq: 0,
+    });
   });
 });
 
 test("qr bootstrap starts a fresh replay window instead of leaking buffered messages", () => {
-  const macIdentity = createOkpKeyPair("ed25519");
-  const phoneIdentity = createOkpKeyPair("ed25519");
-  const firstEphemeral = createOkpKeyPair("x25519");
-  const secondEphemeral = createOkpKeyPair("x25519");
-  const wireMessages = [];
-  const secureTransport = createBridgeSecureTransport({
-    sessionId: "session-4",
-    relayUrl: "wss://relay.example/relay",
-    deviceState: {
-      macDeviceId: "mac-4",
-      macIdentityPrivateKey: macIdentity.privateKey,
-      macIdentityPublicKey: macIdentity.publicKey,
-      trustedPhones: {},
-    },
-  });
-  secureTransport.bindLiveSendWireMessage((message) => {
-    wireMessages.push(message);
-  });
-
-  finishHandshake({
-    secureTransport,
-    sessionId: "session-4",
-    macDeviceId: "mac-4",
-    phoneDeviceId: "phone-4",
-    macIdentity,
-    phoneIdentity,
-    phoneEphemeral: firstEphemeral,
-    handshakeMode: HANDSHAKE_MODE_QR_BOOTSTRAP,
-    lastAppliedBridgeOutboundSeq: 0,
-  });
-
-  secureTransport.queueOutboundApplicationMessage(
-    JSON.stringify({ id: "stale-response", result: { ok: true } }),
-    (message) => {
+  withTempDeviceStateEnv(() => {
+    const macIdentity = createOkpKeyPair("ed25519");
+    const phoneIdentity = createOkpKeyPair("ed25519");
+    const firstEphemeral = createOkpKeyPair("x25519");
+    const secondEphemeral = createOkpKeyPair("x25519");
+    const wireMessages = [];
+    const secureTransport = createBridgeSecureTransport({
+      sessionId: "session-4",
+      relayUrl: "wss://relay.example/relay",
+      deviceState: {
+        macDeviceId: "mac-4",
+        macIdentityPrivateKey: macIdentity.privateKey,
+        macIdentityPublicKey: macIdentity.publicKey,
+        trustedPhones: {},
+      },
+    });
+    secureTransport.bindLiveSendWireMessage((message) => {
       wireMessages.push(message);
-    }
-  );
-  assert.equal(wireMessages.length, 1);
+    });
 
-  finishHandshake({
-    secureTransport,
-    sessionId: "session-4",
-    macDeviceId: "mac-4",
-    phoneDeviceId: "phone-4",
-    macIdentity,
-    phoneIdentity,
-    phoneEphemeral: secondEphemeral,
-    handshakeMode: HANDSHAKE_MODE_QR_BOOTSTRAP,
-    lastAppliedBridgeOutboundSeq: 0,
+    finishHandshake({
+      secureTransport,
+      sessionId: "session-4",
+      macDeviceId: "mac-4",
+      phoneDeviceId: "phone-4",
+      macIdentity,
+      phoneIdentity,
+      phoneEphemeral: firstEphemeral,
+      handshakeMode: HANDSHAKE_MODE_QR_BOOTSTRAP,
+      lastAppliedBridgeOutboundSeq: 0,
+    });
+
+    secureTransport.queueOutboundApplicationMessage(
+      JSON.stringify({ id: "stale-response", result: { ok: true } }),
+      (message) => {
+        wireMessages.push(message);
+      }
+    );
+    assert.equal(wireMessages.length, 1);
+
+    finishHandshake({
+      secureTransport,
+      sessionId: "session-4",
+      macDeviceId: "mac-4",
+      phoneDeviceId: "phone-4",
+      macIdentity,
+      phoneIdentity,
+      phoneEphemeral: secondEphemeral,
+      handshakeMode: HANDSHAKE_MODE_QR_BOOTSTRAP,
+      lastAppliedBridgeOutboundSeq: 0,
+    });
+
+    assert.equal(wireMessages.length, 1);
   });
-
-  assert.equal(wireMessages.length, 1);
 });
 
 test("rebinding the relay socket replays bridge output from the last phone ack", () => {
-  const macIdentity = createOkpKeyPair("ed25519");
-  const phoneIdentity = createOkpKeyPair("ed25519");
-  const phoneEphemeral = createOkpKeyPair("x25519");
-  const secureTransport = createBridgeSecureTransport({
-    sessionId: "session-5",
-    relayUrl: "wss://relay.example/relay",
-    deviceState: {
+  withTempDeviceStateEnv(() => {
+    const macIdentity = createOkpKeyPair("ed25519");
+    const phoneIdentity = createOkpKeyPair("ed25519");
+    const phoneEphemeral = createOkpKeyPair("x25519");
+    const secureTransport = createBridgeSecureTransport({
+      sessionId: "session-5",
+      relayUrl: "wss://relay.example/relay",
+      deviceState: {
+        macDeviceId: "mac-5",
+        macIdentityPrivateKey: macIdentity.privateKey,
+        macIdentityPublicKey: macIdentity.publicKey,
+        trustedPhones: {},
+      },
+    });
+
+    const { serverHello, transcriptBytes } = finishHandshake({
+      secureTransport,
+      sessionId: "session-5",
       macDeviceId: "mac-5",
-      macIdentityPrivateKey: macIdentity.privateKey,
-      macIdentityPublicKey: macIdentity.publicKey,
-      trustedPhones: {},
-    },
+      phoneDeviceId: "phone-5",
+      macIdentity,
+      phoneIdentity,
+      phoneEphemeral,
+      handshakeMode: HANDSHAKE_MODE_QR_BOOTSTRAP,
+      lastAppliedBridgeOutboundSeq: 0,
+    });
+
+    const sharedSecret = diffieHellman({
+      privateKey: createPrivateKey({
+        key: {
+          crv: "X25519",
+          d: base64ToBase64Url(phoneEphemeral.privateKey),
+          kty: "OKP",
+          x: base64ToBase64Url(phoneEphemeral.publicKey),
+        },
+        format: "jwk",
+      }),
+      publicKey: createPublicKey({
+        key: {
+          crv: "X25519",
+          kty: "OKP",
+          x: base64ToBase64Url(serverHello.macEphemeralPublicKey),
+        },
+        format: "jwk",
+      }),
+    });
+    const salt = createHash("sha256").update(transcriptBytes).digest();
+    const infoPrefix = `remodex-e2ee-v1|session-5|mac-5|phone-5|${serverHello.keyEpoch}`;
+    const macToPhoneKey = Buffer.from(
+      hkdfSync("sha256", sharedSecret, salt, Buffer.from(`${infoPrefix}|macToPhone`, "utf8"), 32)
+    );
+
+    secureTransport.bindLiveSendWireMessage(() => false);
+    secureTransport.queueOutboundApplicationMessage(
+      JSON.stringify({ id: "response-5", result: { ok: true } }),
+      () => false
+    );
+
+    const firstRecoveryWireMessages = [];
+    secureTransport.bindLiveSendWireMessage((message) => {
+      firstRecoveryWireMessages.push(message);
+      return true;
+    });
+
+    assert.equal(firstRecoveryWireMessages.length, 1);
+    const outboundEnvelope = JSON.parse(firstRecoveryWireMessages[0]);
+    const outboundPayload = decryptEnvelope(outboundEnvelope, macToPhoneKey);
+    assert.equal(outboundPayload.bridgeOutboundSeq, 1);
+    assert.equal(outboundPayload.payloadText, JSON.stringify({ id: "response-5", result: { ok: true } }));
+
+    const liveWireMessages = [];
+    secureTransport.queueOutboundApplicationMessage(
+      JSON.stringify({ id: "response-6", result: { ok: true } }),
+      () => {
+        throw new Error("expected active relay sender to handle resumed output");
+      }
+    );
+
+    secureTransport.bindLiveSendWireMessage((message) => {
+      liveWireMessages.push(message);
+      return true;
+    });
+
+    assert.equal(liveWireMessages.length, 2);
+    const replayedPayloads = liveWireMessages.map((message) => {
+      const envelope = JSON.parse(message);
+      return decryptEnvelope(envelope, macToPhoneKey);
+    });
+    assert.deepEqual(
+      replayedPayloads.map((payload) => payload.bridgeOutboundSeq),
+      [1, 2]
+    );
   });
-
-  const { serverHello, transcriptBytes } = finishHandshake({
-    secureTransport,
-    sessionId: "session-5",
-    macDeviceId: "mac-5",
-    phoneDeviceId: "phone-5",
-    macIdentity,
-    phoneIdentity,
-    phoneEphemeral,
-    handshakeMode: HANDSHAKE_MODE_QR_BOOTSTRAP,
-    lastAppliedBridgeOutboundSeq: 0,
-  });
-
-  const sharedSecret = diffieHellman({
-    privateKey: createPrivateKey({
-      key: {
-        crv: "X25519",
-        d: base64ToBase64Url(phoneEphemeral.privateKey),
-        kty: "OKP",
-        x: base64ToBase64Url(phoneEphemeral.publicKey),
-      },
-      format: "jwk",
-    }),
-    publicKey: createPublicKey({
-      key: {
-        crv: "X25519",
-        kty: "OKP",
-        x: base64ToBase64Url(serverHello.macEphemeralPublicKey),
-      },
-      format: "jwk",
-    }),
-  });
-  const salt = createHash("sha256").update(transcriptBytes).digest();
-  const infoPrefix = `remodex-e2ee-v1|session-5|mac-5|phone-5|${serverHello.keyEpoch}`;
-  const macToPhoneKey = Buffer.from(
-    hkdfSync("sha256", sharedSecret, salt, Buffer.from(`${infoPrefix}|macToPhone`, "utf8"), 32)
-  );
-
-  secureTransport.bindLiveSendWireMessage(() => false);
-  secureTransport.queueOutboundApplicationMessage(
-    JSON.stringify({ id: "response-5", result: { ok: true } }),
-    () => false
-  );
-
-  const firstRecoveryWireMessages = [];
-  secureTransport.bindLiveSendWireMessage((message) => {
-    firstRecoveryWireMessages.push(message);
-    return true;
-  });
-
-  assert.equal(firstRecoveryWireMessages.length, 1);
-  const outboundEnvelope = JSON.parse(firstRecoveryWireMessages[0]);
-  const outboundPayload = decryptEnvelope(outboundEnvelope, macToPhoneKey);
-  assert.equal(outboundPayload.bridgeOutboundSeq, 1);
-  assert.equal(outboundPayload.payloadText, JSON.stringify({ id: "response-5", result: { ok: true } }));
-
-  const liveWireMessages = [];
-  secureTransport.queueOutboundApplicationMessage(
-    JSON.stringify({ id: "response-6", result: { ok: true } }),
-    () => {
-      throw new Error("expected active relay sender to handle resumed output");
-    }
-  );
-
-  secureTransport.bindLiveSendWireMessage((message) => {
-    liveWireMessages.push(message);
-    return true;
-  });
-
-  assert.equal(liveWireMessages.length, 2);
-  const replayedPayloads = liveWireMessages.map((message) => {
-    const envelope = JSON.parse(message);
-    return decryptEnvelope(envelope, macToPhoneKey);
-  });
-  assert.deepEqual(
-    replayedPayloads.map((payload) => payload.bridgeOutboundSeq),
-    [1, 2]
-  );
 });
 
 test("resume replay does not advance the replay watermark before a phone ack", () => {
-  const macIdentity = createOkpKeyPair("ed25519");
-  const phoneIdentity = createOkpKeyPair("ed25519");
-  const phoneEphemeral = createOkpKeyPair("x25519");
-  const secureTransport = createBridgeSecureTransport({
-    sessionId: "session-6",
-    relayUrl: "wss://relay.example/relay",
-    deviceState: {
-      macDeviceId: "mac-6",
-      macIdentityPrivateKey: macIdentity.privateKey,
-      macIdentityPublicKey: macIdentity.publicKey,
-      trustedPhones: {},
-    },
-  });
-
-  const initialReplayWireMessages = [];
-  secureTransport.bindLiveSendWireMessage((message) => {
-    initialReplayWireMessages.push(message);
-    return true;
-  });
-
-  const { serverHello, transcriptBytes } = finishHandshake({
-    secureTransport,
-    sessionId: "session-6",
-    macDeviceId: "mac-6",
-    phoneDeviceId: "phone-6",
-    macIdentity,
-    phoneIdentity,
-    phoneEphemeral,
-    handshakeMode: HANDSHAKE_MODE_QR_BOOTSTRAP,
-    lastAppliedBridgeOutboundSeq: 0,
-    skipResumeState: true,
-  });
-
-  secureTransport.queueOutboundApplicationMessage(
-    JSON.stringify({ id: "response-6", result: { ok: true } }),
-    () => {
-      throw new Error("expected bound sender to stay attached after secureReady");
-    }
-  );
-
-  secureTransport.handleIncomingWireMessage(
-    JSON.stringify({
-      kind: "resumeState",
+  withTempDeviceStateEnv(() => {
+    const macIdentity = createOkpKeyPair("ed25519");
+    const phoneIdentity = createOkpKeyPair("ed25519");
+    const phoneEphemeral = createOkpKeyPair("x25519");
+    const secureTransport = createBridgeSecureTransport({
       sessionId: "session-6",
-      keyEpoch: serverHello.keyEpoch,
+      relayUrl: "wss://relay.example/relay",
+      deviceState: {
+        macDeviceId: "mac-6",
+        macIdentityPrivateKey: macIdentity.privateKey,
+        macIdentityPublicKey: macIdentity.publicKey,
+        trustedPhones: {},
+      },
+    });
+
+    const initialReplayWireMessages = [];
+    secureTransport.bindLiveSendWireMessage((message) => {
+      initialReplayWireMessages.push(message);
+      return true;
+    });
+
+    const { serverHello, transcriptBytes } = finishHandshake({
+      secureTransport,
+      sessionId: "session-6",
+      macDeviceId: "mac-6",
+      phoneDeviceId: "phone-6",
+      macIdentity,
+      phoneIdentity,
+      phoneEphemeral,
+      handshakeMode: HANDSHAKE_MODE_QR_BOOTSTRAP,
       lastAppliedBridgeOutboundSeq: 0,
-    }),
-    {
-      sendControlMessage() {},
-      onApplicationMessage() {},
-    }
-  );
+      skipResumeState: true,
+    });
 
-  const sharedSecret = diffieHellman({
-    privateKey: createPrivateKey({
-      key: {
-        crv: "X25519",
-        d: base64ToBase64Url(phoneEphemeral.privateKey),
-        kty: "OKP",
-        x: base64ToBase64Url(phoneEphemeral.publicKey),
-      },
-      format: "jwk",
-    }),
-    publicKey: createPublicKey({
-      key: {
-        crv: "X25519",
-        kty: "OKP",
-        x: base64ToBase64Url(serverHello.macEphemeralPublicKey),
-      },
-      format: "jwk",
-    }),
+    secureTransport.queueOutboundApplicationMessage(
+      JSON.stringify({ id: "response-6", result: { ok: true } }),
+      () => {
+        throw new Error("expected bound sender to stay attached after secureReady");
+      }
+    );
+
+    secureTransport.handleIncomingWireMessage(
+      JSON.stringify({
+        kind: "resumeState",
+        sessionId: "session-6",
+        keyEpoch: serverHello.keyEpoch,
+        lastAppliedBridgeOutboundSeq: 0,
+      }),
+      {
+        sendControlMessage() {},
+        onApplicationMessage() {},
+      }
+    );
+
+    const sharedSecret = diffieHellman({
+      privateKey: createPrivateKey({
+        key: {
+          crv: "X25519",
+          d: base64ToBase64Url(phoneEphemeral.privateKey),
+          kty: "OKP",
+          x: base64ToBase64Url(phoneEphemeral.publicKey),
+        },
+        format: "jwk",
+      }),
+      publicKey: createPublicKey({
+        key: {
+          crv: "X25519",
+          kty: "OKP",
+          x: base64ToBase64Url(serverHello.macEphemeralPublicKey),
+        },
+        format: "jwk",
+      }),
+    });
+    const salt = createHash("sha256").update(transcriptBytes).digest();
+    const infoPrefix = `remodex-e2ee-v1|session-6|mac-6|phone-6|${serverHello.keyEpoch}`;
+    const macToPhoneKey = Buffer.from(
+      hkdfSync("sha256", sharedSecret, salt, Buffer.from(`${infoPrefix}|macToPhone`, "utf8"), 32)
+    );
+
+    assert.equal(initialReplayWireMessages.length, 1);
+
+    const reboundWireMessages = [];
+    secureTransport.bindLiveSendWireMessage((message) => {
+      reboundWireMessages.push(message);
+      return true;
+    });
+
+    assert.equal(reboundWireMessages.length, 1);
+    const reboundEnvelope = JSON.parse(reboundWireMessages[0]);
+    const reboundPayload = decryptEnvelope(reboundEnvelope, macToPhoneKey);
+    assert.equal(reboundPayload.bridgeOutboundSeq, 1);
+    assert.equal(reboundPayload.payloadText, JSON.stringify({ id: "response-6", result: { ok: true } }));
   });
-  const salt = createHash("sha256").update(transcriptBytes).digest();
-  const infoPrefix = `remodex-e2ee-v1|session-6|mac-6|phone-6|${serverHello.keyEpoch}`;
-  const macToPhoneKey = Buffer.from(
-    hkdfSync("sha256", sharedSecret, salt, Buffer.from(`${infoPrefix}|macToPhone`, "utf8"), 32)
-  );
-
-  assert.equal(initialReplayWireMessages.length, 1);
-
-  const reboundWireMessages = [];
-  secureTransport.bindLiveSendWireMessage((message) => {
-    reboundWireMessages.push(message);
-    return true;
-  });
-
-  assert.equal(reboundWireMessages.length, 1);
-  const reboundEnvelope = JSON.parse(reboundWireMessages[0]);
-  const reboundPayload = decryptEnvelope(reboundEnvelope, macToPhoneKey);
-  assert.equal(reboundPayload.bridgeOutboundSeq, 1);
-  assert.equal(reboundPayload.payloadText, JSON.stringify({ id: "response-6", result: { ok: true } }));
 });
 
 function finishHandshake({
@@ -658,6 +694,34 @@ function createOkpKeyPair(type) {
     privateKey: base64UrlToBase64(privateJwk.d),
     publicKey: base64UrlToBase64(publicJwk.x),
   };
+}
+
+function withTempDeviceStateEnv(run) {
+  const previousDir = process.env.REMODEX_DEVICE_STATE_DIR;
+  const previousMirror = process.env.REMODEX_DEVICE_STATE_KEYCHAIN_MOCK_FILE;
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-secure-transport-"));
+  const keychainMirrorFile = path.join(tempRoot, "keychain-device-state.json");
+
+  process.env.REMODEX_DEVICE_STATE_DIR = tempRoot;
+  process.env.REMODEX_DEVICE_STATE_KEYCHAIN_MOCK_FILE = keychainMirrorFile;
+
+  try {
+    return run({ tempRoot, keychainMirrorFile });
+  } finally {
+    if (previousDir === undefined) {
+      delete process.env.REMODEX_DEVICE_STATE_DIR;
+    } else {
+      process.env.REMODEX_DEVICE_STATE_DIR = previousDir;
+    }
+
+    if (previousMirror === undefined) {
+      delete process.env.REMODEX_DEVICE_STATE_KEYCHAIN_MOCK_FILE;
+    } else {
+      process.env.REMODEX_DEVICE_STATE_KEYCHAIN_MOCK_FILE = previousMirror;
+    }
+
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
 }
 
 function buildTranscriptBytes({

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -355,6 +355,7 @@ function resolveTrustedMacSession({
     macDeviceId: normalizedMacDeviceId,
     macIdentityPublicKey: liveSession.macIdentityPublicKey,
     displayName: liveSession.displayName || null,
+    platform: liveSession.platform || null,
     sessionId: liveSession.sessionId,
   };
 }
@@ -433,6 +434,7 @@ function readMacRegistrationHeaders(headers, sessionId) {
     macDeviceId: readHeaderString(headers["x-mac-device-id"]),
     macIdentityPublicKey: readHeaderString(headers["x-mac-identity-public-key"]),
     displayName: readHeaderString(headers["x-machine-name"]),
+    platform: readHeaderString(headers["x-machine-platform"]),
     trustedPhoneDeviceId: readHeaderString(headers["x-trusted-phone-device-id"]),
     trustedPhonePublicKey: readHeaderString(headers["x-trusted-phone-public-key"]),
   }, sessionId);
@@ -444,6 +446,7 @@ function normalizeMacRegistration(registration, sessionId) {
     macDeviceId: normalizeNonEmptyString(registration?.macDeviceId),
     macIdentityPublicKey: normalizeNonEmptyString(registration?.macIdentityPublicKey),
     displayName: normalizeNonEmptyString(registration?.displayName),
+    platform: normalizeNonEmptyString(registration?.platform),
     trustedPhoneDeviceId: normalizeNonEmptyString(registration?.trustedPhoneDeviceId),
     trustedPhonePublicKey: normalizeNonEmptyString(registration?.trustedPhonePublicKey),
   };

--- a/relay/server.test.js
+++ b/relay/server.test.js
@@ -159,6 +159,7 @@ test("completion pushes are rejected after the mac relay session disconnects", a
 
 test("trusted session resolve returns the current live session for a trusted iphone", async () => {
   const phoneIdentity = makePhoneIdentity();
+  const platformLabel = hostPlatformLabel();
 
   await withServer(async ({ port }) => {
     const mac = new WebSocket(`ws://127.0.0.1:${port}/relay/live-session-1`, {
@@ -167,6 +168,7 @@ test("trusted session resolve returns the current live session for a trusted iph
         "x-mac-device-id": "mac-1",
         "x-mac-identity-public-key": "mac-public-key-1",
         "x-machine-name": "Emanuele-Mac",
+        "x-machine-platform": platformLabel,
         "x-trusted-phone-device-id": phoneIdentity.phoneDeviceId,
         "x-trusted-phone-public-key": phoneIdentity.phoneIdentityPublicKey,
       },
@@ -191,6 +193,7 @@ test("trusted session resolve returns the current live session for a trusted iph
       macDeviceId: "mac-1",
       macIdentityPublicKey: "mac-public-key-1",
       displayName: "Emanuele-Mac",
+      platform: platformLabel,
       sessionId: "live-session-1",
     });
 
@@ -304,6 +307,7 @@ test("trusted session resolve reports an offline mac without pretending the endp
 
 test("trusted session resolve starts working immediately after a mac updates its trusted-phone registration", async () => {
   const phoneIdentity = makePhoneIdentity();
+  const platformLabel = hostPlatformLabel();
 
   await withServer(async ({ port }) => {
     const mac = new WebSocket(`ws://127.0.0.1:${port}/relay/live-session-4`, {
@@ -311,6 +315,8 @@ test("trusted session resolve starts working immediately after a mac updates its
         "x-role": "mac",
         "x-mac-device-id": "mac-4",
         "x-mac-identity-public-key": "mac-public-key-4",
+        "x-machine-name": "Updated-Mac",
+        "x-machine-platform": platformLabel,
       },
     });
     await onceOpen(mac);
@@ -321,6 +327,7 @@ test("trusted session resolve starts working immediately after a mac updates its
         macDeviceId: "mac-4",
         macIdentityPublicKey: "mac-public-key-4",
         displayName: "Updated-Mac",
+        platform: platformLabel,
         trustedPhoneDeviceId: phoneIdentity.phoneDeviceId,
         trustedPhonePublicKey: phoneIdentity.phoneIdentityPublicKey,
       },
@@ -340,7 +347,46 @@ test("trusted session resolve starts working immediately after a mac updates its
     assert.equal(response.status, 200);
     const body = await response.json();
     assert.equal(body.displayName, "Updated-Mac");
+    assert.equal(body.platform, platformLabel);
     assert.equal(body.sessionId, "live-session-4");
+
+    const macClosed = onceClosed(mac);
+    mac.close();
+    await macClosed;
+  });
+});
+
+test("trusted session resolve tolerates legacy registrations without platform metadata", async () => {
+  const phoneIdentity = makePhoneIdentity();
+
+  await withServer(async ({ port }) => {
+    const mac = new WebSocket(`ws://127.0.0.1:${port}/relay/live-session-legacy`, {
+      headers: {
+        "x-role": "mac",
+        "x-mac-device-id": "mac-legacy",
+        "x-mac-identity-public-key": "mac-public-key-legacy",
+        "x-machine-name": "Legacy-Mac",
+        "x-trusted-phone-device-id": phoneIdentity.phoneDeviceId,
+        "x-trusted-phone-public-key": phoneIdentity.phoneIdentityPublicKey,
+      },
+    });
+    await onceOpen(mac);
+
+    const response = await fetch(`http://127.0.0.1:${port}/v1/trusted/session/resolve`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(makeTrustedResolveBody({
+        macDeviceId: "mac-legacy",
+        phoneIdentity,
+        nonce: "nonce-legacy",
+        timestamp: Date.now(),
+      })),
+    });
+
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.displayName, "Legacy-Mac");
+    assert.equal(body.platform, null);
 
     const macClosed = onceClosed(mac);
     mac.close();
@@ -759,6 +805,19 @@ function base64UrlToBase64(value) {
   return remainder === 0
     ? normalized
     : normalized + "=".repeat(4 - remainder);
+}
+
+function hostPlatformLabel() {
+  if (process.platform === "darwin") {
+    return "macOS";
+  }
+  if (process.platform === "win32") {
+    return "Windows";
+  }
+  if (process.platform === "linux") {
+    return "Linux";
+  }
+  return process.platform;
 }
 
 function base64ToBase64Url(value) {


### PR DESCRIPTION
## Summary
- add native multi-computer pairing and active host switching on iPhone across Home and Settings
- extend bridge and relay host metadata for macOS and Windows presentation while keeping the single-active-host transport model
- add a personal-team-friendly debug signing path so the app can run on-device without managed push capabilities

## Testing
- xcodebuild test -scheme CodexMobile -destination 'platform=iOS Simulator,OS=26.3.1,name=iPhone 17' -only-testing:CodexMobileTests/CodexSecurePairingStateTests/testPreferredTrustedMacDeviceIdUsesExplicitSelectedHostOverRecencyFallback -only-testing:CodexMobileTests/ContentViewModelReconnectTests/testPreferredReconnectURLResolvesExplicitlySelectedHostBeforeMoreRecentFallback -only-testing:CodexMobileTests/ContentViewModelReconnectTests/testPreferredReconnectURLDoesNotFallbackToSavedSessionForDifferentSelectedHost
- npm test --prefix phodex-bridge
- npm test --prefix relay
- built, installed, and launched com.heminlin.remodex.debug on Lin's iPhone