### PR TITLE
feat: add AI-generated git commit and PR drafts

### DIFF
--- a/CodexMobile/CodexMobile/Models/GitActionModels.swift
+++ b/CodexMobile/CodexMobile/Models/GitActionModels.swift
@@ -125,6 +125,18 @@ struct GitCommitResult: Sendable {
     }
 }
 
+struct GitGeneratedCommitMessageResult: Sendable {
+    let subject: String
+    let body: String
+    let fullMessage: String
+
+    init(from json: [String: JSONValue]) {
+        self.subject = json["subject"]?.stringValue ?? ""
+        self.body = json["body"]?.stringValue ?? ""
+        self.fullMessage = json["fullMessage"]?.stringValue ?? ""
+    }
+}
+
 struct GitPushResult: Sendable {
     let branch: String
     let remote: String?
@@ -266,6 +278,16 @@ struct GitRemoteUrlResult: Sendable {
     init(from json: [String: JSONValue]) {
         self.url = json["url"]?.stringValue ?? ""
         self.ownerRepo = json["ownerRepo"]?.stringValue
+    }
+}
+
+struct GitPullRequestDraftResult: Sendable {
+    let title: String
+    let body: String
+
+    init(from json: [String: JSONValue]) {
+        self.title = json["title"]?.stringValue ?? ""
+        self.body = json["body"]?.stringValue ?? ""
     }
 }
 

--- a/CodexMobile/CodexMobile/Services/CodexService+RuntimeConfig.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+RuntimeConfig.swift
@@ -93,6 +93,12 @@ extension CodexService {
         normalizeRuntimeSelectionsAfterModelsUpdate()
     }
 
+    func setSelectedGitWriterModelId(_ modelId: String?) {
+        let normalized = modelId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        selectedGitWriterModelId = (normalized?.isEmpty == false) ? normalized : nil
+        normalizeRuntimeSelectionsAfterModelsUpdate()
+    }
+
     func setSelectedReasoningEffort(_ effort: String?) {
         let normalized = effort?.trimmingCharacters(in: .whitespacesAndNewlines)
         selectedReasoningEffort = (normalized?.isEmpty == false) ? normalized : nil
@@ -176,6 +182,14 @@ extension CodexService {
 
     func selectedModelOption() -> CodexModelOption? {
         selectedModelOption(from: availableModels)
+    }
+
+    func selectedGitWriterModelOption() -> CodexModelOption? {
+        selectedGitWriterModelOption(from: availableModels)
+    }
+
+    func gitWriterModelIdentifier() -> String? {
+        selectedGitWriterModelOption()?.model
     }
 
     func supportedReasoningEffortsForSelectedModel() -> [CodexReasoningEffortOption] {
@@ -442,6 +456,13 @@ private extension CodexService {
             selectedReasoningEffort = nil
         }
 
+        if let selectedGitWriterModelId,
+           !availableModels.contains(where: {
+               $0.id == selectedGitWriterModelId || $0.model == selectedGitWriterModelId
+           }) {
+            self.selectedGitWriterModelId = nil
+        }
+
         persistRuntimeSelections()
     }
 
@@ -458,6 +479,31 @@ private extension CodexService {
         return nil
     }
 
+    func selectedGitWriterModelOption(
+        from models: [CodexModelOption],
+        explicitModelId: String? = nil
+    ) -> CodexModelOption? {
+        guard !models.isEmpty else {
+            return nil
+        }
+
+        let savedSelection = explicitModelId ?? selectedGitWriterModelId
+        if let savedSelection,
+           let directMatch = models.first(where: { $0.id == savedSelection || $0.model == savedSelection }) {
+            return directMatch
+        }
+
+        if let miniModel = models.first(where: { $0.id == "gpt-5.4-mini" || $0.model == "gpt-5.4-mini" }) {
+            return miniModel
+        }
+
+        if let runtimeSelected = selectedModelOption(from: models) {
+            return runtimeSelected
+        }
+
+        return fallbackModel(from: models)
+    }
+
     func fallbackModel(from models: [CodexModelOption]) -> CodexModelOption? {
         if let defaultModel = models.first(where: { $0.isDefault }) {
             return defaultModel
@@ -470,6 +516,12 @@ private extension CodexService {
             defaults.set(selectedModelId, forKey: Self.selectedModelIdDefaultsKey)
         } else {
             defaults.removeObject(forKey: Self.selectedModelIdDefaultsKey)
+        }
+
+        if let selectedGitWriterModelId, !selectedGitWriterModelId.isEmpty {
+            defaults.set(selectedGitWriterModelId, forKey: Self.selectedGitWriterModelIdDefaultsKey)
+        } else {
+            defaults.removeObject(forKey: Self.selectedGitWriterModelIdDefaultsKey)
         }
 
         if let selectedReasoningEffort, !selectedReasoningEffort.isEmpty {

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -342,6 +342,7 @@ final class CodexService {
     var syncRealtimeEnabled = true
     var availableModels: [CodexModelOption] = []
     var selectedModelId: String?
+    var selectedGitWriterModelId: String?
     var selectedReasoningEffort: String?
     var selectedServiceTier: CodexServiceTier?
     // Per-chat runtime overrides let the composer diverge from app-wide defaults.
@@ -550,6 +551,7 @@ final class CodexService {
     let remoteNotificationRegistrar: CodexRemoteNotificationRegistering
 
     static let selectedModelIdDefaultsKey = "codex.selectedModelId"
+    static let selectedGitWriterModelIdDefaultsKey = "codex.selectedGitWriterModelId"
     static let selectedReasoningEffortDefaultsKey = "codex.selectedReasoningEffort"
     static let selectedServiceTierDefaultsKey = "codex.selectedServiceTier"
     static let threadRuntimeOverridesDefaultsKey = "codex.threadRuntimeOverrides"
@@ -605,6 +607,10 @@ final class CodexService {
         let savedModelId = defaults.string(forKey: Self.selectedModelIdDefaultsKey)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         self.selectedModelId = (savedModelId?.isEmpty == false) ? savedModelId : nil
+
+        let savedGitWriterModelId = defaults.string(forKey: Self.selectedGitWriterModelIdDefaultsKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        self.selectedGitWriterModelId = (savedGitWriterModelId?.isEmpty == false) ? savedGitWriterModelId : nil
 
         let savedReasoning = defaults.string(forKey: Self.selectedReasoningEffortDefaultsKey)?
             .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/CodexMobile/CodexMobile/Services/GitActionsService.swift
+++ b/CodexMobile/CodexMobile/Services/GitActionsService.swift
@@ -105,6 +105,15 @@ final class GitActionsService {
         return GitCommitResult(from: json)
     }
 
+    func generateCommitMessage(model: String?) async throws -> GitGeneratedCommitMessageResult {
+        var params: [String: JSONValue] = [:]
+        if let model, !model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            params["model"] = .string(model)
+        }
+        let json = try await request(method: "git/generateCommitMessage", params: params)
+        return GitGeneratedCommitMessageResult(from: json)
+    }
+
     func push() async throws -> GitPushResult {
         let json = try await request(method: "git/push")
         let result = GitPushResult(from: json)
@@ -200,6 +209,21 @@ final class GitActionsService {
     func remoteUrl() async throws -> GitRemoteUrlResult {
         let json = try await request(method: "git/remoteUrl")
         return GitRemoteUrlResult(from: json)
+    }
+
+    func generatePullRequestDraft(
+        model: String?,
+        baseBranch: String?
+    ) async throws -> GitPullRequestDraftResult {
+        var params: [String: JSONValue] = [:]
+        if let model, !model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            params["model"] = .string(model)
+        }
+        if let baseBranch, !baseBranch.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            params["baseBranch"] = .string(baseBranch)
+        }
+        let json = try await request(method: "git/generatePullRequestDraft", params: params)
+        return GitPullRequestDraftResult(from: json)
     }
 
     func branchesWithStatus() async throws -> GitBranchesWithStatusResult {

--- a/CodexMobile/CodexMobile/Views/SettingsView.swift
+++ b/CodexMobile/CodexMobile/Views/SettingsView.swift
@@ -131,6 +131,27 @@ struct SettingsView: View {
                 .labelsHidden()
                 .tint(settingsAccentColor)
             }
+
+            Divider()
+
+            HStack {
+                Text("Git writer model")
+                Spacer()
+                Picker("Git writer model", selection: gitWriterModelSelection) {
+                    ForEach(gitWriterModelOptions, id: \.id) { model in
+                        Text(TurnComposerMetaMapper.modelTitle(for: model))
+                            .tag(model.id)
+                    }
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+                .tint(settingsAccentColor)
+                .disabled(gitWriterModelOptions.isEmpty)
+            }
+
+            Text("Used for AI-generated commit messages and PR drafts. Defaults to GPT-5.4 Mini when available.")
+                .font(AppFont.caption())
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -296,6 +317,17 @@ struct SettingsView: View {
                     selection == runtimeNormalValue ? nil : CodexServiceTier(rawValue: selection)
                 )
             }
+        )
+    }
+
+    private var gitWriterModelOptions: [CodexModelOption] {
+        TurnComposerMetaMapper.orderedModels(from: codex.availableModels)
+    }
+
+    private var gitWriterModelSelection: Binding<String> {
+        Binding(
+            get: { codex.selectedGitWriterModelOption()?.id ?? gitWriterModelOptions.first?.id ?? "" },
+            set: { codex.setSelectedGitWriterModelId($0.isEmpty ? nil : $0) }
         )
     }
 

--- a/CodexMobile/CodexMobile/Views/Turn/TurnViewModel.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnViewModel.swift
@@ -2098,6 +2098,7 @@ final class TurnViewModel {
             defer { self.runningGitAction = nil }
 
             let gitService = GitActionsService(codex: codex, workingDirectory: workingDirectory)
+            let gitWriterModel = codex.gitWriterModelIdentifier()
 
             do {
                 switch action {
@@ -2120,7 +2121,8 @@ final class TurnViewModel {
                     }
 
                 case .commit:
-                    let result = try await gitService.commit(message: nil)
+                    let draft = try await gitService.generateCommitMessage(model: gitWriterModel)
+                    let result = try await gitService.commit(message: draft.fullMessage)
                     let statusAfter = try? await gitService.status()
                     if let statusAfter { applyGitRepoSync(statusAfter) }
                     _ = result // commit succeeded
@@ -2135,7 +2137,8 @@ final class TurnViewModel {
                     )
 
                 case .commitAndPush:
-                    _ = try await gitService.commit(message: nil)
+                    let draft = try await gitService.generateCommitMessage(model: gitWriterModel)
+                    _ = try await gitService.commit(message: draft.fullMessage)
                     let pushResult = try await gitService.push()
                     handleSuccessfulPush(
                         pushResult,
@@ -2163,7 +2166,17 @@ final class TurnViewModel {
                             message: "Could not determine the repository default branch."
                         )
                     }
-                    let prURL = buildPRURL(ownerRepo: ownerRepo, branch: branch, base: base)
+                    let draft = try await gitService.generatePullRequestDraft(
+                        model: gitWriterModel,
+                        baseBranch: base
+                    )
+                    let prURL = remodexBuildPullRequestURL(
+                        ownerRepo: ownerRepo,
+                        branch: branch,
+                        base: base,
+                        title: draft.title,
+                        body: draft.body
+                    )
                     if let url = URL(string: prURL) {
                         await UIApplication.shared.open(url)
                     }
@@ -2219,8 +2232,10 @@ final class TurnViewModel {
             }
 
             let gitService = GitActionsService(codex: codex, workingDirectory: workingDirectory)
+            let gitWriterModel = codex.gitWriterModelIdentifier()
             do {
-                _ = try await gitService.commit(message: nil)
+                let draft = try await gitService.generateCommitMessage(model: gitWriterModel)
+                _ = try await gitService.commit(message: draft.fullMessage)
                 inlineCommitAndPushPhase = .pushing
                 let pushResult = try await gitService.push()
                 handleSuccessfulPush(
@@ -2255,11 +2270,31 @@ final class TurnViewModel {
         return try await gitService.remoteUrl()
     }
 
-    private func buildPRURL(ownerRepo: String, branch: String, base: String) -> String {
-        let encodedBranch = branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch
-        let encodedBase = base.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? base
-        return "https://github.com/\(ownerRepo)/compare/\(encodedBase)...\(encodedBranch)?expand=1"
+}
+
+func remodexBuildPullRequestURL(
+    ownerRepo: String,
+    branch: String,
+    base: String,
+    title: String,
+    body: String
+) -> String {
+    let encodedBranch = branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch
+    let encodedBase = base.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? base
+    var components = URLComponents(
+        string: "https://github.com/\(ownerRepo)/compare/\(encodedBase)...\(encodedBranch)"
+    )
+    components?.queryItems = [
+        URLQueryItem(name: "quick_pull", value: "1"),
+        URLQueryItem(name: "title", value: title),
+        URLQueryItem(name: "body", value: body),
+    ]
+    guard let urlString = components?.url?.absoluteString else {
+        let encodedTitle = title.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let encodedBody = body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        return "https://github.com/\(ownerRepo)/compare/\(encodedBase)...\(encodedBranch)?quick_pull=1&title=\(encodedTitle)&body=\(encodedBody)"
     }
+    return urlString
 }
 
 struct TurnComposerMentionedFile: Identifiable, Equatable {

--- a/CodexMobile/CodexMobileTests/CodexGitWriterModelTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexGitWriterModelTests.swift
@@ -1,0 +1,80 @@
+// FILE: CodexGitWriterModelTests.swift
+// Purpose: Verifies Git writer model fallback and persistence stay independent from runtime chat defaults.
+// Layer: Unit Test
+// Exports: CodexGitWriterModelTests
+// Depends on: XCTest, CodexMobile
+
+import XCTest
+@testable import CodexMobile
+
+@MainActor
+final class CodexGitWriterModelTests: XCTestCase {
+    private static var retainedServices: [CodexService] = []
+
+    func testGitWriterModelDefaultsToGPT54MiniWhenAvailable() {
+        let service = makeService()
+        service.availableModels = [
+            makeModel(id: "gpt-5.4", isDefault: true),
+            makeModel(id: "gpt-5.4-mini"),
+        ]
+
+        XCTAssertEqual(service.selectedGitWriterModelOption()?.model, "gpt-5.4-mini")
+        XCTAssertEqual(service.gitWriterModelIdentifier(), "gpt-5.4-mini")
+    }
+
+    func testGitWriterModelFallsBackToRuntimeSelectionWhenMiniUnavailable() {
+        let service = makeService()
+        service.availableModels = [
+            makeModel(id: "gpt-5.4", isDefault: true),
+            makeModel(id: "gpt-5.3"),
+        ]
+        service.setSelectedModelId("gpt-5.3")
+
+        XCTAssertEqual(service.selectedGitWriterModelOption()?.model, "gpt-5.3")
+    }
+
+    func testGitWriterModelPreferencePersistsSeparatelyFromRuntimeModel() {
+        let suiteName = "CodexGitWriterModelTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let firstService = CodexService(defaults: defaults)
+        Self.retainedServices.append(firstService)
+        firstService.availableModels = [
+            makeModel(id: "gpt-5.4", isDefault: true),
+            makeModel(id: "gpt-5.4-mini"),
+        ]
+        firstService.setSelectedModelId("gpt-5.4")
+        firstService.setSelectedGitWriterModelId("gpt-5.4-mini")
+
+        let secondService = CodexService(defaults: defaults)
+        Self.retainedServices.append(secondService)
+        secondService.availableModels = firstService.availableModels
+
+        XCTAssertEqual(secondService.selectedModelOption()?.model, "gpt-5.4")
+        XCTAssertEqual(secondService.selectedGitWriterModelOption()?.model, "gpt-5.4-mini")
+    }
+
+    private func makeService() -> CodexService {
+        let suiteName = "CodexGitWriterModelTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+        let service = CodexService(defaults: defaults)
+        Self.retainedServices.append(service)
+        return service
+    }
+
+    private func makeModel(id: String, isDefault: Bool = false) -> CodexModelOption {
+        CodexModelOption(
+            id: id,
+            model: id,
+            displayName: id.uppercased(),
+            description: "Test model",
+            isDefault: isDefault,
+            supportedReasoningEfforts: [
+                CodexReasoningEffortOption(reasoningEffort: "medium", description: "Medium"),
+            ],
+            defaultReasoningEffort: "medium"
+        )
+    }
+}

--- a/CodexMobile/CodexMobileTests/TurnGitDraftFlowTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnGitDraftFlowTests.swift
@@ -1,0 +1,133 @@
+// FILE: TurnGitDraftFlowTests.swift
+// Purpose: Verifies git draft generation is used before commit and PR URLs include GitHub prefill params.
+// Layer: Unit Test
+// Exports: TurnGitDraftFlowTests
+// Depends on: XCTest, CodexMobile
+
+import XCTest
+@testable import CodexMobile
+
+@MainActor
+final class TurnGitDraftFlowTests: XCTestCase {
+    private static var retainedServices: [CodexService] = []
+
+    func testCommitActionGeneratesDraftBeforeCommitting() async throws {
+        let service = makeService()
+        service.availableModels = [
+            makeModel(id: "gpt-5.4-mini"),
+        ]
+
+        var recordedMethods: [String] = []
+        var committedMessage: String?
+        let commitExpectation = expectation(description: "Commit flow completes")
+        service.requestTransportOverride = { method, params in
+            recordedMethods.append(method)
+            if method == "git/commit" {
+                committedMessage = params?.objectValue?["message"]?.stringValue
+                commitExpectation.fulfill()
+            }
+
+            switch method {
+            case "git/generateCommitMessage":
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([
+                        "subject": .string("Update git flow"),
+                        "body": .string("- Draft a commit message before committing\n- Refresh status after the commit"),
+                        "fullMessage": .string("Update git flow\n\n- Draft a commit message before committing\n- Refresh status after the commit"),
+                    ]),
+                    includeJSONRPC: false
+                )
+            case "git/commit":
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([
+                        "hash": .string("abc123"),
+                        "branch": .string("remodex/topic"),
+                        "summary": .string("1 file changed"),
+                    ]),
+                    includeJSONRPC: false
+                )
+            case "git/status":
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([
+                        "branch": .string("remodex/topic"),
+                        "tracking": .string("origin/remodex/topic"),
+                        "dirty": .bool(false),
+                        "ahead": .integer(0),
+                        "behind": .integer(0),
+                        "localOnlyCommitCount": .integer(0),
+                        "state": .string("up_to_date"),
+                        "canPush": .bool(false),
+                        "publishedToRemote": .bool(true),
+                        "files": .array([]),
+                    ]),
+                    includeJSONRPC: false
+                )
+            default:
+                XCTFail("Unexpected method: \(method)")
+                return RPCMessage(id: .string(UUID().uuidString), result: .object([:]), includeJSONRPC: false)
+            }
+        }
+
+        let viewModel = TurnViewModel()
+        viewModel.triggerGitAction(
+            .commit,
+            codex: service,
+            workingDirectory: "/tmp/project",
+            threadID: "thread-1",
+            activeTurnID: nil
+        )
+
+        await fulfillment(of: [commitExpectation], timeout: 2.0)
+
+        XCTAssertEqual(Array(recordedMethods.prefix(2)), ["git/generateCommitMessage", "git/commit"])
+        XCTAssertEqual(
+            committedMessage,
+            "Update git flow\n\n- Draft a commit message before committing\n- Refresh status after the commit"
+        )
+    }
+
+    func testPullRequestURLIncludesGitHubPrefillQueryParameters() throws {
+        let urlString = remodexBuildPullRequestURL(
+            ownerRepo: "openai/remodex",
+            branch: "feature/topic",
+            base: "main",
+            title: "Improve local git drafts",
+            body: "## Summary\n- Add PR drafting\n\n## Testing\n- Not run\n\n## Notes\n- Uses quick pull"
+        )
+
+        let components = try XCTUnwrap(URLComponents(string: urlString), "URL should be parseable")
+
+        XCTAssertEqual(components.queryItems?.first(where: { $0.name == "quick_pull" })?.value, "1")
+        XCTAssertEqual(components.queryItems?.first(where: { $0.name == "title" })?.value, "Improve local git drafts")
+        XCTAssertEqual(
+            components.queryItems?.first(where: { $0.name == "body" })?.value,
+            "## Summary\n- Add PR drafting\n\n## Testing\n- Not run\n\n## Notes\n- Uses quick pull"
+        )
+    }
+
+    private func makeService() -> CodexService {
+        let suiteName = "TurnGitDraftFlowTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+        let service = CodexService(defaults: defaults)
+        Self.retainedServices.append(service)
+        return service
+    }
+
+    private func makeModel(id: String) -> CodexModelOption {
+        CodexModelOption(
+            id: id,
+            model: id,
+            displayName: id.uppercased(),
+            description: "Test model",
+            isDefault: true,
+            supportedReasoningEfforts: [
+                CodexReasoningEffortOption(reasoningEffort: "medium", description: "Medium"),
+            ],
+            defaultReasoningEffort: "medium"
+        )
+    }
+}

--- a/phodex-bridge/package-lock.json
+++ b/phodex-bridge/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "remodex",
       "version": "1.3.8",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "qrcode-terminal": "^0.12.0",

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -508,7 +508,9 @@ function startBridge({
     })) {
       return;
     }
-    if (handleGitRequest(rawMessage, sendApplicationResponse)) {
+    if (handleGitRequest(rawMessage, sendApplicationResponse, {
+      codexAppPath: config.codexAppPath,
+    })) {
       return;
     }
     desktopRefresher.handleInbound(rawMessage);

--- a/phodex-bridge/src/git-handler.js
+++ b/phodex-bridge/src/git-handler.js
@@ -4,7 +4,7 @@
 // Exports: handleGitRequest
 // Depends on: child_process, fs, os, path, crypto
 
-const { execFile } = require("child_process");
+const { execFile, spawn } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -13,7 +13,16 @@ const { promisify } = require("util");
 
 const execFileAsync = promisify(execFile);
 const GIT_TIMEOUT_MS = 30_000;
+const GIT_DRAFT_TIMEOUT_MS = 120_000;
 const EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+const DEFAULT_GIT_WRITER_MODEL = "gpt-5.4-mini";
+
+let runStructuredCodexJsonImpl = runStructuredCodexJson;
+
+function resolveGitWriterModel(rawModel) {
+  const trimmed = typeof rawModel === "string" ? rawModel.trim() : "";
+  return trimmed || DEFAULT_GIT_WRITER_MODEL;
+}
 
 /**
  * Intercepts git/* JSON-RPC methods and executes git commands locally.
@@ -21,7 +30,7 @@ const EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
  * @param {(response: string) => void} sendResponse - Callback to send response back
  * @returns {boolean} true if message was handled, false if it should pass through
  */
-function handleGitRequest(rawMessage, sendResponse) {
+function handleGitRequest(rawMessage, sendResponse, options = {}) {
   let parsed;
   try {
     parsed = JSON.parse(rawMessage);
@@ -37,7 +46,7 @@ function handleGitRequest(rawMessage, sendResponse) {
   const id = parsed.id;
   const params = parsed.params || {};
 
-  handleGitMethod(method, params)
+  handleGitMethod(method, params, options)
     .then((result) => {
       sendResponse(JSON.stringify({ id, result }));
     })
@@ -59,7 +68,7 @@ function handleGitRequest(rawMessage, sendResponse) {
   return true;
 }
 
-async function handleGitMethod(method, params) {
+async function handleGitMethod(method, params, options = {}) {
   const cwd = await resolveGitCwd(params);
 
   switch (method) {
@@ -69,6 +78,8 @@ async function handleGitMethod(method, params) {
       return gitDiff(cwd);
     case "git/commit":
       return gitCommit(cwd, params);
+    case "git/generateCommitMessage":
+      return gitGenerateCommitMessage(cwd, params, options);
     case "git/push":
       return gitPush(cwd);
     case "git/pull":
@@ -97,6 +108,8 @@ async function handleGitMethod(method, params) {
       return gitResetToRemote(cwd, params);
     case "git/remoteUrl":
       return gitRemoteUrl(cwd);
+    case "git/generatePullRequestDraft":
+      return gitGeneratePullRequestDraft(cwd, params, options);
     case "git/branchesWithStatus":
       return gitBranchesWithStatus(cwd);
     default:
@@ -196,6 +209,73 @@ async function gitCommit(cwd, params) {
   const summary = summaryMatch ? summaryMatch[0] : output.split("\n").pop()?.trim() || "";
 
   return { hash, branch, summary };
+}
+
+// ─── Git Draft Generation ────────────────────────────────────
+
+async function gitGenerateCommitMessage(cwd, params, options = {}) {
+  const model = resolveGitWriterModel(params.model);
+
+  try {
+    const context = await buildCommitDraftContext(cwd);
+    const prompt = buildCommitDraftPrompt(context);
+    const schema = {
+      type: "object",
+      properties: {
+        subject: { type: "string" },
+        body: { type: "string" },
+        fullMessage: { type: "string" },
+      },
+      required: ["subject", "body", "fullMessage"],
+      additionalProperties: false,
+    };
+    const draft = await runStructuredCodexJsonImpl({
+      cwd,
+      model,
+      prompt,
+      schema,
+      codexAppPath: options.codexAppPath,
+    });
+
+    return normalizeCommitDraft(draft);
+  } catch (error) {
+    if (error?.errorCode) {
+      throw error;
+    }
+    throw wrapDraftGenerationError(error, "commit");
+  }
+}
+
+async function gitGeneratePullRequestDraft(cwd, params, options = {}) {
+  const model = resolveGitWriterModel(params.model);
+
+  try {
+    const context = await buildPullRequestDraftContext(cwd, params);
+    const prompt = buildPullRequestDraftPrompt(context);
+    const schema = {
+      type: "object",
+      properties: {
+        title: { type: "string" },
+        body: { type: "string" },
+      },
+      required: ["title", "body"],
+      additionalProperties: false,
+    };
+    const draft = await runStructuredCodexJsonImpl({
+      cwd,
+      model,
+      prompt,
+      schema,
+      codexAppPath: options.codexAppPath,
+    });
+
+    return normalizePullRequestDraft(draft);
+  } catch (error) {
+    if (error?.errorCode) {
+      throw error;
+    }
+    throw wrapDraftGenerationError(error, "pull_request");
+  }
 }
 
 // ─── Git Push ─────────────────────────────────────────────────
@@ -301,6 +381,7 @@ async function gitBranches(cwd) {
     localCheckoutPath,
     current,
     default: defaultBranch,
+    defaultBranch,
   };
 }
 
@@ -765,6 +846,405 @@ async function gitRemoteUrl(cwd) {
   const raw = (await git(cwd, "config", "--get", "remote.origin.url")).trim();
   const ownerRepo = parseOwnerRepo(raw);
   return { url: raw, ownerRepo };
+}
+
+async function buildCommitDraftContext(cwd) {
+  const [statusResult, repoRoot] = await Promise.all([
+    gitStatus(cwd),
+    resolveRepoRoot(cwd).catch(() => cwd),
+  ]);
+
+  if (!statusResult.dirty) {
+    throw gitError("nothing_to_commit", "Nothing to commit.");
+  }
+
+  const trackedBase = await refExists(cwd, "HEAD") ? "HEAD" : EMPTY_TREE_HASH;
+  const trackedPatch = await git(cwd, "diff", "--binary", "--find-renames", trackedBase);
+  const untrackedPaths = statusResult.files
+    .filter((file) => file.status === "??")
+    .map((file) => file.path)
+    .filter(Boolean);
+  const untrackedPatch = await diffPatchForUntrackedFiles(cwd, untrackedPaths);
+  const patch = [trackedPatch.trim(), untrackedPatch.trim()].filter(Boolean).join("\n\n").trim();
+
+  if (!patch) {
+    throw gitError("nothing_to_commit", "Nothing to commit.");
+  }
+
+  return {
+    repoRoot,
+    branch: statusResult.branch || "HEAD",
+    files: statusResult.files,
+    diff: statusResult.diff || { additions: 0, deletions: 0, binaryFiles: 0 },
+    patch,
+  };
+}
+
+async function buildPullRequestDraftContext(cwd, params) {
+  const branchResult = await gitBranches(cwd);
+  const currentBranch = (branchResult.current || "").trim();
+  const baseBranch = resolveBaseBranchName(params.baseBranch, branchResult.default || branchResult.defaultBranch);
+
+  if (!currentBranch) {
+    throw gitError("no_branch", "No current branch found.");
+  }
+
+  if (!baseBranch) {
+    throw gitError("no_default_branch", "Could not determine the repository default branch.");
+  }
+
+  const baseRef = await resolveExistingBranchRef(cwd, baseBranch);
+  const mergeBase = (await git(cwd, "merge-base", "HEAD", baseRef)).trim();
+  const patch = (await git(cwd, "diff", "--binary", "--find-renames", `${mergeBase}..HEAD`)).trim();
+  const numstatOutput = await git(cwd, "diff", "--numstat", `${mergeBase}..HEAD`);
+  const diff = parseNumstatTotals(numstatOutput);
+  const commitList = (
+    await git(cwd, "log", "--format=%h %s", `${mergeBase}..HEAD`)
+  )
+    .trim()
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 40);
+
+  if (!patch && commitList.length === 0) {
+    throw gitError("nothing_to_compare", "No branch changes are available for a pull request.");
+  }
+
+  return {
+    repoRoot: await resolveRepoRoot(cwd).catch(() => cwd),
+    currentBranch,
+    baseBranch,
+    mergeBase,
+    diff,
+    commitList,
+    patch,
+  };
+}
+
+async function resolveExistingBranchRef(cwd, branchName) {
+  const localRef = `refs/heads/${branchName}`;
+  const remoteRef = `refs/remotes/origin/${branchName}`;
+
+  if (await refExists(cwd, localRef)) {
+    return localRef;
+  }
+  if (await refExists(cwd, remoteRef)) {
+    return remoteRef;
+  }
+
+  return branchName;
+}
+
+async function refExists(cwd, refName) {
+  try {
+    await git(cwd, "show-ref", "--verify", "--quiet", refName);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function buildCommitDraftPrompt(context) {
+  const changedFiles = context.files
+    .map((file) => `- ${file.status || "M"} ${file.path}`)
+    .join("\n");
+
+  return [
+    "Write a detailed Git commit message from the repository context below.",
+    "Return JSON only that matches the provided schema.",
+    "Rules:",
+    "- `subject` must be imperative, 72 characters or fewer, and must not end with a period.",
+    "- `body` must be non-empty and use 2 to 5 concise Markdown bullets.",
+    "- `fullMessage` must equal the final commit text: subject, blank line, then body.",
+    "- Do not mention AI, Codex, prompt instructions, or that the message was generated.",
+    "",
+    `Repository: ${context.repoRoot}`,
+    `Branch: ${context.branch}`,
+    `Diff totals: +${context.diff.additions} -${context.diff.deletions} binary=${context.diff.binaryFiles}`,
+    "Changed files:",
+    changedFiles || "- (none)",
+    "",
+    "Patch:",
+    "```diff",
+    context.patch,
+    "```",
+  ].join("\n");
+}
+
+function buildPullRequestDraftPrompt(context) {
+  const commitLines = context.commitList.length > 0 ? context.commitList.map((line) => `- ${line}`).join("\n") : "- None";
+
+  return [
+    "Write a pull request title and body from the repository context below.",
+    "Return JSON only that matches the provided schema.",
+    "Rules:",
+    "- `title` should be concise and readable on GitHub.",
+    "- `body` must be Markdown with exactly these top-level sections: `## Summary`, `## Testing`, `## Notes`.",
+    "- In `## Testing`, explicitly say when testing was not run or could not be verified. Do not invent test results.",
+    "- Keep the body specific to the actual diff and commits.",
+    "- Do not mention AI, Codex, prompt instructions, or that the text was generated.",
+    "",
+    `Repository: ${context.repoRoot}`,
+    `Base branch: ${context.baseBranch}`,
+    `Current branch: ${context.currentBranch}`,
+    `Merge base: ${context.mergeBase}`,
+    `Diff totals: +${context.diff.additions} -${context.diff.deletions} binary=${context.diff.binaryFiles}`,
+    "Commits since base:",
+    commitLines,
+    "",
+    "Patch:",
+    "```diff",
+    context.patch,
+    "```",
+  ].join("\n");
+}
+
+function normalizeCommitDraft(draft) {
+  const subject = normalizeCommitSubject(draft?.subject);
+  const body = normalizeNonEmptyMultilineString(draft?.body);
+
+  if (!subject || !body) {
+    throw new Error("Commit draft was missing a valid subject or body.");
+  }
+
+  const fullMessage = `${subject}\n\n${body}`;
+  return { subject, body, fullMessage };
+}
+
+function normalizePullRequestDraft(draft) {
+  const title = normalizeNonEmptyLine(draft?.title);
+  const body = normalizeNonEmptyMultilineString(draft?.body);
+
+  if (!title || !body) {
+    throw new Error("Pull request draft was missing a valid title or body.");
+  }
+
+  const requiredHeadings = ["## Summary", "## Testing", "## Notes"];
+  if (!requiredHeadings.every((heading) => body.includes(heading))) {
+    throw new Error("Pull request draft body was missing one or more required sections.");
+  }
+
+  return { title, body };
+}
+
+function normalizeCommitSubject(rawValue) {
+  const trimmed = normalizeNonEmptyLine(rawValue);
+  if (!trimmed) {
+    return "";
+  }
+
+  const withoutTrailingPeriod = trimmed.replace(/\.+$/, "");
+  if (!withoutTrailingPeriod || withoutTrailingPeriod.length > 72) {
+    return "";
+  }
+
+  return withoutTrailingPeriod;
+}
+
+function normalizeNonEmptyLine(rawValue) {
+  if (typeof rawValue !== "string") {
+    return "";
+  }
+
+  return rawValue
+    .split("\n")[0]
+    .trim();
+}
+
+function normalizeNonEmptyMultilineString(rawValue) {
+  if (typeof rawValue !== "string") {
+    return "";
+  }
+
+  const trimmed = rawValue.trim();
+  return trimmed || "";
+}
+
+function wrapDraftGenerationError(error, kind) {
+  const detail = normalizeDraftErrorDetail(error);
+  if (kind === "commit") {
+    return gitError(
+      "commit_message_generation_failed",
+      detail ? `Could not generate a commit message. ${detail}` : "Could not generate a commit message."
+    );
+  }
+
+  return gitError(
+    "pull_request_draft_generation_failed",
+    detail ? `Could not generate a pull request draft. ${detail}` : "Could not generate a pull request draft."
+  );
+}
+
+function normalizeDraftErrorDetail(error) {
+  const rawMessage = typeof error?.userMessage === "string"
+    ? error.userMessage
+    : typeof error?.message === "string"
+      ? error.message
+      : "";
+  const trimmed = rawMessage.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const singleLine = trimmed.split("\n").map((line) => line.trim()).filter(Boolean).pop() || trimmed;
+  return singleLine.endsWith(".") ? singleLine : `${singleLine}.`;
+}
+
+async function runStructuredCodexJson({ cwd, model, prompt, schema, codexAppPath }) {
+  const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-git-ai-"));
+  const schemaPath = path.join(tempDirectory, "schema.json");
+  const outputPath = path.join(tempDirectory, "output.json");
+  const commands = resolveCodexExecCommands(codexAppPath);
+
+  fs.writeFileSync(schemaPath, JSON.stringify(schema), "utf8");
+
+  try {
+    let lastError = null;
+
+    for (const command of commands) {
+      try {
+        return await spawnCodexExecJson({
+          command,
+          cwd,
+          model,
+          prompt,
+          schemaPath,
+          outputPath,
+        });
+      } catch (error) {
+        lastError = error;
+        if (!shouldRetryCodexExecWithNextCommand(error)) {
+          throw error;
+        }
+      }
+    }
+
+    throw lastError || new Error("Codex CLI is not available on this Mac.");
+  } finally {
+    fs.rmSync(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+function resolveCodexExecCommands(codexAppPath) {
+  const commands = ["codex"];
+  const bundledCommand = resolveBundledCodexCommand(codexAppPath);
+  if (bundledCommand && !commands.includes(bundledCommand)) {
+    commands.push(bundledCommand);
+  }
+  return commands;
+}
+
+function resolveBundledCodexCommand(codexAppPath) {
+  const trimmedAppPath = typeof codexAppPath === "string" ? codexAppPath.trim() : "";
+  if (!trimmedAppPath) {
+    return "";
+  }
+
+  const candidate = path.join(trimmedAppPath, "Contents", "Resources", "codex");
+  return isLaunchableFile(candidate) ? candidate : "";
+}
+
+function isLaunchableFile(candidatePath) {
+  try {
+    return fs.statSync(candidatePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function shouldRetryCodexExecWithNextCommand(error) {
+  return error?.code === "ENOENT";
+}
+
+function spawnCodexExecJson({ command, cwd, model, prompt, schemaPath, outputPath }) {
+  const args = [
+    "exec",
+    "--ephemeral",
+    "-C",
+    cwd,
+    "-m",
+    model,
+    "--output-schema",
+    schemaPath,
+    "-o",
+    outputPath,
+    "-",
+  ];
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: process.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, GIT_DRAFT_TIMEOUT_MS);
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+
+    child.on("close", (code, signal) => {
+      clearTimeout(timeout);
+
+      if (timedOut) {
+        reject(new Error("Codex CLI timed out while generating the draft."));
+        return;
+      }
+
+      if (code !== 0) {
+        reject(createCodexExecFailure(code, signal, stdout, stderr));
+        return;
+      }
+
+      try {
+        const outputText = fs.readFileSync(outputPath, "utf8").trim();
+        if (!outputText) {
+          throw new Error("Codex CLI returned an empty structured response.");
+        }
+        resolve(JSON.parse(outputText));
+      } catch (error) {
+        reject(error);
+      }
+    });
+
+    child.stdin.end(prompt);
+  });
+}
+
+function createCodexExecFailure(code, signal, stdout, stderr) {
+  const detail = [stderr, stdout]
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .flatMap((value) => value.split("\n"))
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .pop();
+
+  const suffix = detail ? ` ${detail}` : "";
+  const error = new Error(
+    signal
+      ? `Codex CLI was interrupted while generating the draft.${suffix}`
+      : `Codex CLI exited with code ${code} while generating the draft.${suffix}`
+  );
+  error.code = code;
+  error.signal = signal;
+  return error;
 }
 
 function parseOwnerRepo(remoteUrl) {
@@ -1518,6 +1998,8 @@ module.exports = {
   handleGitRequest,
   gitStatus,
   __test: {
+    gitGenerateCommitMessage,
+    gitGeneratePullRequestDraft,
     gitBranches,
     gitCreateBranch,
     gitCreateWorktree,
@@ -1536,5 +2018,11 @@ module.exports = {
     scopedLocalCheckoutPath,
     scopedWorktreePath,
     resolveBaseBranchName,
+    setRunStructuredCodexJsonImplementation(fn) {
+      runStructuredCodexJsonImpl = typeof fn === "function" ? fn : runStructuredCodexJson;
+    },
+    resetRunStructuredCodexJsonImplementation() {
+      runStructuredCodexJsonImpl = runStructuredCodexJson;
+    },
   },
 };

--- a/phodex-bridge/test/git-handler.test.js
+++ b/phodex-bridge/test/git-handler.test.js
@@ -13,6 +13,10 @@ const { execFileSync } = require("node:child_process");
 
 const { __test, gitStatus } = require("../src/git-handler");
 
+test.afterEach(() => {
+  __test.resetRunStructuredCodexJsonImplementation();
+});
+
 function git(cwd, ...args) {
   return execFileSync("git", args, {
     cwd,
@@ -397,6 +401,126 @@ test("gitStatus marks a branch as published when origin has it even without loca
   } finally {
     fs.rmSync(repoDir, { recursive: true, force: true });
     fs.rmSync(remoteDir, { recursive: true, force: true });
+  }
+});
+
+test("gitGenerateCommitMessage forwards the selected model and includes tracked plus untracked changes", async () => {
+  const repoDir = makeTempRepo();
+  let capturedInvocation = null;
+
+  try {
+    fs.writeFileSync(path.join(repoDir, "README.md"), "# Test\n\nupdated\n");
+    fs.writeFileSync(path.join(repoDir, "new-file.txt"), "hello from untracked\n");
+
+    __test.setRunStructuredCodexJsonImplementation(async (payload) => {
+      capturedInvocation = payload;
+      return {
+        subject: "Update repository docs",
+        body: "- Refresh the README content\n- Add a new untracked file for the workflow",
+        fullMessage: "ignored by normalization",
+      };
+    });
+
+    const result = await __test.gitGenerateCommitMessage(repoDir, { model: "gpt-5.4-mini" });
+
+    assert.equal(result.subject, "Update repository docs");
+    assert.equal(
+      result.fullMessage,
+      "Update repository docs\n\n- Refresh the README content\n- Add a new untracked file for the workflow"
+    );
+    assert.equal(capturedInvocation?.model, "gpt-5.4-mini");
+    assert.equal(capturedInvocation?.cwd, repoDir);
+    assert.match(capturedInvocation?.prompt || "", /README\.md/);
+    assert.match(capturedInvocation?.prompt || "", /new-file\.txt/);
+    assert.match(capturedInvocation?.prompt || "", /updated/);
+    assert.match(capturedInvocation?.prompt || "", /hello from untracked/);
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+test("gitGeneratePullRequestDraft summarizes branch changes against the default branch", async () => {
+  const repoDir = makeTempRepo();
+  const remoteDir = makeBareRemote();
+  let capturedInvocation = null;
+
+  try {
+    git(remoteDir, "init", "--bare");
+    git(repoDir, "remote", "add", "origin", remoteDir);
+    git(repoDir, "push", "-u", "origin", "main");
+    git(repoDir, "checkout", "-b", "remodex/pr-draft");
+    fs.writeFileSync(path.join(repoDir, "README.md"), "# Test\n\nbranch change\n");
+    git(repoDir, "add", "README.md");
+    git(repoDir, "commit", "-m", "Update readme on branch");
+
+    __test.setRunStructuredCodexJsonImplementation(async (payload) => {
+      capturedInvocation = payload;
+      return {
+        title: "Improve README branch summary",
+        body: "## Summary\n- Update the README content for the branch\n\n## Testing\n- Not run (not requested)\n\n## Notes\n- Keeps the change scoped to documentation",
+      };
+    });
+
+    const result = await __test.gitGeneratePullRequestDraft(repoDir, { model: "gpt-5.4-mini", baseBranch: "main" });
+
+    assert.equal(result.title, "Improve README branch summary");
+    assert.match(capturedInvocation?.prompt || "", /Base branch: main/);
+    assert.match(capturedInvocation?.prompt || "", /Current branch: remodex\/pr-draft/);
+    assert.match(capturedInvocation?.prompt || "", /Update readme on branch/);
+    assert.match(capturedInvocation?.prompt || "", /branch change/);
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+    fs.rmSync(remoteDir, { recursive: true, force: true });
+  }
+});
+
+test("gitGenerateCommitMessage surfaces generation failures without falling back to a default message", async () => {
+  const repoDir = makeTempRepo();
+
+  try {
+    fs.writeFileSync(path.join(repoDir, "README.md"), "# Test\n\nupdated\n");
+
+    __test.setRunStructuredCodexJsonImplementation(async () => {
+      throw new Error("Auth failed");
+    });
+
+    await assert.rejects(
+      __test.gitGenerateCommitMessage(repoDir, { model: "gpt-5.4-mini" }),
+      (error) =>
+        error?.errorCode === "commit_message_generation_failed"
+          && error?.userMessage === "Could not generate a commit message. Auth failed."
+    );
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+test("gitGenerateCommitMessage supports repositories without an initial commit", async () => {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-git-handler-unborn-"));
+  let capturedInvocation = null;
+
+  try {
+    git(repoDir, "init", "-b", "main");
+    git(repoDir, "config", "user.name", "Remodex Tests");
+    git(repoDir, "config", "user.email", "tests@example.com");
+    fs.writeFileSync(path.join(repoDir, "README.md"), "# First commit\n");
+
+    __test.setRunStructuredCodexJsonImplementation(async (payload) => {
+      capturedInvocation = payload;
+      return {
+        subject: "Create initial project files",
+        body: "- Add the first tracked project file\n- Prepare the repository for its initial commit",
+        fullMessage: "ignored by normalization",
+      };
+    });
+
+    const result = await __test.gitGenerateCommitMessage(repoDir, { model: "gpt-5.4-mini" });
+
+    assert.equal(result.subject, "Create initial project files");
+    assert.match(capturedInvocation?.prompt || "", /README\.md/);
+    assert.match(capturedInvocation?.prompt || "", /First commit/);
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## What Changed

* Added local AI-generated Git commit message drafting in the bridge
* Added local AI-generated pull request draft generation with GitHub prefill support
* Wired the iOS app to use generated commit messages for commit and commit-and-push flows
* Added a dedicated Git writer model setting in the app
* Added bridge and iOS tests covering model selection and draft-generation flows

## Why

Writing commit messages and PR descriptions manually adds friction to the local Git flow, especially on mobile.

This change lets remodex generate structured commit messages and PR drafts from the actual repo diff, while keeping everything local-first through the existing bridge workflow.

It also separates the model used for Git writing from the normal chat/runtime model so users can choose a faster or cheaper model for commit and PR drafting without affecting the rest of the app.

## UI Changes

Yes

* Added a new **Git writer model** setting in Settings
* Commit / commit-and-push flows now use generated commit messages automatically
* PR creation now opens GitHub with generated title and body prefilled
<table>
  <tr>
    <td align="center" width="45%">
      <img src="https://github.com/user-attachments/assets/def9c9ce-92e3-4364-b08b-2e7565f9b0a5" alt="Generated PR draft flow" width="100%" />
    </td>
    <td align="center" width="45%">
      <img src="https://github.com/user-attachments/assets/0cbbdd88-eedf-4e6c-8fb4-8fac5a74a90d" alt="Git writer model setting" width="70%" />
    </td>
  </tr>
</table>


## Checklist

* [x] This PR is small and focused
* [x] I explained what changed and why
* [x] UI changes included
* [x] UI Images included
* [ ] Video included
