### PR TITLE
docs: remove Convex from public self-hosting docs

### DIFF
--- a/Docs/self-hosting.md
+++ b/Docs/self-hosting.md
@@ -5,7 +5,7 @@ This guide is for developers who clone the public GitHub repository and want to 
 It covers two supported setups:
 
 1. Local LAN pairing on your own machine
-2. A self-hosted VPS relay that your bridge connects to over the internet
+2. A self-hosted relay on your VPS or private network that your bridge connects to directly
 
 This document intentionally avoids any private hosted-service details. If you are using the public repo, assume you are bringing your own relay endpoint.
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ A common private setup looks like this:
 
 If that relay is fronting a Mac bridge, the macOS daemon can keep the bridge alive for hands-free reconnects. If you self-host against a non-macOS bridge, the same relay path still works, but automatic background service management is not built in yet.
 
-Reverse-proxy subpaths work too, so a hosted relay behind Traefik can live under the same domain as other APIs:
+Reverse-proxy subpaths work too, so a self-hosted relay behind Traefik can live under the same domain as other APIs:
 
 ```sh
 REMODEX_RELAY="wss://api.example.com/remodex/relay" remodex up
@@ -192,16 +192,16 @@ If you point `REMODEX_RELAY` at your own self-hosted relay, managed push stays o
 
 ## Publish to npm
 
-Published npm packages can embed default private relay settings at pack time via the `prepack` script.
+If you publish your own bridge package, you can inject a default relay during `prepack` without changing the public source checkout.
 
-The current package version is `1.3.4`.
+The current package version is `1.3.7`.
 
-To publish the bridge with `api.phodex.app` as the default relay:
+For example:
 
 ```sh
 cd phodex-bridge
 npm login
-REMODEX_PACKAGE_DEFAULT_RELAY_URL="wss://api.phodex.app/relay" \
+REMODEX_PACKAGE_DEFAULT_RELAY_URL="wss://relay.example.com/relay" \
 npm publish
 ```
 
@@ -265,7 +265,7 @@ Prints the installed Remodex CLI version.
 
 ```sh
 remodex --version
-# => 1.3.4
+# => 1.3.7
 ```
 
 ### `remodex reset-pairing`

--- a/SELF_HOSTING_MODEL.md
+++ b/SELF_HOSTING_MODEL.md
@@ -34,7 +34,7 @@ The public repo now also includes the trusted-Mac reconnect flow, but the built-
 If you use the public repo, you should expect one of these flows:
 
 1. Local LAN pairing on your own machine with `./run-local-remodex.sh`
-2. A self-hosted relay on your own VPS, passed in through `REMODEX_RELAY`
+2. A self-hosted relay on your own VPS or private network, passed in through `REMODEX_RELAY`
 
 That means:
 
@@ -97,7 +97,7 @@ If you cloned Remodex from GitHub:
 
 - do not expect a private hosted relay to be built in
 - use `./run-local-remodex.sh` for local testing
-- use `REMODEX_RELAY` for your own VPS or hosted relay
+- use `REMODEX_RELAY` for your own VPS or self-hosted relay
 - use QR once to trust the Mac, then let reconnect reuse that trust
 - remember that the built-in daemon/background service path is currently macOS-only
 - treat the public repo as the self-hostable version of the project


### PR DESCRIPTION
## Summary
- remove stale hosted/Convex wording from public self-hosting docs
- keep the docs focused on local relay, self-hosted relay, and trusted reconnect flows
- replace hardcoded hosted relay examples with generic self-hosted examples

## Test plan
- [x] `npm test --prefix /Users/zackjackson/remodex/.claude/worktrees/agent-a3ba24af/relay`
- [ ] `npm test --prefix /Users/zackjackson/remodex/.claude/worktrees/agent-a3ba24af/phodex-bridge` (fails in existing suite: `gitCheckout surfaces a specific error when the branch is open in another worktree`)
- [x] Skipped e2e because this unit only changes docs

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)