### PR TITLE
Add full-width navigation swipe handling

### DIFF
--- a/CodexMobile/CodexMobile.xcodeproj/project.pbxproj
+++ b/CodexMobile/CodexMobile.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1BF7B512D49503A3C3290F00 /* BridgeMenuBarStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1FC345ADD350213550F36C /* BridgeMenuBarStore.swift */; };
 		22B3C4D5E6F708192A3B4C5D /* CodexFuzzyFileSearchDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B3C4D5E6F708192A3B4C5E /* CodexFuzzyFileSearchDecodeTests.swift */; };
 		2A6D4B8C1E3F507192A4B6C8 /* CodexStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A6D4B8C1E3F507192A4B6C9 /* CodexStatusTests.swift */; };
+		2F6A8C1E3D4B5F709182A3C4 /* RootNavigationSwipePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6A8C1E3D4B5F709182A3C5 /* RootNavigationSwipePolicyTests.swift */; };
 		3C6D5E4F7A8B9C0D1E2F3A4B /* ContentNavigationSwipePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6D5E4F7A8B9C0D1E2F3A4C /* ContentNavigationSwipePolicyTests.swift */; };
 		45ECA26015C46B1F63E84A73 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A932BE773A84EFEA525DF684 /* Assets.xcassets */; };
 		4C0F0D55A5051D8301463C69 /* TurnComposerSendAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BE370810CFD7A76DC2A25F /* TurnComposerSendAvailabilityTests.swift */; };
@@ -73,6 +74,7 @@
 		11A2B3C4D5E6F708192A3B4D /* TurnFileAutocompleteTokenTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TurnFileAutocompleteTokenTests.swift; sourceTree = "<group>"; };
 		22B3C4D5E6F708192A3B4C5E /* CodexFuzzyFileSearchDecodeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodexFuzzyFileSearchDecodeTests.swift; sourceTree = "<group>"; };
 		2A6D4B8C1E3F507192A4B6C9 /* CodexStatusTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodexStatusTests.swift; sourceTree = "<group>"; };
+		2F6A8C1E3D4B5F709182A3C5 /* RootNavigationSwipePolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RootNavigationSwipePolicyTests.swift; sourceTree = "<group>"; };
 		3C6D5E4F7A8B9C0D1E2F3A4C /* ContentNavigationSwipePolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentNavigationSwipePolicyTests.swift; sourceTree = "<group>"; };
 		357D589B8C179934A884F8CC /* BridgeControlService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BridgeControlService.swift; sourceTree = "<group>"; };
 		3A1FC345ADD350213550F36C /* BridgeMenuBarStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BridgeMenuBarStore.swift; sourceTree = "<group>"; };
@@ -174,6 +176,7 @@
 				A2B3C4D5E6F708192A3B4C7 /* CodexServiceThreadListTests.swift */,
 				E1A2B3C4D5E6F708192A3B4D /* QRScannerPairingValidatorTests.swift */,
 				2A6D4B8C1E3F507192A4B6C9 /* CodexStatusTests.swift */,
+				2F6A8C1E3D4B5F709182A3C5 /* RootNavigationSwipePolicyTests.swift */,
 				3C6D5E4F7A8B9C0D1E2F3A4C /* ContentNavigationSwipePolicyTests.swift */,
 				6F8E129A7BC34A12D45E6F71 /* CodexThreadStartProjectBindingTests.swift */,
 				F1B2C3D4E5F60718293A4B11 /* CodexGPTAccountTests.swift */,
@@ -484,6 +487,7 @@
 				A2B3C4D5E6F708192A3B4C6 /* CodexServiceThreadListTests.swift in Sources */,
 				E1A2B3C4D5E6F708192A3B4C /* QRScannerPairingValidatorTests.swift in Sources */,
 				2A6D4B8C1E3F507192A4B6C8 /* CodexStatusTests.swift in Sources */,
+				2F6A8C1E3D4B5F709182A3C4 /* RootNavigationSwipePolicyTests.swift in Sources */,
 				3C6D5E4F7A8B9C0D1E2F3A4B /* ContentNavigationSwipePolicyTests.swift in Sources */,
 				6F8E129A7BC34A12D45E6F70 /* CodexThreadStartProjectBindingTests.swift in Sources */,
 				F1B2C3D4E5F60718293A4B10 /* CodexGPTAccountTests.swift in Sources */,

--- a/CodexMobile/CodexMobile.xcodeproj/project.pbxproj
+++ b/CodexMobile/CodexMobile.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1BF7B512D49503A3C3290F00 /* BridgeMenuBarStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1FC345ADD350213550F36C /* BridgeMenuBarStore.swift */; };
 		22B3C4D5E6F708192A3B4C5D /* CodexFuzzyFileSearchDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B3C4D5E6F708192A3B4C5E /* CodexFuzzyFileSearchDecodeTests.swift */; };
 		2A6D4B8C1E3F507192A4B6C8 /* CodexStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A6D4B8C1E3F507192A4B6C9 /* CodexStatusTests.swift */; };
+		3C6D5E4F7A8B9C0D1E2F3A4B /* ContentNavigationSwipePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6D5E4F7A8B9C0D1E2F3A4C /* ContentNavigationSwipePolicyTests.swift */; };
 		45ECA26015C46B1F63E84A73 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A932BE773A84EFEA525DF684 /* Assets.xcassets */; };
 		4C0F0D55A5051D8301463C69 /* TurnComposerSendAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BE370810CFD7A76DC2A25F /* TurnComposerSendAvailabilityTests.swift */; };
 		4CCE0926DAD312571934343A /* TurnTimelineReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EEB36EBEA2A475AC9B30B1F /* TurnTimelineReducerTests.swift */; };
@@ -72,6 +73,7 @@
 		11A2B3C4D5E6F708192A3B4D /* TurnFileAutocompleteTokenTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TurnFileAutocompleteTokenTests.swift; sourceTree = "<group>"; };
 		22B3C4D5E6F708192A3B4C5E /* CodexFuzzyFileSearchDecodeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodexFuzzyFileSearchDecodeTests.swift; sourceTree = "<group>"; };
 		2A6D4B8C1E3F507192A4B6C9 /* CodexStatusTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodexStatusTests.swift; sourceTree = "<group>"; };
+		3C6D5E4F7A8B9C0D1E2F3A4C /* ContentNavigationSwipePolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentNavigationSwipePolicyTests.swift; sourceTree = "<group>"; };
 		357D589B8C179934A884F8CC /* BridgeControlService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BridgeControlService.swift; sourceTree = "<group>"; };
 		3A1FC345ADD350213550F36C /* BridgeMenuBarStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BridgeMenuBarStore.swift; sourceTree = "<group>"; };
 		3B1A9C7D5E4F60718293A4B5 /* BuildSupport/Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = BuildSupport/Base.xcconfig; sourceTree = SOURCE_ROOT; };
@@ -172,6 +174,7 @@
 				A2B3C4D5E6F708192A3B4C7 /* CodexServiceThreadListTests.swift */,
 				E1A2B3C4D5E6F708192A3B4D /* QRScannerPairingValidatorTests.swift */,
 				2A6D4B8C1E3F507192A4B6C9 /* CodexStatusTests.swift */,
+				3C6D5E4F7A8B9C0D1E2F3A4C /* ContentNavigationSwipePolicyTests.swift */,
 				6F8E129A7BC34A12D45E6F71 /* CodexThreadStartProjectBindingTests.swift */,
 				F1B2C3D4E5F60718293A4B11 /* CodexGPTAccountTests.swift */,
 				7A1B2C3D4E5F60718293A4B6 /* CodexThreadRuntimeOverrideTests.swift */,
@@ -481,6 +484,7 @@
 				A2B3C4D5E6F708192A3B4C6 /* CodexServiceThreadListTests.swift in Sources */,
 				E1A2B3C4D5E6F708192A3B4C /* QRScannerPairingValidatorTests.swift in Sources */,
 				2A6D4B8C1E3F507192A4B6C8 /* CodexStatusTests.swift in Sources */,
+				3C6D5E4F7A8B9C0D1E2F3A4B /* ContentNavigationSwipePolicyTests.swift in Sources */,
 				6F8E129A7BC34A12D45E6F70 /* CodexThreadStartProjectBindingTests.swift in Sources */,
 				F1B2C3D4E5F60718293A4B10 /* CodexGPTAccountTests.swift in Sources */,
 				7A1B2C3D4E5F60718293A4B5 /* CodexThreadRuntimeOverrideTests.swift in Sources */,

--- a/CodexMobile/CodexMobile/ContentView.swift
+++ b/CodexMobile/CodexMobile/ContentView.swift
@@ -58,6 +58,7 @@ struct ContentView: View {
     @State private var sidebarGestureAutoCommitted = false
     @State private var sidebarSelectionSuppressedUntil: Date?
     @State private var isOpeningNewChatFromSidebar = false
+    @State private var areSidebarInteractionsSuppressed = false
     @AppStorage("codex.hasSeenOnboarding") private var hasSeenOnboarding = false
     @AppStorage("codex.whatsNew.lastPresentedVersion") private var lastPresentedWhatsNewVersion = ""
 
@@ -350,6 +351,7 @@ struct ContentView: View {
                         selectedThread: $selectedThread,
                         showSettings: $showSettings,
                         isSearchActive: $isSearchActive,
+                        interactionsEnabled: !areSidebarInteractionsSuppressed,
                         showsInlineCloseButton: shouldUseFullWidthSidebar,
                         isVisible: sidebarVisible,
                         onClose: { closeSidebar() },
@@ -665,7 +667,7 @@ struct ContentView: View {
                 sidebarGestureAutoCommitted = true
                 debugSidebarLog(
                     "gesture #\(activeSidebarGestureDebugID ?? 0) auto-commit kind=\(action.debugKind) "
-                        + "translation=\(Int(translation)) commit=\(Int(sidebarSwipeCommitDistance))"
+                        + "translation=\(Int(translation)) commit=\(Int(sidebarSwipeCommitDistance)) source=root"
                 )
                 finishGesture(action)
             }
@@ -677,7 +679,7 @@ struct ContentView: View {
 
                 guard let action = navigationSwipeAction(for: value) else {
                     if activeSidebarGestureDebugID != nil {
-                        debugSidebarLog("gesture cancelled before commit")
+                        debugSidebarLog("gesture cancelled before commit source=root")
                     }
                     sidebarDragOffset = 0
                     sidebarGestureAutoCommitted = false
@@ -701,7 +703,7 @@ struct ContentView: View {
                 debugSidebarLog(
                     "gesture #\(activeSidebarGestureDebugID ?? 0) end kind=\(action.debugKind) "
                         + "translation=\(Int(translation)) predicted=\(Int(predictedTranslation)) "
-                        + "commit=\(Int(sidebarSwipeCommitDistance)) decision=cancel"
+                        + "commit=\(Int(sidebarSwipeCommitDistance)) decision=cancel source=root"
                 )
                 sidebarDragOffset = 0
                 resetSidebarGestureDebug()
@@ -740,9 +742,7 @@ struct ContentView: View {
                     return
                 }
 
-                guard let action = sidebarCloseSwipeAction(for: value) else {
-                    return
-                }
+                guard let action = sidebarCloseSwipeAction(for: value) else { return }
 
                 let translation = RootNavigationSwipePolicy.progressTranslation(
                     for: action,
@@ -894,6 +894,7 @@ struct ContentView: View {
         case .openSidebar:
             setSidebar(open: true)
         case .closeSidebar:
+            areSidebarInteractionsSuppressed = true
             setSidebar(open: false)
         case .navigateBack:
             dismissActiveKeyboard()
@@ -913,7 +914,9 @@ struct ContentView: View {
             "setSidebar open=\(open) prewarmed=\(isSidebarPrewarmed) "
                 + "visible=\(sidebarVisible) revealWidth=\(Int(sidebarRevealWidth))"
         )
-        if !open {
+        if open {
+            areSidebarInteractionsSuppressed = false
+        } else {
             isSearchActive = false
         }
         dismissActiveKeyboard()

--- a/CodexMobile/CodexMobile/ContentView.swift
+++ b/CodexMobile/CodexMobile/ContentView.swift
@@ -362,6 +362,7 @@ struct ContentView: View {
                     )
                     .frame(width: currentSidebarWidth)
                     .animation(.easeInOut(duration: 0.25), value: shouldUseFullWidthSidebar)
+                    .simultaneousGesture(sidebarContentCloseGesture, including: .subviews)
                 }
 
                 ZStack(alignment: .leading) {
@@ -707,6 +708,60 @@ struct ContentView: View {
             }
     }
 
+    private var sidebarContentCloseGesture: some Gesture {
+        DragGesture(minimumDistance: 15, coordinateSpace: .global)
+            .onChanged { value in
+                guard !sidebarGestureAutoCommitted else { return }
+                guard let action = sidebarCloseSwipeAction(for: value) else { return }
+
+                let translation = RootNavigationSwipePolicy.progressTranslation(
+                    for: action,
+                    translationWidth: value.translation.width
+                )
+
+                beginSidebarGestureDebugIfNeeded(kind: action.debugKind, startX: value.startLocation.x)
+                logSidebarGestureProgressIfNeeded(translation: translation)
+                guard RootNavigationSwipePolicy.isCommitReached(
+                    for: action,
+                    translationWidth: value.translation.width,
+                    commitDistance: sidebarSwipeCommitDistance
+                ) else { return }
+
+                sidebarGestureAutoCommitted = true
+                debugSidebarLog(
+                    "gesture #\(activeSidebarGestureDebugID ?? 0) auto-commit kind=\(action.debugKind) "
+                        + "translation=\(Int(translation)) commit=\(Int(sidebarSwipeCommitDistance)) source=sidebar"
+                )
+                finishGesture(action)
+            }
+            .onEnded { value in
+                if sidebarGestureAutoCommitted {
+                    sidebarGestureAutoCommitted = false
+                    return
+                }
+
+                guard let action = sidebarCloseSwipeAction(for: value) else {
+                    return
+                }
+
+                let translation = RootNavigationSwipePolicy.progressTranslation(
+                    for: action,
+                    translationWidth: value.translation.width
+                )
+                let predictedTranslation = RootNavigationSwipePolicy.progressTranslation(
+                    for: action,
+                    translationWidth: value.predictedEndTranslation.width
+                )
+
+                debugSidebarLog(
+                    "gesture #\(activeSidebarGestureDebugID ?? 0) end kind=\(action.debugKind) "
+                        + "translation=\(Int(translation)) predicted=\(Int(predictedTranslation)) "
+                        + "commit=\(Int(sidebarSwipeCommitDistance)) decision=cancel source=sidebar"
+                )
+                resetSidebarGestureDebug()
+            }
+    }
+
     // MARK: - Sidebar Actions
 
     private func toggleSidebar() {
@@ -966,6 +1021,28 @@ struct ContentView: View {
             isSidebarOpen: isSidebarOpen,
             navigationDepth: navigationPath.count
         )
+    }
+
+    private func sidebarCloseSwipeAction(
+        for value: DragGesture.Value
+    ) -> RootNavigationSwipeAction? {
+        guard isSidebarOpen else {
+            return nil
+        }
+
+        let action = RootNavigationSwipePolicy.action(
+            startLocationX: value.startLocation.x,
+            translationWidth: value.translation.width,
+            translationHeight: value.translation.height,
+            isSidebarOpen: true,
+            navigationDepth: navigationPath.count
+        )
+
+        guard action == .closeSidebar else {
+            return nil
+        }
+
+        return action
     }
 
     // Uses the responder chain instead of per-view bindings so mixed SwiftUI/UIKit inputs all close together.

--- a/CodexMobile/CodexMobile/ContentView.swift
+++ b/CodexMobile/CodexMobile/ContentView.swift
@@ -62,8 +62,6 @@ struct ContentView: View {
     @AppStorage("codex.whatsNew.lastPresentedVersion") private var lastPresentedWhatsNewVersion = ""
 
     private let sidebarWidth: CGFloat = 330
-    // Lets the drawer gesture start a bit inside the content instead of only on the bezel edge.
-    private let sidebarOpenActivationWidth: CGFloat = 80
     private let sidebarPrewarmDelayNanoseconds: UInt64 = 700_000_000
     private let whatsNewPresentationDelayNanoseconds: UInt64 = 30_000_000_000
     private let sidebarGestureLogBucketWidth: CGFloat = 40
@@ -396,7 +394,7 @@ struct ContentView: View {
                 .offset(x: currentSidebarRevealWidth)
             }
         }
-        .simultaneousGesture(edgeDragGesture)
+        .simultaneousGesture(navigationSwipeGesture)
     }
 
     // MARK: - Layers
@@ -640,92 +638,73 @@ struct ContentView: View {
 
     // MARK: - Gestures
 
-    private var edgeDragGesture: some Gesture {
+    private var navigationSwipeGesture: some Gesture {
         DragGesture(minimumDistance: 15, coordinateSpace: .global)
             .onChanged { value in
-                guard navigationPath.isEmpty else { return }
                 guard !sidebarGestureAutoCommitted else { return }
+                guard let action = navigationSwipeAction(for: value) else { return }
 
-                if !isSidebarOpen {
-                    guard value.startLocation.x < sidebarOpenActivationWidth,
-                          isOpeningSidebarGesture(value) else { return }
-                    beginSidebarGestureDebugIfNeeded(kind: "open", startX: value.startLocation.x)
-                    logSidebarGestureProgressIfNeeded(translation: value.translation.width)
-                    guard value.translation.width >= sidebarSwipeCommitDistance else { return }
-                    sidebarGestureAutoCommitted = true
-                    debugSidebarLog(
-                        "gesture #\(activeSidebarGestureDebugID ?? 0) auto-commit kind=open "
-                            + "translation=\(Int(value.translation.width)) commit=\(Int(sidebarSwipeCommitDistance))"
-                    )
-                    finishGesture(open: true)
-                } else {
-                    guard isClosingSidebarGesture(value) else { return }
+                if action == .closeSidebar {
                     suppressSidebarSelectionBriefly()
-                    beginSidebarGestureDebugIfNeeded(kind: "close", startX: value.startLocation.x)
-                    logSidebarGestureProgressIfNeeded(translation: -value.translation.width)
-                    guard -value.translation.width >= sidebarSwipeCommitDistance else { return }
-                    sidebarGestureAutoCommitted = true
-                    debugSidebarLog(
-                        "gesture #\(activeSidebarGestureDebugID ?? 0) auto-commit kind=close "
-                            + "translation=\(Int(-value.translation.width)) commit=\(Int(sidebarSwipeCommitDistance))"
-                    )
-                    finishGesture(open: false)
                 }
+
+                let translation = RootNavigationSwipePolicy.progressTranslation(
+                    for: action,
+                    translationWidth: value.translation.width
+                )
+
+                beginSidebarGestureDebugIfNeeded(kind: action.debugKind, startX: value.startLocation.x)
+                logSidebarGestureProgressIfNeeded(translation: translation)
+                guard RootNavigationSwipePolicy.isCommitReached(
+                    for: action,
+                    translationWidth: value.translation.width,
+                    commitDistance: sidebarSwipeCommitDistance
+                ) else { return }
+
+                sidebarGestureAutoCommitted = true
+                debugSidebarLog(
+                    "gesture #\(activeSidebarGestureDebugID ?? 0) auto-commit kind=\(action.debugKind) "
+                        + "translation=\(Int(translation)) commit=\(Int(sidebarSwipeCommitDistance))"
+                )
+                finishGesture(action)
             }
             .onEnded { value in
-                guard navigationPath.isEmpty else { return }
                 if sidebarGestureAutoCommitted {
                     sidebarGestureAutoCommitted = false
                     return
                 }
 
-                if !isSidebarOpen {
-                    guard value.startLocation.x < sidebarOpenActivationWidth,
-                          isOpeningSidebarGesture(value) else {
-                        debugSidebarLog("gesture cancelled before open")
-                        sidebarDragOffset = 0
-                        sidebarGestureAutoCommitted = false
-                        resetSidebarGestureDebug()
-                        return
+                guard let action = navigationSwipeAction(for: value) else {
+                    if activeSidebarGestureDebugID != nil {
+                        debugSidebarLog("gesture cancelled before commit")
                     }
-                    debugSidebarLog(
-                        "gesture #\(activeSidebarGestureDebugID ?? 0) end kind=open "
-                            + "translation=\(Int(value.translation.width)) predicted=\(Int(value.predictedEndTranslation.width)) "
-                            + "commit=\(Int(sidebarSwipeCommitDistance)) decision=snap-close"
-                    )
                     sidebarDragOffset = 0
+                    sidebarGestureAutoCommitted = false
                     resetSidebarGestureDebug()
-                } else {
-                    guard isClosingSidebarGesture(value) else {
-                        debugSidebarLog("gesture cancelled before close")
-                        sidebarDragOffset = 0
-                        sidebarGestureAutoCommitted = false
-                        resetSidebarGestureDebug()
-                        return
-                    }
-                    suppressSidebarSelectionBriefly()
-                    debugSidebarLog(
-                        "gesture #\(activeSidebarGestureDebugID ?? 0) end kind=close "
-                            + "translation=\(Int(-value.translation.width)) predicted=\(Int(-value.predictedEndTranslation.width)) "
-                            + "commit=\(Int(sidebarSwipeCommitDistance)) decision=snap-open"
-                    )
-                    sidebarDragOffset = 0
-                    resetSidebarGestureDebug()
+                    return
                 }
+
+                if action == .closeSidebar {
+                    suppressSidebarSelectionBriefly()
+                }
+
+                let translation = RootNavigationSwipePolicy.progressTranslation(
+                    for: action,
+                    translationWidth: value.translation.width
+                )
+                let predictedTranslation = RootNavigationSwipePolicy.progressTranslation(
+                    for: action,
+                    translationWidth: value.predictedEndTranslation.width
+                )
+
+                debugSidebarLog(
+                    "gesture #\(activeSidebarGestureDebugID ?? 0) end kind=\(action.debugKind) "
+                        + "translation=\(Int(translation)) predicted=\(Int(predictedTranslation)) "
+                        + "commit=\(Int(sidebarSwipeCommitDistance)) decision=cancel"
+                )
+                sidebarDragOffset = 0
+                resetSidebarGestureDebug()
             }
-    }
-
-    // Keeps the sidebar swipe from claiming mostly vertical drags near the screen edge.
-    private func isOpeningSidebarGesture(_ value: DragGesture.Value) -> Bool {
-        let horizontal = value.translation.width
-        let vertical = value.translation.height
-        return horizontal > 0 && abs(horizontal) > abs(vertical) * 1.15
-    }
-
-    private func isClosingSidebarGesture(_ value: DragGesture.Value) -> Bool {
-        let horizontal = value.translation.width
-        let vertical = value.translation.height
-        return horizontal < 0 && abs(horizontal) > abs(vertical) * 1.15
     }
 
     // MARK: - Sidebar Actions
@@ -852,10 +831,25 @@ struct ContentView: View {
             && !isRetryingSavedPairing
     }
 
-    private func finishGesture(open: Bool) {
+    private func finishGesture(_ action: RootNavigationSwipeAction) {
         HapticFeedback.shared.triggerImpactFeedback(style: .light)
-        debugSidebarLog("finishGesture open=\(open)")
-        setSidebar(open: open)
+        debugSidebarLog("finishGesture action=\(action.debugKind)")
+
+        switch action {
+        case .openSidebar:
+            setSidebar(open: true)
+        case .closeSidebar:
+            setSidebar(open: false)
+        case .navigateBack:
+            dismissActiveKeyboard()
+            withAnimation(Self.sidebarSpring) {
+                if !navigationPath.isEmpty {
+                    navigationPath.removeLast()
+                }
+            }
+            sidebarGestureAutoCommitted = false
+            resetSidebarGestureDebug()
+        }
     }
 
     // Forces UIKit-backed inputs like the composer/search text views to resign before the drawer moves.
@@ -960,6 +954,18 @@ struct ContentView: View {
         guard Self.isSidebarDebugLoggingEnabled else { return }
         print("[SidebarDebug] \(message())")
         #endif
+    }
+
+    private func navigationSwipeAction(
+        for value: DragGesture.Value
+    ) -> RootNavigationSwipeAction? {
+        RootNavigationSwipePolicy.action(
+            startLocationX: value.startLocation.x,
+            translationWidth: value.translation.width,
+            translationHeight: value.translation.height,
+            isSidebarOpen: isSidebarOpen,
+            navigationDepth: navigationPath.count
+        )
     }
 
     // Uses the responder chain instead of per-view bindings so mixed SwiftUI/UIKit inputs all close together.

--- a/CodexMobile/CodexMobile/RootNavigationSwipePolicy.swift
+++ b/CodexMobile/CodexMobile/RootNavigationSwipePolicy.swift
@@ -1,5 +1,5 @@
 // FILE: RootNavigationSwipePolicy.swift
-// Purpose: Chooses whether a full-width horizontal swipe should open the sidebar, close it, or navigate back.
+// Purpose: Centralizes route-aware horizontal swipe decisions for sidebar open/close and back navigation.
 // Layer: View Support
 // Exports: RootNavigationSwipeAction, RootNavigationSwipePolicy
 // Depends on: CoreGraphics
@@ -50,8 +50,8 @@ struct RootNavigationSwipePolicy {
         }
 
         if navigationDepth > 0 {
-            // Let UIKit keep owning the bezel-edge back swipe so the custom full-width
-            // gesture only extends the interaction into the middle of the screen.
+            // Keep UIKit's bezel-edge back swipe intact and extend the same
+            // gesture into the middle of the screen ourselves.
             guard startLocationX > systemBackEdgeWidth else {
                 return nil
             }

--- a/CodexMobile/CodexMobile/RootNavigationSwipePolicy.swift
+++ b/CodexMobile/CodexMobile/RootNavigationSwipePolicy.swift
@@ -1,0 +1,90 @@
+// FILE: RootNavigationSwipePolicy.swift
+// Purpose: Chooses whether a full-width horizontal swipe should open the sidebar, close it, or navigate back.
+// Layer: View Support
+// Exports: RootNavigationSwipeAction, RootNavigationSwipePolicy
+// Depends on: CoreGraphics
+
+import CoreGraphics
+
+enum RootNavigationSwipeAction: Equatable {
+    case openSidebar
+    case closeSidebar
+    case navigateBack
+
+    var debugKind: String {
+        switch self {
+        case .openSidebar:
+            return "open"
+        case .closeSidebar:
+            return "close"
+        case .navigateBack:
+            return "back"
+        }
+    }
+}
+
+struct RootNavigationSwipePolicy {
+    private static let horizontalBiasRatio: CGFloat = 1.15
+    private static let systemBackEdgeWidth: CGFloat = 80
+
+    static func action(
+        startLocationX: CGFloat,
+        translationWidth: CGFloat,
+        translationHeight: CGFloat,
+        isSidebarOpen: Bool,
+        navigationDepth: Int
+    ) -> RootNavigationSwipeAction? {
+        guard isPredominantlyHorizontal(
+            translationWidth: translationWidth,
+            translationHeight: translationHeight
+        ) else {
+            return nil
+        }
+
+        if isSidebarOpen {
+            return translationWidth < 0 ? .closeSidebar : nil
+        }
+
+        guard translationWidth > 0 else {
+            return nil
+        }
+
+        if navigationDepth > 0 {
+            // Let UIKit keep owning the bezel-edge back swipe so the custom full-width
+            // gesture only extends the interaction into the middle of the screen.
+            guard startLocationX > systemBackEdgeWidth else {
+                return nil
+            }
+            return .navigateBack
+        }
+
+        return .openSidebar
+    }
+
+    static func progressTranslation(
+        for action: RootNavigationSwipeAction,
+        translationWidth: CGFloat
+    ) -> CGFloat {
+        switch action {
+        case .openSidebar, .navigateBack:
+            return max(0, translationWidth)
+        case .closeSidebar:
+            return max(0, -translationWidth)
+        }
+    }
+
+    static func isCommitReached(
+        for action: RootNavigationSwipeAction,
+        translationWidth: CGFloat,
+        commitDistance: CGFloat
+    ) -> Bool {
+        progressTranslation(for: action, translationWidth: translationWidth) >= commitDistance
+    }
+
+    private static func isPredominantlyHorizontal(
+        translationWidth: CGFloat,
+        translationHeight: CGFloat
+    ) -> Bool {
+        abs(translationWidth) > abs(translationHeight) * horizontalBiasRatio
+    }
+}

--- a/CodexMobile/CodexMobile/Views/Sidebar/SidebarThreadRowView.swift
+++ b/CodexMobile/CodexMobile/Views/Sidebar/SidebarThreadRowView.swift
@@ -50,7 +50,7 @@ struct SidebarThreadRowView: View {
     // MARK: - Parent row (no CodexService dependency)
 
     private var parentRow: some View {
-        Button(action: { HapticFeedback.shared.triggerImpactFeedback(style: .light); onTap() }) {
+        Button(action: onTap) {
             HStack(alignment: .center, spacing: 8) {
                 leadingIndicatorSlot
 
@@ -147,7 +147,7 @@ struct SidebarThreadRowView: View {
     // MARK: - Subagent row (CodexService isolated in SubagentNameLabel)
 
     private var subagentRow: some View {
-        Button(action: { HapticFeedback.shared.triggerImpactFeedback(style: .light); onTap() }) {
+        Button(action: onTap) {
             HStack(alignment: .center, spacing: 8) {
                 leadingIndicatorSlot
 

--- a/CodexMobile/CodexMobile/Views/SidebarView.swift
+++ b/CodexMobile/CodexMobile/Views/SidebarView.swift
@@ -13,6 +13,7 @@ struct SidebarView: View {
     @Binding var selectedThread: CodexThread?
     @Binding var showSettings: Bool
     @Binding var isSearchActive: Bool
+    var interactionsEnabled: Bool = true
     var showsInlineCloseButton: Bool = false
     var isVisible: Bool = true
 
@@ -124,6 +125,7 @@ struct SidebarView: View {
         }
         .frame(maxHeight: .infinity)
         .background(Color(.systemBackground))
+        .allowsHitTesting(interactionsEnabled)
         .task {
             debugSidebarLog("task start visible=\(isVisible) threadCount=\(codex.threads.count)")
             rebuildGroupedThreads()
@@ -267,14 +269,17 @@ struct SidebarView: View {
 
     // Shows a native sheet so folder names and full paths stay readable on small screens.
     private func handleNewChatButtonTap() {
+        guard interactionsEnabled else { return }
         activeSidebarSheet = .newChatProjectPicker
     }
 
     private func presentLocalFolderBrowser() {
+        guard interactionsEnabled else { return }
         activeSidebarSheet = .localFolderBrowser
     }
 
     private func handleNewChatTap(preferredProjectPath: String?) {
+        guard interactionsEnabled else { return }
         createThreadErrorMessage = nil
         isCreatingThread = true
         onNewChatCreationStateChange(true)
@@ -300,6 +305,7 @@ struct SidebarView: View {
     }
 
     private func handleNewWorktreeChatTap(preferredProjectPath: String) {
+        guard interactionsEnabled else { return }
         createThreadErrorMessage = nil
         isCreatingThread = true
         onNewChatCreationStateChange(true)
@@ -325,12 +331,14 @@ struct SidebarView: View {
     }
 
     private func selectThread(_ thread: CodexThread) {
+        guard interactionsEnabled else { return }
         debugSidebarLog("selectThread id=\(thread.id) title=\(thread.displayTitle)")
         prepareSidebarForChatNavigation()
         onOpenThread(thread)
     }
 
     private func openSettings() {
+        guard interactionsEnabled else { return }
         searchText = ""
         isSearchActive = false
         showSettings = true
@@ -346,6 +354,7 @@ struct SidebarView: View {
 
     // Archives every live chat in the selected project group and clears the current selection if needed.
     private func archivePendingProjectGroup() {
+        guard interactionsEnabled else { return }
         guard let group = projectGroupPendingArchive else { return }
 
         let threadIDs = SidebarThreadGrouping.liveThreadIDsForProjectGroup(group, in: codex.threads)

--- a/CodexMobile/CodexMobileTests/ContentNavigationSwipePolicyTests.swift
+++ b/CodexMobile/CodexMobileTests/ContentNavigationSwipePolicyTests.swift
@@ -1,0 +1,71 @@
+// FILE: ContentNavigationSwipePolicyTests.swift
+// Purpose: Guards route-aware full-width swipe behavior for Back and sidebar open/close.
+// Layer: Unit Test
+// Exports: ContentNavigationSwipePolicyTests
+// Depends on: XCTest, CoreGraphics, CodexMobile
+
+import CoreGraphics
+import XCTest
+@testable import CodexMobile
+
+final class ContentNavigationSwipePolicyTests: XCTestCase {
+    func testRightSwipeAtRootOpensSidebarEvenWhenStartedFromMiddleOfScreen() {
+        let action = RootNavigationSwipePolicy.action(
+            startLocationX: 240,
+            translationWidth: 64,
+            translationHeight: 8,
+            isSidebarOpen: false,
+            navigationDepth: 0
+        )
+
+        XCTAssertEqual(action, .openSidebar)
+    }
+
+    func testRightSwipeOnPushedRouteNavigatesBackInsteadOfOpeningSidebar() {
+        let action = RootNavigationSwipePolicy.action(
+            startLocationX: 220,
+            translationWidth: 54,
+            translationHeight: 10,
+            isSidebarOpen: false,
+            navigationDepth: 1
+        )
+
+        XCTAssertEqual(action, .navigateBack)
+    }
+
+    func testRightSwipeNearScreenEdgeOnPushedRouteDefersToSystemBackGesture() {
+        let action = RootNavigationSwipePolicy.action(
+            startLocationX: 18,
+            translationWidth: 54,
+            translationHeight: 6,
+            isSidebarOpen: false,
+            navigationDepth: 1
+        )
+
+        XCTAssertNil(action)
+    }
+
+    func testMostlyVerticalGestureDoesNotTriggerNavigationAction() {
+        let action = RootNavigationSwipePolicy.action(
+            startLocationX: 180,
+            translationWidth: 28,
+            translationHeight: 48,
+            isSidebarOpen: false,
+            navigationDepth: 0
+        )
+
+        XCTAssertNil(action)
+    }
+
+    func testLeftSwipeClosesSidebarWhenDrawerIsOpen() {
+        let action = RootNavigationSwipePolicy.action(
+            startLocationX: 250,
+            translationWidth: -52,
+            translationHeight: 6,
+            isSidebarOpen: true,
+            navigationDepth: 0
+        )
+
+        XCTAssertEqual(action, .closeSidebar)
+    }
+}

--- a/CodexMobile/CodexMobileTests/RootNavigationSwipePolicyTests.swift
+++ b/CodexMobile/CodexMobileTests/RootNavigationSwipePolicyTests.swift
@@ -1,0 +1,71 @@
+// FILE: RootNavigationSwipePolicyTests.swift
+// Purpose: Guards full-width sidebar/back swipe decisions.
+// Layer: Unit Test
+// Exports: RootNavigationSwipePolicyTests
+// Depends on: XCTest, CoreGraphics, CodexMobile
+
+import CoreGraphics
+import XCTest
+@testable import CodexMobile
+
+final class RootNavigationSwipePolicyTests: XCTestCase {
+    func testRightSwipeAtRootOpensSidebarFromMiddleOfScreen() {
+        let action = RootNavigationSwipePolicy.action(
+            startLocationX: 240,
+            translationWidth: 64,
+            translationHeight: 8,
+            isSidebarOpen: false,
+            navigationDepth: 0
+        )
+
+        XCTAssertEqual(action, .openSidebar)
+    }
+
+    func testRightSwipeOnPushedRouteNavigatesBackFromMiddleOfScreen() {
+        let action = RootNavigationSwipePolicy.action(
+            startLocationX: 220,
+            translationWidth: 54,
+            translationHeight: 10,
+            isSidebarOpen: false,
+            navigationDepth: 1
+        )
+
+        XCTAssertEqual(action, .navigateBack)
+    }
+
+    func testRightSwipeNearEdgeOnPushedRouteDefersToSystemBackGesture() {
+        let action = RootNavigationSwipePolicy.action(
+            startLocationX: 18,
+            translationWidth: 54,
+            translationHeight: 6,
+            isSidebarOpen: false,
+            navigationDepth: 1
+        )
+
+        XCTAssertNil(action)
+    }
+
+    func testMostlyVerticalGestureDoesNotTriggerSidebarOrBackAction() {
+        let action = RootNavigationSwipePolicy.action(
+            startLocationX: 180,
+            translationWidth: 28,
+            translationHeight: 48,
+            isSidebarOpen: false,
+            navigationDepth: 0
+        )
+
+        XCTAssertNil(action)
+    }
+
+    func testLeftSwipeClosesSidebarWhenDrawerIsOpen() {
+        let action = RootNavigationSwipePolicy.action(
+            startLocationX: 250,
+            translationWidth: -52,
+            translationHeight: 6,
+            isSidebarOpen: true,
+            navigationDepth: 0
+        )
+
+        XCTAssertEqual(action, .closeSidebar)
+    }
+}


### PR DESCRIPTION
## Why
The app ignored left-to-right swipes unless they started at the extreme left edge. That felt wrong for modern iOS navigation and made the custom sidebar behavior inconsistent with the expected full-width back affordance.

## Root cause
`ContentView` hard-gated sidebar opening to gestures whose `startLocation.x` was within the first 80 points of the screen, and there was no route-aware full-width policy to distinguish root sidebar-open behavior from pushed-screen back navigation.