### PR TITLE
Add plugin mentions to the composer

### DIFF
--- a/CodexMobile/CodexMobile/Models/CodexSkillMetadata.swift
+++ b/CodexMobile/CodexMobile/Models/CodexSkillMetadata.swift
@@ -1,7 +1,7 @@
 // FILE: CodexSkillMetadata.swift
 // Purpose: Skill metadata and mention payload types used by composer autocomplete + turn/start.
 // Layer: Model
-// Exports: CodexSkillMetadata, CodexTurnSkillMention
+// Exports: CodexSkillMetadata, CodexPluginMetadata, CodexTurnSkillMention, CodexTurnMention
 // Depends on: Foundation
 
 import Foundation
@@ -58,4 +58,95 @@ struct CodexTurnSkillMention: Hashable, Sendable {
     let id: String
     let name: String?
     let path: String?
+}
+
+struct CodexPluginMetadata: Hashable, Sendable, Identifiable {
+    let id: String
+    let name: String
+    let marketplaceName: String
+    let marketplacePath: String?
+    let displayName: String?
+    let shortDescription: String?
+    let installed: Bool
+    let enabled: Bool
+    let installPolicy: String?
+
+    nonisolated var isAvailableForMention: Bool {
+        installed || enabled || installPolicy == "INSTALLED_BY_DEFAULT"
+    }
+
+    nonisolated var mentionPath: String {
+        "plugin://\(name)@\(marketplaceName)"
+    }
+
+    nonisolated var displayTitle: String {
+        let trimmedDisplayName = displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmedDisplayName, !trimmedDisplayName.isEmpty {
+            return trimmedDisplayName
+        }
+        return name
+    }
+
+    nonisolated var normalizedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    nonisolated var searchBlob: String {
+        [
+            name,
+            displayName ?? "",
+            shortDescription ?? "",
+            marketplaceName,
+        ]
+            .map(Self.normalizedDiscoveryText)
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+    }
+
+    nonisolated func matchesSearch(query: String) -> Bool {
+        let normalizedQuery = Self.normalizedDiscoveryText(query)
+        return normalizedQuery.isEmpty || searchBlob.contains(normalizedQuery)
+    }
+
+    nonisolated static func normalizedDiscoveryText(_ value: String) -> String {
+        let separators = CharacterSet(charactersIn: ":/_-")
+        return value
+            .lowercased()
+            .components(separatedBy: separators)
+            .joined(separator: " ")
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}
+
+struct CodexPluginListResponse: Decodable {
+    let marketplaces: [CodexPluginMarketplace]
+}
+
+struct CodexPluginMarketplace: Decodable {
+    let name: String
+    let path: String?
+    let plugins: [CodexPluginListItem]
+}
+
+struct CodexPluginListItem: Decodable {
+    let id: String
+    let name: String
+    let installed: Bool
+    let enabled: Bool
+    let installPolicy: String?
+    let interface: CodexPluginInterface?
+}
+
+struct CodexPluginInterface: Decodable, Hashable, Sendable {
+    let displayName: String?
+    let shortDescription: String?
+    let category: String?
+    let developerName: String?
+}
+
+struct CodexTurnMention: Hashable, Sendable {
+    let name: String
+    let path: String
 }

--- a/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
@@ -169,6 +169,7 @@ extension CodexService {
             connectionRecoveryState = .idle
         }
         supportsStructuredSkillInput = true
+        supportsStructuredMentionInput = true
         supportsTurnCollaborationMode = false
         hasResolvedRateLimitsSnapshot = false
         bridgeInstalledVersion = nil
@@ -526,6 +527,7 @@ extension CodexService {
         shouldAutoReconnectOnForeground = false
         connectionRecoveryState = .idle
         supportsStructuredSkillInput = true
+        supportsStructuredMentionInput = true
         supportsTurnCollaborationMode = false
         bridgeInstalledVersion = nil
         latestBridgePackageVersion = nil

--- a/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
@@ -171,6 +171,7 @@ extension CodexService {
         threadId: String?,
         attachments: [CodexImageAttachment] = [],
         skillMentions: [CodexTurnSkillMention] = [],
+        mentionMentions: [CodexTurnMention] = [],
         fileMentions: [String] = [],
         shouldAppendUserMessage: Bool = true,
         collaborationMode: CodexCollaborationModeKind? = nil,
@@ -201,6 +202,7 @@ extension CodexService {
                     trimmedInput,
                     attachments: attachments,
                     skillMentions: skillMentions,
+                    mentionMentions: mentionMentions,
                     fileMentions: fileMentions,
                     to: continuationThread.id,
                     shouldAppendUserMessage: shouldAppendUserMessage,
@@ -217,6 +219,7 @@ extension CodexService {
                 trimmedInput,
                 attachments: attachments,
                 skillMentions: skillMentions,
+                mentionMentions: mentionMentions,
                 fileMentions: fileMentions,
                 to: initialThreadId,
                 shouldAppendUserMessage: shouldAppendUserMessage,
@@ -241,6 +244,7 @@ extension CodexService {
                     trimmedInput,
                     attachments: attachments,
                     skillMentions: skillMentions,
+                    mentionMentions: mentionMentions,
                     fileMentions: fileMentions,
                     to: continuationThread.id,
                     shouldAppendUserMessage: shouldAppendUserMessage,
@@ -445,6 +449,39 @@ extension CodexService {
             .filter { !$0.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
             .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
         return dedupedByName
+    }
+
+    // Loads Codex app-server plugins and returns entries usable as `@plugin` mentions.
+    func listPlugins(
+        cwds: [String]?,
+        forceReload: Bool = false
+    ) async throws -> [CodexPluginMetadata] {
+        let normalizedCwds = (cwds ?? [])
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        var paramsObject: RPCObject = [:]
+        if !normalizedCwds.isEmpty {
+            paramsObject["cwds"] = .array(normalizedCwds.map { .string($0) })
+        }
+        if forceReload {
+            paramsObject["forceReload"] = .bool(true)
+        }
+
+        let response = try await sendRequest(method: "plugin/list", params: .object(paramsObject))
+
+        guard let decodedPlugins = decodePluginMetadata(from: response.result) else {
+            throw CodexServiceError.invalidResponse("plugin/list response missing result.marketplaces[].plugins")
+        }
+
+        let mentionablePlugins = decodedPlugins.filter(\.isAvailableForMention)
+        let dedupedByPath = Dictionary(grouping: mentionablePlugins) { $0.mentionPath }
+            .compactMap { _, bucket -> CodexPluginMetadata? in
+                bucket.first
+            }
+            .filter { !$0.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .sorted { $0.displayTitle.localizedCaseInsensitiveCompare($1.displayTitle) == .orderedAscending }
+
+        return dedupedByPath
     }
 
     // Accepts the latest pending approval request.
@@ -1005,6 +1042,7 @@ extension CodexService {
         _ userInput: String,
         attachments: [CodexImageAttachment] = [],
         skillMentions: [CodexTurnSkillMention] = [],
+        mentionMentions: [CodexTurnMention] = [],
         fileMentions: [String] = [],
         to threadId: String,
         shouldAppendUserMessage: Bool = true,
@@ -1030,6 +1068,7 @@ extension CodexService {
         setProtectedRunningFallback(true, for: threadId)
 
         var includeStructuredSkillItems = supportsStructuredSkillInput && !skillMentions.isEmpty
+        var includeStructuredMentionItems = supportsStructuredMentionInput && !mentionMentions.isEmpty
         var imageURLKey = "url"
         var effectiveCollaborationMode = supportsTurnCollaborationMode ? collaborationMode : nil
         var didDowngradePlanModeForRuntime = false
@@ -1048,8 +1087,10 @@ extension CodexService {
                     userInput: userInput,
                     attachments: attachments,
                     skillMentions: skillMentions,
+                    mentionMentions: mentionMentions,
                     imageURLKey: imageURLKey,
                     includeStructuredSkillItems: includeStructuredSkillItems,
+                    includeStructuredMentionItems: includeStructuredMentionItems,
                     collaborationMode: effectiveCollaborationMode,
                     includeServiceTier: includesServiceTier
                 )
@@ -1080,6 +1121,13 @@ extension CodexService {
                     // Disable structured skill input for this runtime after first incompatibility signal.
                     supportsStructuredSkillInput = false
                     includeStructuredSkillItems = false
+                    continue
+                }
+
+                if includeStructuredMentionItems,
+                   shouldRetryTurnStartWithoutMentionItems(error) {
+                    supportsStructuredMentionInput = false
+                    includeStructuredMentionItems = false
                     continue
                 }
 
@@ -1229,6 +1277,7 @@ extension CodexService {
         expectedTurnId: String?,
         attachments: [CodexImageAttachment] = [],
         skillMentions: [CodexTurnSkillMention] = [],
+        mentionMentions: [CodexTurnMention] = [],
         fileMentions: [String] = [],
         shouldAppendUserMessage: Bool = true,
         collaborationMode: CodexCollaborationModeKind? = nil
@@ -1263,6 +1312,7 @@ extension CodexService {
         }
 
         var includeStructuredSkillItems = supportsStructuredSkillInput && !skillMentions.isEmpty
+        var includeStructuredMentionItems = supportsStructuredMentionInput && !mentionMentions.isEmpty
         var imageURLKey = "url"
         var effectiveCollaborationMode = supportsTurnCollaborationMode ? collaborationMode : nil
         var currentExpectedTurnID = initialTurnID
@@ -1284,7 +1334,9 @@ extension CodexService {
                         attachments: attachments,
                         imageURLKey: imageURLKey,
                         skillMentions: skillMentions,
-                        includeStructuredSkillItems: includeStructuredSkillItems
+                        mentionMentions: mentionMentions,
+                        includeStructuredSkillItems: includeStructuredSkillItems,
+                        includeStructuredMentionItems: includeStructuredMentionItems
                     )
                 ),
             ]
@@ -1315,6 +1367,13 @@ extension CodexService {
                    shouldRetryTurnStartWithoutSkillItems(error) {
                     supportsStructuredSkillInput = false
                     includeStructuredSkillItems = false
+                    continue
+                }
+
+                if includeStructuredMentionItems,
+                   shouldRetryTurnStartWithoutMentionItems(error) {
+                    supportsStructuredMentionInput = false
+                    includeStructuredMentionItems = false
                     continue
                 }
 
@@ -1390,7 +1449,9 @@ extension CodexService {
         attachments: [CodexImageAttachment],
         imageURLKey: String,
         skillMentions: [CodexTurnSkillMention] = [],
-        includeStructuredSkillItems: Bool = true
+        mentionMentions: [CodexTurnMention] = [],
+        includeStructuredSkillItems: Bool = true,
+        includeStructuredMentionItems: Bool = true
     ) -> [JSONValue] {
         var inputItems: [JSONValue] = []
 
@@ -1444,6 +1505,24 @@ extension CodexService {
             }
         }
 
+        if includeStructuredMentionItems {
+            for mention in mentionMentions {
+                let normalizedName = mention.name.trimmingCharacters(in: .whitespacesAndNewlines)
+                let normalizedPath = mention.path.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !normalizedName.isEmpty, !normalizedPath.isEmpty else {
+                    continue
+                }
+
+                inputItems.append(
+                    .object([
+                        "type": .string("mention"),
+                        "name": .string(normalizedName),
+                        "path": .string(normalizedPath),
+                    ])
+                )
+            }
+        }
+
         return inputItems
     }
 
@@ -1453,8 +1532,10 @@ extension CodexService {
         userInput: String,
         attachments: [CodexImageAttachment],
         skillMentions: [CodexTurnSkillMention],
+        mentionMentions: [CodexTurnMention],
         imageURLKey: String,
         includeStructuredSkillItems: Bool,
+        includeStructuredMentionItems: Bool,
         collaborationMode: CodexCollaborationModeKind?,
         includeServiceTier: Bool
     ) throws -> RPCObject {
@@ -1466,7 +1547,9 @@ extension CodexService {
                     attachments: attachments,
                     imageURLKey: imageURLKey,
                     skillMentions: skillMentions,
-                    includeStructuredSkillItems: includeStructuredSkillItems
+                    mentionMentions: mentionMentions,
+                    includeStructuredSkillItems: includeStructuredSkillItems,
+                    includeStructuredMentionItems: includeStructuredMentionItems
                 )
             ),
         ]
@@ -1827,6 +1910,27 @@ extension CodexService {
             || message.contains("field")
     }
 
+    // Detects legacy runtimes that reject input items with `type: "mention"`.
+    func shouldRetryTurnStartWithoutMentionItems(_ error: Error) -> Bool {
+        guard let serviceError = error as? CodexServiceError,
+              case .rpcError(let rpcError) = serviceError else {
+            return false
+        }
+
+        let message = rpcError.message.lowercased()
+        guard message.contains("mention") else {
+            return false
+        }
+
+        return message.contains("unknown")
+            || message.contains("unsupported")
+            || message.contains("invalid")
+            || message.contains("expected")
+            || message.contains("unrecognized")
+            || message.contains("type")
+            || message.contains("field")
+    }
+
     // Detects runtimes that reject plan-mode `collaborationMode` without `experimentalApi`.
     func shouldRetryTurnStartWithoutCollaborationMode(_ error: Error) -> Bool {
         guard let serviceError = error as? CodexServiceError,
@@ -1896,6 +2000,45 @@ extension CodexService {
         }
 
         return hasSkillContainer ? collectedSkills : nil
+    }
+
+    // Parses Codex app-server plugin/list marketplace payloads.
+    func decodePluginMetadata(from result: JSONValue?) -> [CodexPluginMetadata]? {
+        guard let resultObject = result?.objectValue,
+              let response = decodeModel(CodexPluginListResponse.self, from: .object(resultObject)) else {
+            return nil
+        }
+
+        var plugins: [CodexPluginMetadata] = []
+        for marketplace in response.marketplaces {
+            let marketplaceName = marketplace.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !marketplaceName.isEmpty else {
+                continue
+            }
+
+            for plugin in marketplace.plugins {
+                let pluginName = plugin.name.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !pluginName.isEmpty else {
+                    continue
+                }
+
+                plugins.append(
+                    CodexPluginMetadata(
+                        id: plugin.id,
+                        name: pluginName,
+                        marketplaceName: marketplaceName,
+                        marketplacePath: marketplace.path,
+                        displayName: plugin.interface?.displayName,
+                        shortDescription: plugin.interface?.shortDescription,
+                        installed: plugin.installed,
+                        enabled: plugin.enabled,
+                        installPolicy: plugin.installPolicy
+                    )
+                )
+            }
+        }
+
+        return plugins
     }
 
     func shouldRetrySkillsListWithCwdFallback(_ error: Error) -> Bool {

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -372,6 +372,7 @@ final class CodexService {
     var notificationAuthorizationStatus: UNAuthorizationStatus = .notDetermined
     var pendingNotificationOpenThreadID: String?
     var supportsStructuredSkillInput = true
+    var supportsStructuredMentionInput = true
     // Runtime compatibility flag for `turn/start.collaborationMode` plan turns.
     var supportsTurnCollaborationMode = false
     // Runtime compatibility flag for `thread/start|turn/start.serviceTier` speed controls.

--- a/CodexMobile/CodexMobile/Views/Turn/FileAutocompletePanel.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/FileAutocompletePanel.swift
@@ -1,5 +1,5 @@
 // FILE: FileAutocompletePanel.swift
-// Purpose: Autocomplete dropdown for @-file mentions.
+// Purpose: Autocomplete dropdown for @-file and @-plugin mentions.
 // Layer: View Component
 // Exports: FileAutocompletePanel
 // Depends on: SwiftUI, AutocompleteRowButtonStyle
@@ -8,31 +8,44 @@ import SwiftUI
 
 struct FileAutocompletePanel: View {
     let items: [CodexFuzzyFileMatch]
+    var pluginItems: [CodexPluginMetadata] = []
     let isLoading: Bool
+    var isLoadingPlugins: Bool = false
     let query: String
+    var pluginQuery: String = ""
     let onSelect: (CodexFuzzyFileMatch) -> Void
+    var onSelectPlugin: (CodexPluginMetadata) -> Void = { _ in }
 
     private static let rowHeight: CGFloat = 38
     private static let maxVisibleRows = 6
+    private static let sectionHeaderHeight: CGFloat = 24
 
     private static func visibleListHeight(for count: Int) -> CGFloat {
         rowHeight * CGFloat(min(count, maxVisibleRows))
     }
 
+    private var visibleRowCount: Int {
+        var count = items.count + pluginItems.count
+        if isLoading {
+            count += 1
+        }
+        if isLoadingPlugins {
+            count += 1
+        }
+        if !pluginItems.isEmpty {
+            count += 1
+        }
+        if !items.isEmpty || isLoading {
+            count += 1
+        }
+        return count
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if isLoading {
-                HStack(spacing: 8) {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text("Searching files...")
-                        .font(AppFont.footnote())
-                        .foregroundStyle(.secondary)
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-            } else if items.isEmpty {
-                Text("No files for @\(query)")
+            if items.isEmpty && pluginItems.isEmpty && !isLoading && !isLoadingPlugins {
+                let effectiveQuery = pluginQuery.isEmpty ? query : pluginQuery
+                Text("No files or plugins for @\(effectiveQuery)")
                     .font(AppFont.footnote())
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 12)
@@ -40,6 +53,52 @@ struct FileAutocompletePanel: View {
             } else {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
+                        if isLoadingPlugins {
+                            loadingRow("Loading plugins...")
+                        }
+
+                        if !pluginItems.isEmpty {
+                            sectionHeader("Plugins")
+                        }
+
+                        ForEach(pluginItems) { item in
+                            Button {
+                                HapticFeedback.shared.triggerImpactFeedback(style: .light)
+                                onSelectPlugin(item)
+                            } label: {
+                                HStack(spacing: 8) {
+                                    Image(systemName: "puzzlepiece.extension")
+                                        .font(AppFont.system(size: 12, weight: .semibold))
+                                        .foregroundStyle(Color.purple)
+
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(item.displayTitle)
+                                            .font(AppFont.subheadline(weight: .semibold))
+                                            .lineLimit(1)
+
+                                        Text(item.shortDescription ?? item.mentionPath)
+                                            .font(AppFont.caption())
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(1)
+                                    }
+                                }
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .frame(height: Self.rowHeight)
+                                .contentShape(Rectangle())
+                            }
+                            .buttonStyle(AutocompleteRowButtonStyle())
+                        }
+
+                        if !items.isEmpty || isLoading {
+                            sectionHeader("Files")
+                        }
+
+                        if isLoading {
+                            loadingRow("Searching files...")
+                        }
+
                         ForEach(items) { item in
                             Button {
                                 HapticFeedback.shared.triggerImpactFeedback(style: .light)
@@ -66,7 +125,7 @@ struct FileAutocompletePanel: View {
                     }
                 }
                 .scrollIndicators(.visible)
-                .frame(height: Self.visibleListHeight(for: items.count))
+                .frame(height: Self.visibleListHeight(for: visibleRowCount))
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -74,5 +133,25 @@ struct FileAutocompletePanel: View {
         .padding(4)
         .adaptiveGlass(.regular, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
         .padding(.horizontal, 4)
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(AppFont.caption(weight: .semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 12)
+            .frame(height: Self.sectionHeaderHeight, alignment: .bottomLeading)
+    }
+
+    private func loadingRow(_ title: String) -> some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+            Text(title)
+                .font(AppFont.footnote())
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 12)
+        .frame(height: Self.rowHeight, alignment: .leading)
     }
 }

--- a/CodexMobile/CodexMobile/Views/Turn/FileMentionChip.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/FileMentionChip.swift
@@ -1,7 +1,7 @@
 // FILE: FileMentionChip.swift
 // Purpose: Shared file-mention chip UI used in the composer (removable) and message timeline (read-only).
 // Layer: View Component
-// Exports: FileMentionChip, SkillMentionChip, ComposerActionChip, FileMentionChipRow, UserMentionChipRow, UserMessageParser, UserMessageParsed, SkillDisplayNameFormatter
+// Exports: FileMentionChip, SkillMentionChip, PluginMentionChip, ComposerActionChip, FileMentionChipRow, UserMentionChipRow, UserMessageParser, UserMessageParsed, SkillDisplayNameFormatter
 // Depends on: SwiftUI
 
 import SwiftUI
@@ -73,6 +73,40 @@ struct SkillMentionChip: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(Color.indigo.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+/// Compact inline `@ plugin` pill with optional remove affordance.
+struct PluginMentionChip: View {
+    let pluginName: String
+    var onRemove: (() -> Void)? = nil
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "puzzlepiece.extension")
+                .font(AppFont.system(size: 9, weight: .semibold))
+                .foregroundStyle(Color.purple)
+
+            Text(SkillDisplayNameFormatter.displayName(for: pluginName))
+                .font(AppFont.footnote(weight: .medium))
+                .foregroundStyle(Color.purple)
+                .lineLimit(1)
+
+            if let onRemove {
+                Button(action: onRemove) {
+                    Image(systemName: "xmark")
+                        .font(AppFont.system(size: 8, weight: .bold))
+                        .foregroundStyle(Color.purple)
+                        .frame(width: 14, height: 14)
+                        .background(Color.purple.opacity(0.14), in: Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Remove plugin mention")
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Color.purple.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
     }
 }
 

--- a/CodexMobile/CodexMobile/Views/Turn/TurnComposerHostView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnComposerHostView.swift
@@ -67,6 +67,10 @@ struct TurnComposerHostView: View {
             isSkillAutocompleteVisible: viewModel.isSkillAutocompleteVisible,
             isSkillAutocompleteLoading: viewModel.isSkillAutocompleteLoading,
             skillAutocompleteQuery: viewModel.skillAutocompleteQuery,
+            pluginAutocompleteItems: viewModel.pluginAutocompleteItems,
+            isPluginAutocompleteVisible: viewModel.isPluginAutocompleteVisible,
+            isPluginAutocompleteLoading: viewModel.isPluginAutocompleteLoading,
+            pluginAutocompleteQuery: viewModel.pluginAutocompleteQuery,
             slashCommandPanelState: viewModel.slashCommandPanelState,
             hasComposerContentConflictingWithReview: viewModel.hasComposerContentConflictingWithReview,
             isThreadRunning: isThreadRunning,
@@ -84,6 +88,7 @@ struct TurnComposerHostView: View {
             composerAttachments: viewModel.composerAttachments,
             composerMentionedFiles: viewModel.composerMentionedFiles,
             composerMentionedSkills: viewModel.composerMentionedSkills,
+            composerMentionedPlugins: viewModel.composerMentionedPlugins,
             composerReviewSelection: viewModel.composerReviewSelection,
             isSubagentsSelectionArmed: viewModel.isSubagentsSelectionArmed,
             isVoiceRecording: isVoiceRecording,
@@ -174,6 +179,14 @@ struct TurnComposerHostView: View {
                     activeTurnID: activeTurnID
                 )
             },
+            onInputChangedForPluginAutocomplete: { text in
+                viewModel.onInputChangedForPluginAutocomplete(
+                    text,
+                    codex: codex,
+                    thread: thread,
+                    activeTurnID: activeTurnID
+                )
+            },
             onInputChangedForSlashCommandAutocomplete: { text in
                 viewModel.onInputChangedForSlashCommandAutocomplete(
                     text,
@@ -182,6 +195,7 @@ struct TurnComposerHostView: View {
             },
             onSelectFileAutocomplete: viewModel.onSelectFileAutocomplete,
             onSelectSkillAutocomplete: viewModel.onSelectSkillAutocomplete,
+            onSelectPluginAutocomplete: viewModel.onSelectPluginAutocomplete,
             onSelectSlashCommand: { command in
                 switch command {
                 case .codeReview:
@@ -217,6 +231,7 @@ struct TurnComposerHostView: View {
             onCloseSlashCommandPanel: viewModel.closeSlashCommandPanel,
             onRemoveMentionedFile: viewModel.removeMentionedFile,
             onRemoveMentionedSkill: viewModel.removeMentionedSkill,
+            onRemoveMentionedPlugin: viewModel.removeMentionedPlugin,
             onRemoveComposerReviewSelection: viewModel.clearComposerReviewSelection,
             onRemoveComposerSubagentsSelection: viewModel.clearSubagentsSelection,
             onPasteImageData: { imageDataItems in

--- a/CodexMobile/CodexMobile/Views/Turn/TurnComposerView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnComposerView.swift
@@ -69,15 +69,18 @@ struct TurnComposerView: View {
     let onStopTurn: (String?) -> Void
     let onInputChangedForFileAutocomplete: (String) -> Void
     let onInputChangedForSkillAutocomplete: (String) -> Void
+    let onInputChangedForPluginAutocomplete: (String) -> Void
     let onInputChangedForSlashCommandAutocomplete: (String) -> Void
     let onSelectFileAutocomplete: (CodexFuzzyFileMatch) -> Void
     let onSelectSkillAutocomplete: (CodexSkillMetadata) -> Void
+    let onSelectPluginAutocomplete: (CodexPluginMetadata) -> Void
     let onSelectSlashCommand: (TurnComposerSlashCommand) -> Void
     let onSelectCodeReviewTarget: (TurnComposerReviewTarget) -> Void
     let onSelectForkDestination: (TurnComposerForkDestination) -> Void
     let onCloseSlashCommandPanel: () -> Void
     let onRemoveMentionedFile: (String) -> Void
     let onRemoveMentionedSkill: (String) -> Void
+    let onRemoveMentionedPlugin: (String) -> Void
     let onRemoveComposerReviewSelection: () -> Void
     let onRemoveComposerSubagentsSelection: () -> Void
     let onPasteImageData: ([Data]) -> Void
@@ -108,13 +111,14 @@ struct TurnComposerView: View {
                     onRemoveAttachment: onRemoveAttachment,
                     onRemoveMentionedFile: onRemoveMentionedFile,
                     onRemoveMentionedSkill: onRemoveMentionedSkill,
+                    onRemoveMentionedPlugin: onRemoveMentionedPlugin,
                     onRemoveComposerReviewSelection: onRemoveComposerReviewSelection,
                     onRemoveComposerSubagentsSelection: onRemoveComposerSubagentsSelection
                 )
 
                 ZStack(alignment: .topLeading) {
                     if input.isEmpty {
-                        Text("Ask anything... @files, $skills, /commands")
+                        Text("Ask anything... @files/plugins, $skills, /commands")
                             .font(AppFont.body())
                             .foregroundStyle(Color(.placeholderText))
                             .allowsHitTesting(false)
@@ -146,6 +150,7 @@ struct TurnComposerView: View {
                 .onChange(of: input) { _, newValue in
                     onInputChangedForFileAutocomplete(newValue)
                     onInputChangedForSkillAutocomplete(newValue)
+                    onInputChangedForPluginAutocomplete(newValue)
                     onInputChangedForSlashCommandAutocomplete(newValue)
                 }
 
@@ -196,6 +201,7 @@ struct TurnComposerView: View {
                                 state: autocompleteState,
                                 onSelectFileAutocomplete: onSelectFileAutocomplete,
                                 onSelectSkillAutocomplete: onSelectSkillAutocomplete,
+                                onSelectPluginAutocomplete: onSelectPluginAutocomplete,
                                 onSelectSlashCommand: onSelectSlashCommand,
                                 onSelectCodeReviewTarget: onSelectCodeReviewTarget,
                                 onSelectForkDestination: onSelectForkDestination,
@@ -253,6 +259,7 @@ private struct TurnComposerAutocompletePanels: View {
     let state: TurnComposerAutocompleteState
     let onSelectFileAutocomplete: (CodexFuzzyFileMatch) -> Void
     let onSelectSkillAutocomplete: (CodexSkillMetadata) -> Void
+    let onSelectPluginAutocomplete: (CodexPluginMetadata) -> Void
     let onSelectSlashCommand: (TurnComposerSlashCommand) -> Void
     let onSelectCodeReviewTarget: (TurnComposerReviewTarget) -> Void
     let onSelectForkDestination: (TurnComposerForkDestination) -> Void
@@ -263,9 +270,26 @@ private struct TurnComposerAutocompletePanels: View {
             if state.isFileAutocompleteVisible {
                 FileAutocompletePanel(
                     items: state.fileAutocompleteItems,
+                    pluginItems: state.pluginAutocompleteItems,
                     isLoading: state.isFileAutocompleteLoading,
+                    isLoadingPlugins: state.isPluginAutocompleteLoading,
                     query: state.fileAutocompleteQuery,
-                    onSelect: onSelectFileAutocomplete
+                    pluginQuery: state.pluginAutocompleteQuery,
+                    onSelect: onSelectFileAutocomplete,
+                    onSelectPlugin: onSelectPluginAutocomplete
+                )
+            }
+
+            if !state.isFileAutocompleteVisible && state.isPluginAutocompleteVisible {
+                FileAutocompletePanel(
+                    items: [],
+                    pluginItems: state.pluginAutocompleteItems,
+                    isLoading: false,
+                    isLoadingPlugins: state.isPluginAutocompleteLoading,
+                    query: state.pluginAutocompleteQuery,
+                    pluginQuery: state.pluginAutocompleteQuery,
+                    onSelect: onSelectFileAutocomplete,
+                    onSelectPlugin: onSelectPluginAutocomplete
                 )
             }
 
@@ -345,6 +369,7 @@ private struct TurnComposerAccessorySection: View {
     let onRemoveAttachment: (String) -> Void
     let onRemoveMentionedFile: (String) -> Void
     let onRemoveMentionedSkill: (String) -> Void
+    let onRemoveMentionedPlugin: (String) -> Void
     let onRemoveComposerReviewSelection: () -> Void
     let onRemoveComposerSubagentsSelection: () -> Void
 
@@ -381,6 +406,21 @@ private struct TurnComposerAccessorySection: View {
                         ForEach(state.composerMentionedSkills) { skill in
                             SkillMentionChip(skillName: skill.name) {
                                 onRemoveMentionedSkill(skill.id)
+                            }
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+            }
+
+            if state.showsMentionedPlugins {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(state.composerMentionedPlugins) { plugin in
+                            PluginMentionChip(pluginName: plugin.displayName ?? plugin.name) {
+                                onRemoveMentionedPlugin(plugin.id)
                             }
                         }
                     }
@@ -459,6 +499,7 @@ private struct QueuedDraftsPanelPreviewWrapper: View {
                     composerAttachments: [],
                     composerMentionedFiles: [],
                     composerMentionedSkills: [],
+                    composerMentionedPlugins: [],
                     composerReviewSelection: nil,
                     isSubagentsSelectionArmed: true,
                     isVoiceRecording: false,
@@ -475,6 +516,10 @@ private struct QueuedDraftsPanelPreviewWrapper: View {
                     isSkillAutocompleteVisible: false,
                     isSkillAutocompleteLoading: false,
                     skillAutocompleteQuery: "",
+                    pluginAutocompleteItems: [],
+                    isPluginAutocompleteVisible: false,
+                    isPluginAutocompleteLoading: false,
+                    pluginAutocompleteQuery: "",
                     slashCommandPanelState: .hidden,
                     hasComposerContentConflictingWithReview: false,
                     isThreadRunning: true,
@@ -554,15 +599,18 @@ private struct QueuedDraftsPanelPreviewWrapper: View {
                 onStopTurn: { _ in },
                 onInputChangedForFileAutocomplete: { _ in },
                 onInputChangedForSkillAutocomplete: { _ in },
+                onInputChangedForPluginAutocomplete: { _ in },
                 onInputChangedForSlashCommandAutocomplete: { _ in },
                 onSelectFileAutocomplete: { _ in },
                 onSelectSkillAutocomplete: { _ in },
+                onSelectPluginAutocomplete: { _ in },
                 onSelectSlashCommand: { _ in },
                 onSelectCodeReviewTarget: { _ in },
                 onSelectForkDestination: { _ in },
                 onCloseSlashCommandPanel: {},
                 onRemoveMentionedFile: { _ in },
                 onRemoveMentionedSkill: { _ in },
+                onRemoveMentionedPlugin: { _ in },
                 onRemoveComposerReviewSelection: {},
                 onRemoveComposerSubagentsSelection: {},
                 onPasteImageData: { _ in },

--- a/CodexMobile/CodexMobile/Views/Turn/TurnComposerViewState.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnComposerViewState.swift
@@ -16,6 +16,10 @@ struct TurnComposerAutocompleteState {
     let isSkillAutocompleteVisible: Bool
     let isSkillAutocompleteLoading: Bool
     let skillAutocompleteQuery: String
+    let pluginAutocompleteItems: [CodexPluginMetadata]
+    let isPluginAutocompleteVisible: Bool
+    let isPluginAutocompleteLoading: Bool
+    let pluginAutocompleteQuery: String
     let slashCommandPanelState: TurnComposerSlashCommandPanelState
     let hasComposerContentConflictingWithReview: Bool
     let isThreadRunning: Bool
@@ -34,6 +38,7 @@ struct TurnComposerAccessoryState {
     let composerAttachments: [TurnComposerImageAttachment]
     let composerMentionedFiles: [TurnComposerMentionedFile]
     let composerMentionedSkills: [TurnComposerMentionedSkill]
+    let composerMentionedPlugins: [TurnComposerMentionedPlugin]
     let composerReviewSelection: TurnComposerReviewSelection?
     let isSubagentsSelectionArmed: Bool
     let isVoiceRecording: Bool
@@ -52,6 +57,10 @@ struct TurnComposerAccessoryState {
         !composerMentionedSkills.isEmpty
     }
 
+    var showsMentionedPlugins: Bool {
+        !composerMentionedPlugins.isEmpty
+    }
+
     var reviewTarget: TurnComposerReviewTarget? {
         composerReviewSelection?.target
     }
@@ -65,6 +74,6 @@ struct TurnComposerAccessoryState {
     }
 
     var topInputPadding: CGFloat {
-        showsComposerAttachments || showsMentionedFiles || showsMentionedSkills || showsSubagentsSelection || showsVoiceRecordingCapsule || reviewTarget != nil ? 6 : 10
+        showsComposerAttachments || showsMentionedFiles || showsMentionedSkills || showsMentionedPlugins || showsSubagentsSelection || showsVoiceRecordingCapsule || reviewTarget != nil ? 6 : 10
     }
 }

--- a/CodexMobile/CodexMobile/Views/Turn/TurnViewModel.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnViewModel.swift
@@ -51,12 +51,14 @@ struct QueuedTurnDraft: Identifiable {
     let text: String
     let attachments: [CodexImageAttachment]
     let skillMentions: [CodexTurnSkillMention]
+    let mentionMentions: [CodexTurnMention]
     // Preserves special send semantics, such as plan mode, while a busy thread queues locally.
     let collaborationMode: CodexCollaborationModeKind?
     // Preserves the original composer state so a queued row can move back into the input intact.
     let rawInput: String
     let rawFileMentions: [TurnComposerMentionedFile]
     let rawSkillMentions: [TurnComposerMentionedSkill]
+    let rawPluginMentions: [TurnComposerMentionedPlugin]
     let rawAttachments: [TurnComposerImageAttachment]
     let rawSubagentsSelectionArmed: Bool
     let createdAt: Date
@@ -66,10 +68,12 @@ struct QueuedTurnDraft: Identifiable {
         text: String,
         attachments: [CodexImageAttachment],
         skillMentions: [CodexTurnSkillMention],
+        mentionMentions: [CodexTurnMention] = [],
         collaborationMode: CodexCollaborationModeKind?,
         rawInput: String? = nil,
         rawFileMentions: [TurnComposerMentionedFile] = [],
         rawSkillMentions: [TurnComposerMentionedSkill] = [],
+        rawPluginMentions: [TurnComposerMentionedPlugin] = [],
         rawAttachments: [TurnComposerImageAttachment] = [],
         rawSubagentsSelectionArmed: Bool = false,
         createdAt: Date
@@ -78,10 +82,12 @@ struct QueuedTurnDraft: Identifiable {
         self.text = text
         self.attachments = attachments
         self.skillMentions = skillMentions
+        self.mentionMentions = mentionMentions
         self.collaborationMode = collaborationMode
         self.rawInput = rawInput ?? text
         self.rawFileMentions = rawFileMentions
         self.rawSkillMentions = rawSkillMentions
+        self.rawPluginMentions = rawPluginMentions
         self.rawAttachments = rawAttachments
         self.rawSubagentsSelectionArmed = rawSubagentsSelectionArmed
         self.createdAt = createdAt
@@ -115,10 +121,12 @@ final class TurnViewModel {
         let payload: String
         let attachments: [CodexImageAttachment]
         let skillMentions: [CodexTurnSkillMention]
+        let mentionMentions: [CodexTurnMention]
         let collaborationMode: CodexCollaborationModeKind?
         let rawInput: String
         let rawFileMentions: [TurnComposerMentionedFile]
         let rawSkillMentions: [TurnComposerMentionedSkill]
+        let rawPluginMentions: [TurnComposerMentionedPlugin]
         let rawAttachments: [TurnComposerImageAttachment]
         let rawReviewSelection: TurnComposerReviewSelection?
         let rawSubagentsSelectionArmed: Bool
@@ -141,6 +149,7 @@ final class TurnViewModel {
     var composerAttachments: [TurnComposerImageAttachment] = []
     var composerMentionedFiles: [TurnComposerMentionedFile] = []
     var composerMentionedSkills: [TurnComposerMentionedSkill] = []
+    var composerMentionedPlugins: [TurnComposerMentionedPlugin] = []
     var composerReviewSelection: TurnComposerReviewSelection?
     var isSubagentsSelectionArmed = false
     var fileAutocompleteItems: [CodexFuzzyFileMatch] = []
@@ -151,6 +160,10 @@ final class TurnViewModel {
     var isSkillAutocompleteVisible = false
     var isSkillAutocompleteLoading = false
     var skillAutocompleteQuery = ""
+    var pluginAutocompleteItems: [CodexPluginMetadata] = []
+    var isPluginAutocompleteVisible = false
+    var isPluginAutocompleteLoading = false
+    var pluginAutocompleteQuery = ""
     var slashCommandPanelState: TurnComposerSlashCommandPanelState = .hidden
     // MARK: - Git state
 
@@ -235,20 +248,25 @@ final class TurnViewModel {
 
     @ObservationIgnored var fileAutocompleteDebounceTask: Task<Void, Never>?
     @ObservationIgnored var skillAutocompleteDebounceTask: Task<Void, Never>?
+    @ObservationIgnored var pluginAutocompleteDebounceTask: Task<Void, Never>?
     @ObservationIgnored var gitStatusRefreshTask: Task<Void, Never>?
     @ObservationIgnored var pendingGitBranchOperation: GitBranchUserOperation?
     @ObservationIgnored var pendingGitWorktreeOpenHandler: ((GitCreateWorktreeResult) -> Void)?
     @ObservationIgnored var pendingManagedGitWorktreeOpenHandler: ((GitCreateManagedWorktreeResult) -> Void)?
     @ObservationIgnored private var cachedSkillSearchIndexByRoot: [String: [TurnSkillSearchIndexEntry]] = [:]
+    @ObservationIgnored private var cachedPluginSearchIndexByRoot: [String: [TurnPluginSearchIndexEntry]] = [:]
     @ObservationIgnored var unsupportedSkillsAutocompleteRoots: Set<String> = []
+    @ObservationIgnored var unsupportedPluginsAutocompleteRoots: Set<String> = []
     @ObservationIgnored private var dismissedStructuredPlanPromptRequestKeys: Set<String> = []
     @ObservationIgnored private var dismissingStructuredPlanPromptRequestKeys: Set<String> = []
 
     let maxComposerImages = 4
     let maxFileAutocompleteItems = 6
     let maxSkillAutocompleteItems = 6
+    let maxPluginAutocompleteItems = 6
     private let fileAutocompleteDebounceNanoseconds: UInt64 = 180_000_000
     private let skillAutocompleteDebounceNanoseconds: UInt64 = 180_000_000
+    private let pluginAutocompleteDebounceNanoseconds: UInt64 = 180_000_000
     let gitStatusRefreshDebounceNanoseconds: UInt64 = 350_000_000
 
     init() {}
@@ -277,6 +295,8 @@ final class TurnViewModel {
         fileAutocompleteDebounceTask = nil
         skillAutocompleteDebounceTask?.cancel()
         skillAutocompleteDebounceTask = nil
+        pluginAutocompleteDebounceTask?.cancel()
+        pluginAutocompleteDebounceTask = nil
         gitStatusRefreshTask?.cancel()
         gitStatusRefreshTask = nil
     }
@@ -325,6 +345,7 @@ final class TurnViewModel {
             || !composerAttachments.isEmpty
             || !composerMentionedFiles.isEmpty
             || !composerMentionedSkills.isEmpty
+            || !composerMentionedPlugins.isEmpty
             || composerReviewSelection != nil
             || isSubagentsSelectionArmed
             || isPlanModeArmed
@@ -427,12 +448,14 @@ final class TurnViewModel {
     func clearComposer() {
         resetFileAutocompleteState()
         resetSkillAutocompleteState()
+        resetPluginAutocompleteState()
         resetSlashCommandState(clearPendingSelection: true, clearConfirmedSelection: true)
         isSubagentsSelectionArmed = false
         input = ""
         composerAttachments.removeAll()
         composerMentionedFiles.removeAll()
         composerMentionedSkills.removeAll()
+        composerMentionedPlugins.removeAll()
     }
 
     // Appends spoken text into the composer without sending it automatically.
@@ -466,9 +489,14 @@ final class TurnViewModel {
         resetSkillAutocompleteState()
     }
 
+    func clearPluginAutocomplete() {
+        resetPluginAutocompleteState()
+    }
+
     func clearComposerAutocomplete() {
         resetFileAutocompleteState()
         resetSkillAutocompleteState()
+        resetPluginAutocompleteState()
         resetSlashCommandState(clearPendingSelection: true)
     }
 
@@ -527,7 +555,7 @@ final class TurnViewModel {
         resetSlashCommandState(clearPendingSelection: true)
 
         let query = token.query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard query.count >= 2 else {
+        guard query.count >= 1 else {
             fileAutocompleteDebounceTask?.cancel()
             fileAutocompleteDebounceTask = nil
             fileAutocompleteItems = []
@@ -597,6 +625,7 @@ final class TurnViewModel {
 
         // Keep one autocomplete namespace visible at a time.
         resetFileAutocompleteState()
+        resetPluginAutocompleteState()
         resetSlashCommandState(clearPendingSelection: true)
 
         let query = token.query.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -676,6 +705,90 @@ final class TurnViewModel {
         }
     }
 
+    // Debounces installed Codex plugin suggestions for `@plugin` composer mentions.
+    func onInputChangedForPluginAutocomplete(
+        _ text: String,
+        codex: CodexService,
+        thread: CodexThread,
+        activeTurnID: String?
+    ) {
+        guard !isComposerInteractionLocked(activeTurnID: activeTurnID),
+              codex.isConnected,
+              let root = normalizedAutocompleteRoot(for: thread),
+              let token = Self.trailingPluginAutocompleteToken(in: text) else {
+            resetPluginAutocompleteState()
+            return
+        }
+
+        resetSkillAutocompleteState()
+        resetSlashCommandState(clearPendingSelection: true)
+
+        let query = token.query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedRoot = root
+        pluginAutocompleteQuery = query
+        isPluginAutocompleteVisible = true
+        let hasCachedPluginIndex = cachedPluginSearchIndexByRoot[normalizedRoot] != nil
+        let rootIsUnsupported = unsupportedPluginsAutocompleteRoots.contains(normalizedRoot)
+        isPluginAutocompleteLoading = !hasCachedPluginIndex && !rootIsUnsupported
+        pluginAutocompleteDebounceTask?.cancel()
+
+        let expectedQuery = query
+
+        pluginAutocompleteDebounceTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            do {
+                try await Task.sleep(nanoseconds: pluginAutocompleteDebounceNanoseconds)
+            } catch {
+                return
+            }
+
+            guard !Task.isCancelled else { return }
+
+            do {
+                if unsupportedPluginsAutocompleteRoots.contains(normalizedRoot),
+                   cachedPluginSearchIndexByRoot[normalizedRoot] == nil {
+                    guard self.pluginAutocompleteQuery == expectedQuery else { return }
+                    self.pluginAutocompleteItems = []
+                    self.isPluginAutocompleteLoading = false
+                    self.isPluginAutocompleteVisible = false
+                    return
+                }
+
+                let indexedPlugins: [TurnPluginSearchIndexEntry]
+                if let cachedIndex = self.cachedPluginSearchIndexByRoot[normalizedRoot] {
+                    indexedPlugins = cachedIndex
+                } else {
+                    let listedPlugins = try await codex.listPlugins(cwds: [normalizedRoot], forceReload: false)
+                    guard !Task.isCancelled else { return }
+                    indexedPlugins = listedPlugins
+                        .map(TurnPluginSearchIndexEntry.init(plugin:))
+                    self.cachedPluginSearchIndexByRoot[normalizedRoot] = indexedPlugins
+                }
+
+                guard !Task.isCancelled else { return }
+                guard self.pluginAutocompleteQuery == expectedQuery else { return }
+
+                self.pluginAutocompleteItems = self.filteredPluginAutocompleteItems(
+                    for: expectedQuery,
+                    indexedPlugins: indexedPlugins
+                )
+                self.isPluginAutocompleteLoading = false
+                self.isPluginAutocompleteVisible = !self.pluginAutocompleteItems.isEmpty
+            } catch {
+                guard self.pluginAutocompleteQuery == expectedQuery else { return }
+
+                if Self.isMethodNotFoundRPCError(error) {
+                    self.unsupportedPluginsAutocompleteRoots.insert(normalizedRoot)
+                }
+
+                self.pluginAutocompleteItems = []
+                self.isPluginAutocompleteLoading = false
+                self.isPluginAutocompleteVisible = false
+            }
+        }
+    }
+
     // Replaces `@query` with `@filename` in text and adds chip above input.
     func onSelectFileAutocomplete(_ item: CodexFuzzyFileMatch) {
         clearComposerReviewSelectionIfNeededForNonReviewContent()
@@ -697,6 +810,37 @@ final class TurnViewModel {
             )
         }
         resetFileAutocompleteState()
+    }
+
+    // Replaces `@query` with `@plugin` and stores the app-server mention item for turn/start.
+    func onSelectPluginAutocomplete(_ plugin: CodexPluginMetadata) {
+        clearComposerReviewSelectionIfNeededForNonReviewContent()
+
+        let normalizedPluginName = plugin.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedMentionPath = plugin.mentionPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedPluginName.isEmpty, !normalizedMentionPath.isEmpty else {
+            resetPluginAutocompleteState()
+            return
+        }
+
+        if let updatedInput = Self.replacingTrailingPluginAutocompleteToken(
+            in: input,
+            with: normalizedPluginName
+        ) {
+            input = updatedInput
+        }
+
+        if !composerMentionedPlugins.contains(where: { $0.path == normalizedMentionPath }) {
+            composerMentionedPlugins.append(
+                TurnComposerMentionedPlugin(
+                    name: normalizedPluginName,
+                    path: normalizedMentionPath,
+                    displayName: plugin.displayName
+                )
+            )
+        }
+
+        resetPluginAutocompleteState()
     }
 
     // Replaces `$query` with `$skill` and stores the selected skill mention for turn/start.
@@ -757,6 +901,7 @@ final class TurnViewModel {
 
         resetFileAutocompleteState()
         resetSkillAutocompleteState()
+        resetPluginAutocompleteState()
         slashCommandPanelState = .commands(query: token.query)
     }
 
@@ -821,6 +966,13 @@ final class TurnViewModel {
             input = Self.removeBoundedToken("$\(mention.name)", from: input)
         }
         composerMentionedSkills.removeAll(where: { $0.id == id })
+    }
+
+    func removeMentionedPlugin(id: String) {
+        if let mention = composerMentionedPlugins.first(where: { $0.id == id }) {
+            input = Self.removeBoundedToken("@\(mention.name)", from: input)
+        }
+        composerMentionedPlugins.removeAll(where: { $0.id == id })
     }
 
     func openCamera(codex: CodexService) {
@@ -939,6 +1091,9 @@ final class TurnViewModel {
         let skillMentions = composerMentionedSkills.map {
             CodexTurnSkillMention(id: $0.name, name: $0.name, path: $0.path)
         }
+        let mentionMentions = composerMentionedPlugins.map {
+            CodexTurnMention(name: $0.name, path: $0.path)
+        }
         let reviewSelection = composerReviewSelection
 
         guard (!payload.isEmpty || !attachments.isEmpty || reviewSelection != nil),
@@ -963,10 +1118,12 @@ final class TurnViewModel {
             text: payload,
             attachments: attachments,
             skillMentions: skillMentions,
+            mentionMentions: mentionMentions,
             collaborationMode: isPlanModeArmed ? .plan : nil,
             rawInput: input,
             rawFileMentions: composerMentionedFiles,
             rawSkillMentions: composerMentionedSkills,
+            rawPluginMentions: composerMentionedPlugins,
             rawAttachments: composerAttachments,
             rawSubagentsSelectionArmed: isSubagentsSelectionArmed,
             createdAt: Date()
@@ -975,10 +1132,12 @@ final class TurnViewModel {
             payload: payload,
             attachments: attachments,
             skillMentions: skillMentions,
+            mentionMentions: mentionMentions,
             collaborationMode: isPlanModeArmed ? .plan : nil,
             rawInput: input,
             rawFileMentions: composerMentionedFiles,
             rawSkillMentions: composerMentionedSkills,
+            rawPluginMentions: composerMentionedPlugins,
             rawAttachments: composerAttachments,
             rawReviewSelection: reviewSelection,
             rawSubagentsSelectionArmed: isSubagentsSelectionArmed
@@ -1040,6 +1199,7 @@ final class TurnViewModel {
                     threadId: threadID,
                     attachments: nextDraft.attachments,
                     skillMentions: nextDraft.skillMentions,
+                    mentionMentions: nextDraft.mentionMentions,
                     fileMentions: confirmedFileMentionPaths(from: nextDraft.rawFileMentions),
                     collaborationMode: nextDraft.collaborationMode
                 )
@@ -1088,6 +1248,7 @@ final class TurnViewModel {
                         threadId: threadID,
                         attachments: draft.attachments,
                         skillMentions: draft.skillMentions,
+                        mentionMentions: draft.mentionMentions,
                         fileMentions: confirmedFileMentionPaths(from: draft.rawFileMentions),
                         collaborationMode: draft.collaborationMode
                     )
@@ -1105,6 +1266,7 @@ final class TurnViewModel {
                     expectedTurnId: expectedTurnID,
                     attachments: draft.attachments,
                     skillMentions: draft.skillMentions,
+                    mentionMentions: draft.mentionMentions,
                     fileMentions: confirmedFileMentionPaths(from: draft.rawFileMentions),
                     shouldAppendUserMessage: true,
                     collaborationMode: draft.collaborationMode
@@ -1288,6 +1450,47 @@ final class TurnViewModel {
         )
     }
 
+    // Plugin discovery opens on bare `@`; selecting a suggestion is what stores the structured mention.
+    static func trailingPluginAutocompleteToken(in text: String) -> TurnTrailingPluginAutocompleteToken? {
+        guard !text.isEmpty else {
+            return nil
+        }
+
+        let tokenStart: String.Index
+        if let lastWhitespaceIndex = text.lastIndex(where: { $0.isWhitespace }) {
+            tokenStart = text.index(after: lastWhitespaceIndex)
+        } else {
+            tokenStart = text.startIndex
+        }
+
+        guard tokenStart < text.endIndex else {
+            return nil
+        }
+
+        let token = text[tokenStart..<text.endIndex]
+        guard token.first == "@" else {
+            return nil
+        }
+
+        let lastAtIndex = token.lastIndex(of: "@") ?? token.startIndex
+        let triggerIndex = lastAtIndex
+        let mentionToken = text[triggerIndex..<text.endIndex]
+        guard mentionToken.dropFirst().allSatisfy({ !$0.isWhitespace && $0 != "@" && $0 != "(" && $0 != ")" }) else {
+            return nil
+        }
+
+        let queryStart = text.index(after: triggerIndex)
+        let query = String(text[queryStart..<text.endIndex])
+        guard !query.contains(where: { $0.isWhitespace }) else {
+            return nil
+        }
+
+        return TurnTrailingPluginAutocompleteToken(
+            query: query,
+            tokenRange: triggerIndex..<text.endIndex
+        )
+    }
+
     // Extracts only a final `/query` token so slash commands open from the same composer input.
     static func trailingSlashCommandToken(in text: String) -> TurnTrailingSlashCommandToken? {
         TurnComposerCommandLogic.trailingSlashCommandToken(in: text)
@@ -1464,6 +1667,18 @@ final class TurnViewModel {
         return updated
     }
 
+    static func replacingTrailingPluginAutocompleteToken(in text: String, with selectedPlugin: String) -> String? {
+        let trimmedPlugin = selectedPlugin.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPlugin.isEmpty,
+              let token = trailingPluginAutocompleteToken(in: text) else {
+            return nil
+        }
+
+        var updated = text
+        updated.replaceSubrange(token.tokenRange, with: "@\(trimmedPlugin) ")
+        return updated
+    }
+
     static func removingTrailingSlashCommandToken(in text: String) -> String? {
         TurnComposerCommandLogic.removingTrailingSlashCommandToken(in: text)
     }
@@ -1488,8 +1703,12 @@ final class TurnViewModel {
         let rawQuery = String(text[queryStart..<text.endIndex])
         let query = rawQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty,
-              !query.contains(where: \.isNewline),
-              isAllowedFileAutocompleteQuery(query) else {
+              !query.contains(where: \.isNewline) else {
+            return nil
+        }
+
+        let isBareLowercaseSearch = query.first?.isLowercase == true && !query.contains(":")
+        guard isBareLowercaseSearch || isAllowedFileAutocompleteQuery(query) else {
             return nil
         }
 
@@ -1706,6 +1925,16 @@ final class TurnViewModel {
         return Array(filtered.prefix(maxSkillAutocompleteItems))
     }
 
+    private func filteredPluginAutocompleteItems(
+        for query: String,
+        indexedPlugins: [TurnPluginSearchIndexEntry]
+    ) -> [CodexPluginMetadata] {
+        let filtered = indexedPlugins.lazy
+            .filter { $0.plugin.matchesSearch(query: query) }
+            .map(\.plugin)
+        return Array(filtered.prefix(maxPluginAutocompleteItems))
+    }
+
     private func normalizedAutocompleteRoot(for thread: CodexThread) -> String? {
         thread.gitWorkingDirectory
     }
@@ -1784,6 +2013,7 @@ final class TurnViewModel {
                     threadId: threadID,
                     attachments: pendingSend.attachments,
                     skillMentions: pendingSend.skillMentions,
+                    mentionMentions: pendingSend.mentionMentions,
                     fileMentions: confirmedFileMentionPaths(from: pendingSend.rawFileMentions),
                     collaborationMode: pendingSend.collaborationMode
                 )
@@ -1808,6 +2038,7 @@ final class TurnViewModel {
         input = pendingSend.rawInput
         composerMentionedFiles = pendingSend.rawFileMentions
         composerMentionedSkills = pendingSend.rawSkillMentions
+        composerMentionedPlugins = pendingSend.rawPluginMentions
         composerAttachments = pendingSend.rawAttachments
         composerReviewSelection = pendingSend.rawReviewSelection
         isSubagentsSelectionArmed = pendingSend.rawSubagentsSelectionArmed
@@ -1835,6 +2066,7 @@ final class TurnViewModel {
         input = draft.rawInput
         composerMentionedFiles = draft.rawFileMentions
         composerMentionedSkills = draft.rawSkillMentions
+        composerMentionedPlugins = draft.rawPluginMentions
         composerAttachments = draft.rawAttachments
         composerReviewSelection = nil
         isSubagentsSelectionArmed = draft.rawSubagentsSelectionArmed
@@ -1914,6 +2146,15 @@ final class TurnViewModel {
         isSkillAutocompleteVisible = false
         isSkillAutocompleteLoading = false
         skillAutocompleteQuery = ""
+    }
+
+    private func resetPluginAutocompleteState() {
+        pluginAutocompleteDebounceTask?.cancel()
+        pluginAutocompleteDebounceTask = nil
+        pluginAutocompleteItems = []
+        isPluginAutocompleteVisible = false
+        isPluginAutocompleteLoading = false
+        pluginAutocompleteQuery = ""
     }
 
     private func resetSlashCommandState(
@@ -2353,12 +2594,24 @@ struct TurnComposerMentionedSkill: Identifiable, Equatable {
     let description: String?
 }
 
+struct TurnComposerMentionedPlugin: Identifiable, Equatable {
+    let id = UUID().uuidString
+    let name: String
+    let path: String
+    let displayName: String?
+}
+
 struct TurnTrailingFileAutocompleteToken: Equatable {
     let query: String
     let tokenRange: Range<String.Index>
 }
 
 struct TurnTrailingSkillAutocompleteToken: Equatable {
+    let query: String
+    let tokenRange: Range<String.Index>
+}
+
+struct TurnTrailingPluginAutocompleteToken: Equatable {
     let query: String
     let tokenRange: Range<String.Index>
 }
@@ -2381,6 +2634,14 @@ private struct TurnSkillSearchIndexEntry: Equatable {
         } else {
             self.searchBlob = "\(name)\n\(description)"
         }
+    }
+}
+
+private struct TurnPluginSearchIndexEntry: Equatable {
+    let plugin: CodexPluginMetadata
+
+    init(plugin: CodexPluginMetadata) {
+        self.plugin = plugin
     }
 }
 

--- a/CodexMobile/CodexMobileTests/CodexTurnInputPayloadSkillTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexTurnInputPayloadSkillTests.swift
@@ -55,6 +55,84 @@ final class CodexTurnInputPayloadSkillTests: XCTestCase {
         XCTAssertFalse(hasSkillItem)
     }
 
+    func testMakeTurnInputPayloadIncludesPluginMentionItemsWhenEnabled() {
+        let service = makeService()
+        let payload = service.makeTurnInputPayload(
+            userInput: "Use @gmail",
+            attachments: [],
+            imageURLKey: "url",
+            mentionMentions: [
+                CodexTurnMention(name: "gmail", path: "plugin://gmail@openai-curated"),
+            ],
+            includeStructuredMentionItems: true
+        )
+
+        let mentionItem = payload
+            .compactMap(\.objectValue)
+            .first(where: { $0["type"]?.stringValue == "mention" })
+
+        XCTAssertEqual(mentionItem?["name"]?.stringValue, "gmail")
+        XCTAssertEqual(mentionItem?["path"]?.stringValue, "plugin://gmail@openai-curated")
+    }
+
+    func testDecodePluginMetadataFiltersMarketplaceFieldsIntoMentionPath() {
+        let service = makeService()
+        let plugins = service.decodePluginMetadata(
+            from: .object([
+                "marketplaces": .array([
+                    .object([
+                        "name": .string("openai-curated"),
+                        "path": .null,
+                        "plugins": .array([
+                            .object([
+                                "id": .string("gmail@openai-curated"),
+                                "name": .string("gmail"),
+                                "installed": .bool(true),
+                                "enabled": .bool(true),
+                                "installPolicy": .string("AVAILABLE"),
+                                "interface": .object([
+                                    "displayName": .string("Gmail"),
+                                    "shortDescription": .string("Search mail"),
+                                ]),
+                            ]),
+                        ]),
+                    ]),
+                ]),
+            ])
+        )
+
+        XCTAssertEqual(plugins?.first?.name, "gmail")
+        XCTAssertEqual(plugins?.first?.mentionPath, "plugin://gmail@openai-curated")
+        XCTAssertEqual(plugins?.first?.displayTitle, "Gmail")
+    }
+
+    func testDecodePluginMetadataMarksDefaultInstalledPluginsMentionable() {
+        let service = makeService()
+        let plugins = service.decodePluginMetadata(
+            from: .object([
+                "marketplaces": .array([
+                    .object([
+                        "name": .string("openai-curated"),
+                        "path": .string("/plugins"),
+                        "plugins": .array([
+                            .object([
+                                "id": .string("browser@openai-curated"),
+                                "name": .string("browser"),
+                                "installed": .bool(false),
+                                "enabled": .bool(false),
+                                "installPolicy": .string("INSTALLED_BY_DEFAULT"),
+                                "interface": .null,
+                            ]),
+                        ]),
+                    ]),
+                ]),
+            ])
+        )
+
+        XCTAssertEqual(plugins?.first?.installPolicy, "INSTALLED_BY_DEFAULT")
+        XCTAssertEqual(plugins?.first?.isAvailableForMention, true)
+    }
+
     private func makeService() -> CodexService {
         let suiteName = "CodexTurnInputPayloadSkillTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName) ?? .standard

--- a/CodexMobile/CodexMobileTests/TurnFileAutocompleteTokenTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnFileAutocompleteTokenTests.swift
@@ -38,8 +38,54 @@ final class TurnFileAutocompleteTokenTests: XCTestCase {
         XCTAssertNil(TurnViewModel.trailingFileAutocompleteToken(in: "paste @t3tools/contracts:build"))
     }
 
-    func testTrailingTokenDoesNotParseBareTerminalHandle() {
-        XCTAssertNil(TurnViewModel.trailingFileAutocompleteToken(in: "paste @remodex"))
+    func testTrailingTokenParsesBareLowercaseSearchAfterAt() {
+        let token = TurnViewModel.trailingFileAutocompleteToken(in: "paste @remodex")
+
+        XCTAssertEqual(token?.query, "remodex")
+    }
+
+    func testTrailingFileTokenParsesAfterFirstLowercaseLetter() {
+        let token = TurnViewModel.trailingFileAutocompleteToken(in: "open @r")
+
+        XCTAssertEqual(token?.query, "r")
+    }
+
+    func testTrailingPluginTokenParsesBareAtMention() {
+        let token = TurnViewModel.trailingPluginAutocompleteToken(in: "use @gmail")
+
+        XCTAssertEqual(token?.query, "gmail")
+    }
+
+    func testTrailingPluginTokenParsesBareAtTrigger() {
+        let token = TurnViewModel.trailingPluginAutocompleteToken(in: "use @")
+
+        XCTAssertEqual(token?.query, "")
+    }
+
+    func testTrailingPluginTokenUsesLastAdjacentAtMention() {
+        let token = TurnViewModel.trailingPluginAutocompleteToken(in: "@first@gma")
+
+        XCTAssertEqual(token?.query, "gma")
+    }
+
+    func testTrailingPluginTokenDoesNotParseEmailAddress() {
+        XCTAssertNil(TurnViewModel.trailingPluginAutocompleteToken(in: "email@test.com"))
+    }
+
+    func testReplacingTrailingPluginTokenUpdatesOnlyFinalAtToken() {
+        let updated = TurnViewModel.replacingTrailingPluginAutocompleteToken(
+            in: "compare @first and @gma",
+            with: "gmail"
+        )
+
+        XCTAssertEqual(updated, "compare @first and @gmail ")
+    }
+
+    func testProviderDiscoveryTextNormalizesSeparatorsLikeT3Code() {
+        XCTAssertEqual(
+            CodexPluginMetadata.normalizedDiscoveryText("openai-curated/gmail_plugin"),
+            "openai curated gmail plugin"
+        )
     }
 
     func testTrailingTokenStillParsesLineReferencedFile() {


### PR DESCRIPTION
## Summary
- Added plugin metadata lookup and structured `mention` payload support in turn start/continue requests.
- Extended the composer autocomplete UI to search, display, and insert `@plugin` mentions alongside file mentions.
- Added removable plugin mention chips in the composer and wired the new state through the turn view model and host view.
- Included tests covering plugin mention payload generation and autocomplete token parsing.

## Testing
- Not run (not requested).
- Added/updated unit tests for plugin mention payload construction.
- Added/updated unit tests for autocomplete token handling with plugin mention support.