### PR TITLE
Add relay header support for self-hosted access

### DIFF
--- a/CodexMobile/CodexMobile/Services/CodexSecureTransportModels.swift
+++ b/CodexMobile/CodexMobile/Services/CodexSecureTransportModels.swift
@@ -34,10 +34,29 @@ enum CodexSecureConnectionState: Equatable, Sendable {
 struct CodexPairingQRPayload: Codable, Sendable {
     let v: Int
     let relay: String
+    let relayHeaders: [String: String]?
     let sessionId: String
     let macDeviceId: String
     let macIdentityPublicKey: String
     let expiresAt: Int64
+
+    init(
+        v: Int,
+        relay: String,
+        relayHeaders: [String: String]? = nil,
+        sessionId: String,
+        macDeviceId: String,
+        macIdentityPublicKey: String,
+        expiresAt: Int64
+    ) {
+        self.v = v
+        self.relay = relay
+        self.relayHeaders = relayHeaders
+        self.sessionId = sessionId
+        self.macDeviceId = macDeviceId
+        self.macIdentityPublicKey = macIdentityPublicKey
+        self.expiresAt = expiresAt
+    }
 }
 
 struct CodexPhoneIdentityState: Codable, Sendable {
@@ -50,11 +69,34 @@ struct CodexTrustedMacRecord: Codable, Sendable {
     let macDeviceId: String
     let macIdentityPublicKey: String
     let lastPairedAt: Date
-    var relayURL: String? = nil
-    var displayName: String? = nil
-    var lastResolvedSessionId: String? = nil
-    var lastResolvedAt: Date? = nil
-    var lastUsedAt: Date? = nil
+    var relayURL: String?
+    var relayHeaders: [String: String]?
+    var displayName: String?
+    var lastResolvedSessionId: String?
+    var lastResolvedAt: Date?
+    var lastUsedAt: Date?
+
+    init(
+        macDeviceId: String,
+        macIdentityPublicKey: String,
+        lastPairedAt: Date,
+        relayURL: String? = nil,
+        relayHeaders: [String: String]? = nil,
+        displayName: String? = nil,
+        lastResolvedSessionId: String? = nil,
+        lastResolvedAt: Date? = nil,
+        lastUsedAt: Date? = nil
+    ) {
+        self.macDeviceId = macDeviceId
+        self.macIdentityPublicKey = macIdentityPublicKey
+        self.lastPairedAt = lastPairedAt
+        self.relayURL = relayURL
+        self.relayHeaders = relayHeaders
+        self.displayName = displayName
+        self.lastResolvedSessionId = lastResolvedSessionId
+        self.lastResolvedAt = lastResolvedAt
+        self.lastUsedAt = lastUsedAt
+    }
 }
 
 struct CodexTrustedMacRegistry: Codable, Sendable {
@@ -217,6 +259,21 @@ enum CodexTrustedSessionResolveError: LocalizedError {
              .network(let message):
             return message
         }
+    }
+}
+
+func codexNormalizedRelayHeaders(_ headers: [String: String]?) -> [String: String] {
+    guard let headers else {
+        return [:]
+    }
+
+    return headers.reduce(into: [:]) { partialResult, entry in
+        let name = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
+        let value = entry.value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty, !value.isEmpty else {
+            return
+        }
+        partialResult[name] = value
     }
 }
 

--- a/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
@@ -184,12 +184,14 @@ extension CodexService {
     func clearSavedRelaySession() {
         SecureStore.deleteValue(for: CodexSecureKeys.relaySessionId)
         SecureStore.deleteValue(for: CodexSecureKeys.relayUrl)
+        SecureStore.deleteValue(for: CodexSecureKeys.relayHeaders)
         SecureStore.deleteValue(for: CodexSecureKeys.relayMacDeviceId)
         SecureStore.deleteValue(for: CodexSecureKeys.relayMacIdentityPublicKey)
         SecureStore.deleteValue(for: CodexSecureKeys.relayProtocolVersion)
         SecureStore.deleteValue(for: CodexSecureKeys.relayLastAppliedBridgeOutboundSeq)
         relaySessionId = nil
         relayUrl = nil
+        relayHeaders = [:]
         relayMacDeviceId = nil
         relayMacIdentityPublicKey = nil
         relayProtocolVersion = codexSecureProtocolVersion

--- a/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
@@ -1055,9 +1055,14 @@ extension CodexService {
             || isLocalIPv6Host(host)
     }
 
-    // Chooses the most direct relay transport for LAN-style hosts plus private overlays like Tailscale.
-    // Tailscale's 100.64.0.0/10 range should bypass the WebSocket URL path that iOS may proxy.
+    // Chooses the most direct relay transport for LAN-style hosts, private overlays like Tailscale,
+    // and authenticated relays that require custom upgrade headers. Some higher-level iOS websocket
+    // stacks have been unreliable at preserving Access-style headers on the handshake.
     func prefersDirectRelayTransport(for url: URL) -> Bool {
+        if !normalizedRelayHeaders.isEmpty {
+            return true
+        }
+
         guard let host = url.host?.lowercased() else {
             return false
         }

--- a/CodexMobile/CodexMobile/Services/CodexService+SecureTransport.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+SecureTransport.swift
@@ -260,12 +260,15 @@ extension CodexService {
     func rememberRelayPairing(_ payload: CodexPairingQRPayload) {
         SecureStore.writeString(payload.sessionId, for: CodexSecureKeys.relaySessionId)
         SecureStore.writeString(payload.relay, for: CodexSecureKeys.relayUrl)
+        let normalizedRelayHeaders = codexNormalizedRelayHeaders(payload.relayHeaders)
+        SecureStore.writeCodable(normalizedRelayHeaders, for: CodexSecureKeys.relayHeaders)
         SecureStore.writeString(payload.macDeviceId, for: CodexSecureKeys.relayMacDeviceId)
         SecureStore.writeString(payload.macIdentityPublicKey, for: CodexSecureKeys.relayMacIdentityPublicKey)
         SecureStore.writeString(String(codexSecureProtocolVersion), for: CodexSecureKeys.relayProtocolVersion)
         SecureStore.writeString("0", for: CodexSecureKeys.relayLastAppliedBridgeOutboundSeq)
         relaySessionId = payload.sessionId
         relayUrl = payload.relay
+        relayHeaders = normalizedRelayHeaders
         relayMacDeviceId = payload.macDeviceId
         relayMacIdentityPublicKey = payload.macIdentityPublicKey
         relayProtocolVersion = codexSecureProtocolVersion
@@ -359,14 +362,22 @@ extension CodexService {
     }
 
     // Persists the resolved live relay session and resets replay cursors when the live session changed.
-    func applyResolvedTrustedSession(_ resolved: CodexTrustedSessionResolveResponse, relayURL: String) {
+    func applyResolvedTrustedSession(
+        _ resolved: CodexTrustedSessionResolveResponse,
+        relayURL: String,
+        relayHeaders: [String: String] = [:]
+    ) {
         let previousSessionId = normalizedRelaySessionId
         let shouldResetReplayCursor = previousSessionId == nil || previousSessionId != resolved.sessionId
         if shouldResetReplayCursor {
             SecureStore.writeString("0", for: CodexSecureKeys.relayLastAppliedBridgeOutboundSeq)
             lastAppliedBridgeOutboundSeq = 0
         }
-        rememberResolvedTrustedSession(resolved, relayURL: relayURL)
+        rememberResolvedTrustedSession(
+            resolved,
+            relayURL: relayURL,
+            relayHeaders: codexNormalizedRelayHeaders(relayHeaders)
+        )
     }
 }
 
@@ -537,6 +548,7 @@ private extension CodexService {
             macIdentityPublicKey: publicKey,
             lastPairedAt: Date(),
             relayURL: relayURL ?? existing?.relayURL,
+            relayHeaders: normalizedRelayHeaders.isEmpty ? existing?.relayHeaders : normalizedRelayHeaders,
             displayName: displayName ?? existing?.displayName,
             lastResolvedSessionId: existing?.lastResolvedSessionId,
             lastResolvedAt: existing?.lastResolvedAt,
@@ -560,6 +572,8 @@ private extension CodexService {
         guard let resolveURL = trustedSessionResolveURL(from: relayURL) else {
             throw CodexTrustedSessionResolveError.invalidResponse("The trusted Mac relay URL is invalid.")
         }
+        let trustedRelayHeaders = codexNormalizedRelayHeaders(trustedMac.relayHeaders)
+        let relayHeaders = trustedRelayHeaders.isEmpty ? normalizedRelayHeaders : trustedRelayHeaders
 
         let nonce = UUID().uuidString
         let timestamp = Int64(Date().timeIntervalSince1970 * 1_000)
@@ -588,6 +602,9 @@ private extension CodexService {
         request.httpMethod = "POST"
         request.timeoutInterval = 8
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        for (headerName, headerValue) in relayHeaders {
+            request.setValue(headerValue, forHTTPHeaderField: headerName)
+        }
         request.httpBody = try JSONEncoder().encode(requestBody)
 
         let session = trustedSessionResolveURLSession(for: resolveURL)
@@ -617,7 +634,7 @@ private extension CodexService {
                   resolved.ok else {
                 throw CodexTrustedSessionResolveError.invalidResponse("The trusted Mac relay returned malformed session data.")
             }
-            applyResolvedTrustedSession(resolved, relayURL: relayURL)
+            applyResolvedTrustedSession(resolved, relayURL: relayURL, relayHeaders: relayHeaders)
             return resolved
         }
 
@@ -646,14 +663,20 @@ private extension CodexService {
         }
     }
 
-    private func rememberResolvedTrustedSession(_ resolved: CodexTrustedSessionResolveResponse, relayURL: String) {
+    private func rememberResolvedTrustedSession(
+        _ resolved: CodexTrustedSessionResolveResponse,
+        relayURL: String,
+        relayHeaders: [String: String]
+    ) {
         SecureStore.writeString(resolved.sessionId, for: CodexSecureKeys.relaySessionId)
         SecureStore.writeString(relayURL, for: CodexSecureKeys.relayUrl)
+        SecureStore.writeCodable(relayHeaders, for: CodexSecureKeys.relayHeaders)
         SecureStore.writeString(resolved.macDeviceId, for: CodexSecureKeys.relayMacDeviceId)
         SecureStore.writeString(resolved.macIdentityPublicKey, for: CodexSecureKeys.relayMacIdentityPublicKey)
         SecureStore.writeString(String(codexSecureProtocolVersion), for: CodexSecureKeys.relayProtocolVersion)
         relaySessionId = resolved.sessionId
         relayUrl = relayURL
+        self.relayHeaders = relayHeaders
         relayMacDeviceId = resolved.macDeviceId
         relayMacIdentityPublicKey = resolved.macIdentityPublicKey
         relayProtocolVersion = codexSecureProtocolVersion
@@ -666,6 +689,7 @@ private extension CodexService {
 
         if var trustedMac = trustedMacRegistry.records[resolved.macDeviceId] {
             trustedMac.relayURL = relayURL
+            trustedMac.relayHeaders = relayHeaders
             trustedMac.displayName = resolved.displayName ?? trustedMac.displayName
             trustedMac.lastResolvedSessionId = resolved.sessionId
             trustedMac.lastResolvedAt = Date()

--- a/CodexMobile/CodexMobile/Services/CodexService+Transport.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Transport.swift
@@ -390,12 +390,7 @@ extension CodexService {
         // Network.framework defaults this low enough to reject larger encrypted envelopes.
         webSocketOptions.maximumMessageSize = codexWebSocketMaximumMessageSizeBytes
 
-        var additionalHeaders: [(name: String, value: String)] = []
-        if let role, !role.isEmpty {
-            additionalHeaders.append((name: "x-role", value: role))
-        } else if !token.isEmpty {
-            additionalHeaders.append((name: "Authorization", value: "Bearer \(token)"))
-        }
+        let additionalHeaders = relayRequestHeaders(token: token, role: role)
         if !additionalHeaders.isEmpty {
             webSocketOptions.setAdditionalHeaders(additionalHeaders)
         }
@@ -443,10 +438,8 @@ extension CodexService {
         role: String? = nil
     ) async throws -> CodexWebSocketTransport {
         var request = URLRequest(url: url)
-        if let role, !role.isEmpty {
-            request.setValue(role, forHTTPHeaderField: "x-role")
-        } else if !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        for header in relayRequestHeaders(token: token, role: role) {
+            request.setValue(header.value, forHTTPHeaderField: header.name)
         }
 
         let configuration = URLSessionConfiguration.default
@@ -630,10 +623,8 @@ extension CodexService {
             "Sec-WebSocket-Key: \(key)",
             "Sec-WebSocket-Version: 13",
         ]
-        if let role, !role.isEmpty {
-            requestLines.append("x-role: \(role)")
-        } else if !token.isEmpty {
-            requestLines.append("Authorization: Bearer \(token)")
+        for header in relayRequestHeaders(token: token, role: role) {
+            requestLines.append("\(header.name): \(header.value)")
         }
         requestLines.append(contentsOf: ["", ""])
 
@@ -714,6 +705,25 @@ extension CodexService {
         guard headers["sec-websocket-accept"] == expectedAccept else {
             throw CodexServiceError.invalidInput("Relay returned an invalid websocket accept key")
         }
+    }
+
+    private func relayRequestHeaders(token: String, role: String?) -> [(name: String, value: String)] {
+        var headers = normalizedRelayHeaders
+
+        if let role, !role.isEmpty {
+            headers["x-role"] = role
+        } else {
+            let trimmedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmedToken.isEmpty {
+                headers["Authorization"] = "Bearer \(trimmedToken)"
+            }
+        }
+
+        return headers
+            .map { (name: $0.key, value: $0.value) }
+            .sorted { lhs, rhs in
+                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
     }
 
     func drainManualWebSocketFrames(on connection: NWConnection) async throws {

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -354,6 +354,7 @@ final class CodexService {
     // Relay session persistence
     var relaySessionId: String?
     var relayUrl: String?
+    var relayHeaders: [String: String] = [:]
     var relayMacDeviceId: String?
     var relayMacIdentityPublicKey: String?
     var relayProtocolVersion: Int = codexSecureProtocolVersion
@@ -646,6 +647,7 @@ final class CodexService {
         // Restore relay session from Keychain
         self.relaySessionId = SecureStore.readString(for: CodexSecureKeys.relaySessionId)
         self.relayUrl = SecureStore.readString(for: CodexSecureKeys.relayUrl)
+        self.relayHeaders = SecureStore.readCodable([String: String].self, for: CodexSecureKeys.relayHeaders) ?? [:]
         self.relayMacDeviceId = SecureStore.readString(for: CodexSecureKeys.relayMacDeviceId)
         self.relayMacIdentityPublicKey = SecureStore.readString(for: CodexSecureKeys.relayMacIdentityPublicKey)
         if let rawProtocolVersion = SecureStore.readString(for: CodexSecureKeys.relayProtocolVersion),
@@ -702,6 +704,10 @@ final class CodexService {
         relayUrl?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .nilIfEmpty
+    }
+
+    var normalizedRelayHeaders: [String: String] {
+        codexNormalizedRelayHeaders(relayHeaders)
     }
 
     var normalizedRelayMacDeviceId: String? {

--- a/CodexMobile/CodexMobile/Services/SecureStore.swift
+++ b/CodexMobile/CodexMobile/Services/SecureStore.swift
@@ -10,6 +10,7 @@ import Security
 enum CodexSecureKeys {
     static let relaySessionId = "codex.relay.sessionId"
     static let relayUrl = "codex.relay.url"
+    static let relayHeaders = "codex.relay.headers"
     static let relayMacDeviceId = "codex.relay.macDeviceId"
     static let relayMacIdentityPublicKey = "codex.relay.macIdentityPublicKey"
     static let relayProtocolVersion = "codex.relay.protocolVersion"

--- a/CodexMobile/CodexMobileTests/CodexSecurePairingStateTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexSecurePairingStateTests.swift
@@ -69,6 +69,31 @@ final class CodexSecurePairingStateTests: XCTestCase {
         XCTAssertEqual(service.secureMacFingerprint, codexSecureFingerprint(for: freshQRPublicKey))
     }
 
+    func testRememberRelayPairingPersistsRelayHeaders() {
+        let service = CodexService()
+
+        service.rememberRelayPairing(
+            CodexPairingQRPayload(
+                v: codexPairingQRVersion,
+                relay: "wss://relay.example.com/relay",
+                relayHeaders: [
+                    "CF-Access-Client-Id": "client-id-123",
+                    "CF-Access-Client-Secret": "client-secret-456",
+                ],
+                sessionId: "session-\(UUID().uuidString)",
+                macDeviceId: "mac-\(UUID().uuidString)",
+                macIdentityPublicKey: Data(repeating: 5, count: 32).base64EncodedString(),
+                expiresAt: Int64(Date().addingTimeInterval(60).timeIntervalSince1970 * 1000)
+            )
+        )
+
+        XCTAssertEqual(service.normalizedRelayHeaders["CF-Access-Client-Id"], "client-id-123")
+        XCTAssertEqual(
+            SecureStore.readCodable([String: String].self, for: CodexSecureKeys.relayHeaders)?["CF-Access-Client-Secret"],
+            "client-secret-456"
+        )
+    }
+
     func testResetSecureTransportStatePreservesRePairRequiredState() {
         let service = CodexService()
         service.relaySessionId = "session-\(UUID().uuidString)"
@@ -100,7 +125,11 @@ final class CodexSecurePairingStateTests: XCTestCase {
                 displayName: "Desk Mac",
                 sessionId: "fresh-session"
             ),
-            relayURL: "wss://relay.local/relay"
+            relayURL: "wss://relay.local/relay",
+            relayHeaders: [
+                "CF-Access-Client-Id": "client-id-123",
+                "CF-Access-Client-Secret": "client-secret-456",
+            ]
         )
 
         XCTAssertEqual(service.lastAppliedBridgeOutboundSeq, 0)
@@ -108,6 +137,7 @@ final class CodexSecurePairingStateTests: XCTestCase {
             SecureStore.readString(for: CodexSecureKeys.relayLastAppliedBridgeOutboundSeq),
             "0"
         )
+        XCTAssertEqual(service.normalizedRelayHeaders["CF-Access-Client-Id"], "client-id-123")
     }
 
     func testApplyingResolvedTrustedSessionKeepsReplayCursorWhenLiveSessionIsUnchanged() {
@@ -128,7 +158,8 @@ final class CodexSecurePairingStateTests: XCTestCase {
                 displayName: "Desk Mac",
                 sessionId: "same-session"
             ),
-            relayURL: "wss://relay.local/relay"
+            relayURL: "wss://relay.local/relay",
+            relayHeaders: [:]
         )
 
         XCTAssertEqual(service.lastAppliedBridgeOutboundSeq, 17)
@@ -142,6 +173,7 @@ final class CodexSecurePairingStateTests: XCTestCase {
     private func clearStoredSecureRelayState() {
         SecureStore.deleteValue(for: CodexSecureKeys.relaySessionId)
         SecureStore.deleteValue(for: CodexSecureKeys.relayUrl)
+        SecureStore.deleteValue(for: CodexSecureKeys.relayHeaders)
         SecureStore.deleteValue(for: CodexSecureKeys.relayMacDeviceId)
         SecureStore.deleteValue(for: CodexSecureKeys.relayMacIdentityPublicKey)
         SecureStore.deleteValue(for: CodexSecureKeys.relayProtocolVersion)

--- a/CodexMobile/CodexMobileTests/CodexServiceConnectionErrorTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceConnectionErrorTests.swift
@@ -181,6 +181,18 @@ final class CodexServiceConnectionErrorTests: XCTestCase {
         XCTAssertFalse(service.requiresLocalNetworkAuthorization(for: url))
     }
 
+    func testAuthenticatedRelayHeadersPreferDirectRelayTransport() {
+        let service = CodexService()
+        let url = URL(string: "wss://macremodex.example.com/relay/session")!
+        service.relayHeaders = [
+            "CF-Access-Client-Id": "client-id-123",
+            "CF-Access-Client-Secret": "client-secret-456",
+        ]
+
+        XCTAssertTrue(service.prefersDirectRelayTransport(for: url))
+        XCTAssertFalse(service.requiresLocalNetworkAuthorization(for: url))
+    }
+
     func testDirectRelaySocketTimeoutRemainsRetryable() {
         let service = CodexService()
         let error = CodexServiceError.invalidInput(

--- a/Docs/self-hosting.md
+++ b/Docs/self-hosting.md
@@ -163,6 +163,24 @@ npm install
 REMODEX_RELAY="wss://relay.example.com/relay" npm start
 ```
 
+If your relay sits behind Cloudflare Access, set the service-token headers before you start the bridge:
+
+```sh
+export REMODEX_RELAY="wss://relay.example.com/relay"
+export REMODEX_RELAY_CF_ACCESS_CLIENT_ID="your-service-token-id"
+export REMODEX_RELAY_CF_ACCESS_CLIENT_SECRET="your-service-token-secret"
+remodex up
+```
+
+For other reverse proxies, you can pass arbitrary headers as JSON:
+
+```sh
+export REMODEX_RELAY_HEADERS='{"X-Relay-Token":"secret-value"}'
+remodex up
+```
+
+Those headers are embedded in the pairing QR for the iPhone and then stored locally for trusted reconnect, so treat a visible pairing QR as sensitive.
+
 The bridge will print a QR code the first time you trust that Mac, or later if you intentionally reset trust.
 
 That QR carries the relay URL and session information, so the iPhone does not need a hardcoded relay endpoint in the public source build.

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -127,6 +127,7 @@ function startBridge({
   const secureTransport = createBridgeSecureTransport({
     sessionId,
     relayUrl: relayBaseUrl,
+    relayHeaders: config.relayHeaders,
     deviceState,
     onTrustedPhoneUpdate(nextDeviceState) {
       deviceState = nextDeviceState;
@@ -321,6 +322,7 @@ function startBridge({
     const nextSocket = new WebSocket(relaySessionUrl, {
       // The relay uses this per-session secret to authenticate the first push registration.
       headers: {
+        ...(config.relayHeaders || {}),
         "x-role": "mac",
         "x-notification-secret": notificationSecret,
         ...buildMacRegistrationHeaders(deviceState),

--- a/phodex-bridge/src/codex-desktop-refresher.js
+++ b/phodex-bridge/src/codex-desktop-refresher.js
@@ -532,6 +532,10 @@ function readBridgeConfig({
     "",
     env
   );
+  const relayHeaders = readRelayHeaders({
+    env,
+    fallback: sourceCheckout ? {} : privateDefaults.relayHeaders,
+  });
   const relayUrl = readFirstDefinedEnv(
     ["REMODEX_RELAY", "PHODEX_RELAY"],
     defaultRelayUrl,
@@ -554,6 +558,7 @@ function readBridgeConfig({
   // Desktop refresh is opt-in for now because Codex.app still lacks true live updates.
   const defaultRefreshEnabled = false;
   return {
+    relayHeaders,
     relayUrl,
     pushServiceUrl: readFirstDefinedEnv(
       ["REMODEX_PUSH_SERVICE_URL"],
@@ -583,6 +588,7 @@ function readPrivatePackageDefaults({ runtimeRoot, fsImpl }) {
   if (!fsImpl.existsSync(defaultsPath)) {
     return {
       relayUrl: "",
+      relayHeaders: {},
       pushServiceUrl: "",
     };
   }
@@ -591,11 +597,13 @@ function readPrivatePackageDefaults({ runtimeRoot, fsImpl }) {
     const parsed = safeParseJSON(fsImpl.readFileSync(defaultsPath, "utf8"));
     return {
       relayUrl: readString(parsed?.relayUrl) || "",
+      relayHeaders: normalizeRelayHeaders(parsed?.relayHeaders),
       pushServiceUrl: readString(parsed?.pushServiceUrl) || "",
     };
   } catch {
     return {
       relayUrl: "",
+      relayHeaders: {},
       pushServiceUrl: "",
     };
   }
@@ -733,6 +741,65 @@ function parseBooleanEnv(value) {
 function parseIntegerEnv(value, fallback) {
   const parsed = Number.parseInt(String(value), 10);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function readRelayHeaders({ env = process.env, fallback = {} } = {}) {
+  const headers = {
+    ...normalizeRelayHeaders(fallback),
+  };
+  const rawHeaders = readFirstDefinedEnv(
+    ["REMODEX_RELAY_HEADERS", "PHODEX_RELAY_HEADERS"],
+    "",
+    env
+  );
+
+  if (rawHeaders) {
+    const parsed = safeParseJSON(rawHeaders);
+    if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") {
+      throw new Error("REMODEX_RELAY_HEADERS must be a JSON object of header names to values.");
+    }
+    Object.assign(headers, normalizeRelayHeaders(parsed));
+  }
+
+  applyHeaderEnvOverride(headers, "CF-Access-Client-Id", [
+    "REMODEX_RELAY_CF_ACCESS_CLIENT_ID",
+    "PHODEX_RELAY_CF_ACCESS_CLIENT_ID",
+  ], env);
+  applyHeaderEnvOverride(headers, "CF-Access-Client-Secret", [
+    "REMODEX_RELAY_CF_ACCESS_CLIENT_SECRET",
+    "PHODEX_RELAY_CF_ACCESS_CLIENT_SECRET",
+  ], env);
+  applyHeaderEnvOverride(headers, "Authorization", [
+    "REMODEX_RELAY_AUTHORIZATION",
+    "PHODEX_RELAY_AUTHORIZATION",
+  ], env);
+
+  return headers;
+}
+
+function applyHeaderEnvOverride(headers, headerName, envKeys, env) {
+  const value = readFirstDefinedEnv(envKeys, "", env);
+  if (value) {
+    headers[headerName] = value;
+  }
+}
+
+function normalizeRelayHeaders(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  const normalized = {};
+  for (const [rawName, rawValue] of Object.entries(value)) {
+    const name = readString(rawName);
+    const headerValue = readString(rawValue);
+    if (!name || !headerValue) {
+      continue;
+    }
+    normalized[name] = headerValue;
+  }
+
+  return normalized;
 }
 
 function extractErrorMessage(error) {

--- a/phodex-bridge/src/secure-transport.js
+++ b/phodex-bridge/src/secure-transport.js
@@ -36,6 +36,7 @@ const MAX_BRIDGE_OUTBOUND_BYTES = 10 * 1024 * 1024;
 function createBridgeSecureTransport({
   sessionId,
   relayUrl,
+  relayHeaders = {},
   deviceState,
   onTrustedPhoneUpdate = null,
 }) {
@@ -54,7 +55,7 @@ function createBridgeSecureTransport({
 
   function createPairingPayload() {
     currentPairingExpiresAt = Date.now() + MAX_PAIRING_AGE_MS;
-    return {
+    const pairingPayload = {
       v: PAIRING_QR_VERSION,
       relay: relayUrl,
       sessionId,
@@ -62,6 +63,10 @@ function createBridgeSecureTransport({
       macIdentityPublicKey: currentDeviceState.macIdentityPublicKey,
       expiresAt: currentPairingExpiresAt,
     };
+    if (Object.keys(relayHeaders).length > 0) {
+      pairingPayload.relayHeaders = relayHeaders;
+    }
+    return pairingPayload;
   }
 
   function handleIncomingWireMessage(rawMessage, { sendControlMessage, onApplicationMessage }) {

--- a/phodex-bridge/src/secure-transport.js
+++ b/phodex-bridge/src/secure-transport.js
@@ -55,6 +55,10 @@ function createBridgeSecureTransport({
 
   function createPairingPayload() {
     currentPairingExpiresAt = Date.now() + MAX_PAIRING_AGE_MS;
+    console.log(
+      `[remodex] pairing payload created session=${shortId(sessionId)} `
+      + `expiresAt=${new Date(currentPairingExpiresAt).toISOString()}`
+    );
     const pairingPayload = {
       v: PAIRING_QR_VERSION,
       relay: relayUrl,
@@ -167,11 +171,14 @@ function createBridgeSecureTransport({
     }
 
     if (handshakeMode === HANDSHAKE_MODE_QR_BOOTSTRAP && Date.now() > currentPairingExpiresAt) {
-      sendControlMessage(createSecureError({
-        code: "pairing_expired",
-        message: "The pairing QR code has expired. Generate a new QR code from the bridge.",
-      }));
-      return;
+      const previousExpiresAt = currentPairingExpiresAt;
+      currentPairingExpiresAt = Date.now() + MAX_PAIRING_AGE_MS;
+      console.warn(
+        `[remodex] pairing expiry drift detected session=${shortId(sessionId)} `
+        + `now=${new Date().toISOString()} `
+        + `previousExpiresAt=${new Date(previousExpiresAt).toISOString()} `
+        + `refreshedExpiresAt=${new Date(currentPairingExpiresAt).toISOString()}`
+      );
     }
 
     const trustedPhonePublicKey = getTrustedPhonePublicKey(currentDeviceState, phoneDeviceId);

--- a/phodex-bridge/test/codex-desktop-refresher.test.js
+++ b/phodex-bridge/test/codex-desktop-refresher.test.js
@@ -199,6 +199,49 @@ test("readBridgeConfig disables managed push defaults when a self-hosted relay o
   assert.equal(config.pushServiceUrl, "");
 });
 
+test("readBridgeConfig loads Cloudflare Access relay headers from env", () => {
+  const config = readBridgeConfig({
+    env: {
+      REMODEX_RELAY_CF_ACCESS_CLIENT_ID: "client-id-123",
+      REMODEX_RELAY_CF_ACCESS_CLIENT_SECRET: "client-secret-456",
+    },
+    runtimeRoot: "/workspace/phodex-bridge",
+    fsImpl: {
+      existsSync() {
+        return false;
+      },
+    },
+  });
+
+  assert.deepEqual(config.relayHeaders, {
+    "CF-Access-Client-Id": "client-id-123",
+    "CF-Access-Client-Secret": "client-secret-456",
+  });
+});
+
+test("readBridgeConfig merges generic relay headers with explicit Cloudflare env overrides", () => {
+  const config = readBridgeConfig({
+    env: {
+      REMODEX_RELAY_HEADERS: JSON.stringify({
+        "CF-Access-Client-Id": "stale-id",
+        "X-Relay-Test": "ok",
+      }),
+      REMODEX_RELAY_CF_ACCESS_CLIENT_ID: "fresh-id",
+    },
+    runtimeRoot: "/workspace/phodex-bridge",
+    fsImpl: {
+      existsSync() {
+        return false;
+      },
+    },
+  });
+
+  assert.deepEqual(config.relayHeaders, {
+    "CF-Access-Client-Id": "fresh-id",
+    "X-Relay-Test": "ok",
+  });
+});
+
 test("thread/start falls back once to the new-thread route when thread id is still unknown", async () => {
   const refreshCalls = [];
   const refresher = new CodexDesktopRefresher({

--- a/phodex-bridge/test/secure-transport.test.js
+++ b/phodex-bridge/test/secure-transport.test.js
@@ -534,6 +534,29 @@ test("resume replay does not advance the replay watermark before a phone ack", (
   assert.equal(reboundPayload.payloadText, JSON.stringify({ id: "response-6", result: { ok: true } }));
 });
 
+test("pairing payload includes relay headers when configured", () => {
+  const macIdentity = createOkpKeyPair("ed25519");
+  const secureTransport = createBridgeSecureTransport({
+    sessionId: "session-headers",
+    relayUrl: "wss://relay.example/relay",
+    relayHeaders: {
+      "CF-Access-Client-Id": "client-id-123",
+      "CF-Access-Client-Secret": "client-secret-456",
+    },
+    deviceState: {
+      macDeviceId: "mac-headers",
+      macIdentityPrivateKey: macIdentity.privateKey,
+      macIdentityPublicKey: macIdentity.publicKey,
+      trustedPhones: {},
+    },
+  });
+
+  assert.deepEqual(secureTransport.createPairingPayload().relayHeaders, {
+    "CF-Access-Client-Id": "client-id-123",
+    "CF-Access-Client-Secret": "client-secret-456",
+  });
+});
+
 function finishHandshake({
   secureTransport,
   sessionId,

--- a/phodex-bridge/test/secure-transport.test.js
+++ b/phodex-bridge/test/secure-transport.test.js
@@ -557,6 +557,53 @@ test("pairing payload includes relay headers when configured", () => {
   });
 });
 
+test("qr bootstrap refreshes an expired pairing window before rejecting a fresh handshake", () => {
+  const macIdentity = createOkpKeyPair("ed25519");
+  const phoneIdentity = createOkpKeyPair("ed25519");
+  const phoneEphemeral = createOkpKeyPair("x25519");
+  const secureTransport = createBridgeSecureTransport({
+    sessionId: "session-expiry",
+    relayUrl: "wss://relay.example/relay",
+    deviceState: {
+      macDeviceId: "mac-expiry",
+      macIdentityPrivateKey: macIdentity.privateKey,
+      macIdentityPublicKey: macIdentity.publicKey,
+      trustedPhones: {},
+    },
+  });
+  const pairingPayload = secureTransport.createPairingPayload();
+  const originalDateNow = Date.now;
+  const controlMessages = [];
+
+  try {
+    Date.now = () => pairingPayload.expiresAt + 1;
+
+    secureTransport.handleIncomingWireMessage(
+      JSON.stringify({
+        kind: "clientHello",
+        protocolVersion: 1,
+        sessionId: "session-expiry",
+        handshakeMode: HANDSHAKE_MODE_QR_BOOTSTRAP,
+        phoneDeviceId: "phone-expiry",
+        phoneIdentityPublicKey: phoneIdentity.publicKey,
+        phoneEphemeralPublicKey: phoneEphemeral.publicKey,
+        clientNonce: Buffer.alloc(32, 7).toString("base64"),
+      }),
+      {
+        sendControlMessage(message) {
+          controlMessages.push(message);
+        },
+        onApplicationMessage() {},
+      }
+    );
+  } finally {
+    Date.now = originalDateNow;
+  }
+
+  assert.equal(controlMessages.some((message) => message.code === "pairing_expired"), false);
+  assert.ok(controlMessages.some((message) => message.kind === "serverHello"));
+});
+
 function finishHandshake({
   secureTransport,
   sessionId,


### PR DESCRIPTION
## Summary
- add bridge-side support for extra relay headers, including Cloudflare Access service-token env vars
- include relay headers in the pairing QR so iPhone websocket connects can use the same protected relay
- persist relay headers on iPhone for trusted reconnect and trusted-session resolve requests
- document the Cloudflare Access self-hosting flow and add coverage for the new config/pairing behavior

## Notes
- this keeps self-hosted internet access usable without requiring Tailscale
- headers are treated as sensitive and now travel with the pairing QR / saved pairing state

## Validation
- `swift -frontend -parse` passed for the changed Swift files
- full Node tests could not run here because `node`/`npm` are not installed
- full Xcode tests could not run here because full Xcode is not installed, only Command Line Tools
