### PR TITLE
[Merged ✅] Fix recursive text interpolation in reasoning details

### DIFF
--- a/CodexMobile/CodexMobile.xcodeproj/project.pbxproj
+++ b/CodexMobile/CodexMobile.xcodeproj/project.pbxproj
@@ -388,7 +388,7 @@
 			mainGroup = C09A76A52F4B8D7B003B3F3A;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				C0DED3342F5E39DC0021A8E8 /* XCRemoteSwiftPackageReference "textual" */,
+				3B283BC772E3836F32C00079 /* XCRemoteSwiftPackageReference "textual" */,
 				C04E21492F71D34100AA3193 /* XCRemoteSwiftPackageReference "purchases-ios-spm" */,
 				C0F0D1FD2F7210A700A17B41 /* XCRemoteSwiftPackageReference "MarkdownView" */,
 			);
@@ -934,12 +934,12 @@
 				minimumVersion = 5.66.0;
 			};
 		};
-		C0DED3342F5E39DC0021A8E8 /* XCRemoteSwiftPackageReference "textual" */ = {
+		3B283BC772E3836F32C00079 /* XCRemoteSwiftPackageReference "textual" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/gonzalezreal/textual.git";
+			repositoryURL = "https://github.com/devnoname120/textual.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.1;
+				branch = main;
+				kind = branch;
 			};
 		};
 		C0F0D1FD2F7210A700A17B41 /* XCRemoteSwiftPackageReference "MarkdownView" */ = {
@@ -960,7 +960,7 @@
 		};
 		C0DED3352F5E39DC0021A8E8 /* Textual */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C0DED3342F5E39DC0021A8E8 /* XCRemoteSwiftPackageReference "textual" */;
+			package = 3B283BC772E3836F32C00079 /* XCRemoteSwiftPackageReference "textual" */;
 			productName = Textual;
 		};
 		C0F0D1FE2F7210A700A17B41 /* MarkdownView */ = {

--- a/CodexMobile/CodexMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodexMobile/CodexMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -66,10 +66,10 @@
     {
       "identity" : "textual",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gonzalezreal/textual.git",
+      "location" : "https://github.com/devnoname120/textual.git",
       "state" : {
-        "revision" : "5b06b811c0f5313b6b84bbef98c635a630638c38",
-        "version" : "0.3.1"
+        "branch" : "main",
+        "revision" : "ac751f2fcfc96309d9330ee9a7356840f964e211"
       }
     },
     {


### PR DESCRIPTION
This fixes the recursive text issue in reasoning details and switches the Textual dependency to `devnoname120/textual` instead of vendoring Textual into the app.

The dependency change is needed because the required Textual fix currently lives on the fork:
https://github.com/gonzalezreal/textual/compare/main...devnoname120:textual:main

For me Remodex was practically unusable because it would constantly crash at start if I had the misluck of being in a “cursed” thread which would crash and open every time the app was started again which made the app crash again.