### PR TITLE
Update timeline collapsing for completed turns

### DIFF
--- a/CodexMobile/CodexMobile/Services/CodexService+Messages.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Messages.swift
@@ -3349,7 +3349,10 @@ extension CodexService {
            !pendingAssistantDeltaStreamOrder.contains(streamID) {
             pendingAssistantDeltaStreamOrder.append(streamID)
         }
-        pendingAssistantDeltaByStreamID[streamID, default: ""].append(delta)
+        pendingAssistantDeltaByStreamID[streamID] = mergeAssistantDelta(
+            existingText: pendingAssistantDeltaByStreamID[streamID] ?? "",
+            incomingDelta: delta
+        )
         schedulePendingAssistantDeltaFlushIfNeeded()
     }
 
@@ -3371,7 +3374,10 @@ extension CodexService {
            !pendingAssistantDeltaStreamOrder.contains(destinationStreamID) {
             pendingAssistantDeltaStreamOrder.append(destinationStreamID)
         }
-        pendingAssistantDeltaByStreamID[destinationStreamID, default: ""].append(fallbackDelta)
+        pendingAssistantDeltaByStreamID[destinationStreamID] = mergeAssistantDelta(
+            existingText: pendingAssistantDeltaByStreamID[destinationStreamID] ?? "",
+            incomingDelta: fallbackDelta
+        )
         pendingAssistantDeltaContextByStreamID[destinationStreamID] = (
             threadId: threadId,
             turnId: turnId.trimmingCharacters(in: .whitespacesAndNewlines),

--- a/CodexMobile/CodexMobile/Views/Turn/TurnTimelineRenderProjection.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnTimelineRenderProjection.swift
@@ -1,0 +1,233 @@
+// FILE: TurnTimelineRenderProjection.swift
+// Purpose: Builds lightweight render items from raw timeline messages.
+// Layer: View Model / Projection
+// Exports: TurnTimelineRenderProjection, TurnTimelineRenderItem, timeline grouping models
+// Depends on: Foundation, CodexMessage
+
+import Foundation
+
+// ─── Render Item Models ───────────────────────────────────────
+
+struct TurnTimelineToolBurstGroup: Identifiable, Equatable {
+    static let collapsedVisibleCount = 5
+
+    let id: String
+    let messages: [CodexMessage]
+
+    init(messages: [CodexMessage]) {
+        self.messages = messages
+        self.id = "tool-burst:\(messages.first?.id ?? "unknown")"
+    }
+
+    var pinnedMessages: [CodexMessage] {
+        Array(messages.prefix(Self.collapsedVisibleCount))
+    }
+
+    var overflowMessages: [CodexMessage] {
+        Array(messages.dropFirst(Self.collapsedVisibleCount))
+    }
+
+    var hiddenCount: Int {
+        overflowMessages.count
+    }
+}
+
+struct TurnTimelinePreviousMessagesGroup: Identifiable, Equatable {
+    let id: String
+    let finalMessageID: String
+    let messages: [CodexMessage]
+
+    init(finalMessage: CodexMessage, messages: [CodexMessage]) {
+        self.id = "previous-messages:\(finalMessage.id)"
+        self.finalMessageID = finalMessage.id
+        self.messages = messages
+    }
+
+    var hiddenCount: Int {
+        messages.count
+    }
+}
+
+enum TurnTimelineRenderItem: Identifiable, Equatable {
+    case message(CodexMessage)
+    case toolBurst(TurnTimelineToolBurstGroup)
+    case previousMessages(TurnTimelinePreviousMessagesGroup)
+
+    var id: String {
+        switch self {
+        case .message(let message):
+            return message.id
+        case .toolBurst(let group):
+            return group.id
+        case .previousMessages(let group):
+            return group.id
+        }
+    }
+}
+
+// ─── Projection ────────────────────────────────────────────────
+
+enum TurnTimelineRenderProjection {
+    // Groups tool runs and completed-turn preamble rows so the visible timeline stays compact.
+    static func project(messages: [CodexMessage], completedTurnIDs: Set<String> = []) -> [TurnTimelineRenderItem] {
+        var items: [TurnTimelineRenderItem] = []
+        var bufferedToolMessages: [CodexMessage] = []
+        let finalCollapsePlan = previousMessagesCollapsePlan(
+            in: messages,
+            completedTurnIDs: completedTurnIDs
+        )
+        let hiddenIndices = Set(finalCollapsePlan.values.flatMap(\.indices))
+        let groupByStartIndex = Dictionary(
+            uniqueKeysWithValues: finalCollapsePlan.values.map { ($0.startIndex, $0) }
+        )
+
+        func flushBufferedToolMessages() {
+            guard !bufferedToolMessages.isEmpty else { return }
+            if bufferedToolMessages.count > TurnTimelineToolBurstGroup.collapsedVisibleCount {
+                items.append(.toolBurst(TurnTimelineToolBurstGroup(messages: bufferedToolMessages)))
+            } else {
+                items.append(contentsOf: bufferedToolMessages.map(TurnTimelineRenderItem.message))
+            }
+            bufferedToolMessages.removeAll(keepingCapacity: true)
+        }
+
+        for (index, message) in messages.enumerated() {
+            if let group = groupByStartIndex[index] {
+                flushBufferedToolMessages()
+                items.append(.previousMessages(group.group))
+            }
+
+            if hiddenIndices.contains(index) {
+                continue
+            }
+
+            guard isToolBurstCandidate(message) else {
+                flushBufferedToolMessages()
+                items.append(.message(message))
+                continue
+            }
+
+            if let previous = bufferedToolMessages.last,
+               !canShareToolBurst(previous: previous, incoming: message) {
+                flushBufferedToolMessages()
+            }
+
+            bufferedToolMessages.append(message)
+        }
+
+        flushBufferedToolMessages()
+        return items
+    }
+
+    static func collapsedFinalMessageIDs(
+        in messages: [CodexMessage],
+        completedTurnIDs: Set<String>
+    ) -> Set<String> {
+        Set(previousMessagesCollapsePlan(
+            in: messages,
+            completedTurnIDs: completedTurnIDs
+        ).keys.map { messages[$0].id })
+    }
+
+    private struct PreviousMessagesCollapse {
+        let startIndex: Int
+        let indices: [Int]
+        let group: TurnTimelinePreviousMessagesGroup
+    }
+
+    // Finds completed final answers and the same-turn status/tool rows that should sit behind the disclosure.
+    private static func previousMessagesCollapsePlan(
+        in messages: [CodexMessage],
+        completedTurnIDs: Set<String>
+    ) -> [Int: PreviousMessagesCollapse] {
+        guard !completedTurnIDs.isEmpty else {
+            return [:]
+        }
+
+        let finalAssistantIndexByTurn = messages.indices.reduce(into: [String: Int]()) { result, index in
+            let message = messages[index]
+            guard message.role == .assistant,
+                  !message.isStreaming,
+                  !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  let turnID = normalizedIdentifier(message.turnId),
+                  completedTurnIDs.contains(turnID) else {
+                return
+            }
+            result[turnID] = index
+        }
+
+        var plan: [Int: PreviousMessagesCollapse] = [:]
+        for (turnID, finalIndex) in finalAssistantIndexByTurn {
+            let lowerBound = lastUserIndexBefore(finalIndex, in: messages, turnID: turnID).map { $0 + 1 } ?? messages.startIndex
+            let hiddenIndices = messages.indices.filter { index in
+                guard index >= lowerBound, index < finalIndex else {
+                    return false
+                }
+                let candidate = messages[index]
+                return normalizedIdentifier(candidate.turnId) == turnID
+                    && candidate.role != .user
+            }
+
+            guard let startIndex = hiddenIndices.first else {
+                continue
+            }
+
+            let hiddenMessages = hiddenIndices.map { messages[$0] }
+            plan[finalIndex] = PreviousMessagesCollapse(
+                startIndex: startIndex,
+                indices: hiddenIndices,
+                group: TurnTimelinePreviousMessagesGroup(
+                    finalMessage: messages[finalIndex],
+                    messages: hiddenMessages
+                )
+            )
+        }
+
+        return plan
+    }
+
+    private static func lastUserIndexBefore(_ index: Int, in messages: [CodexMessage], turnID: String) -> Int? {
+        messages.indices.reversed().first { candidateIndex in
+            guard candidateIndex < index else {
+                return false
+            }
+            let candidate = messages[candidateIndex]
+            return candidate.role == .user
+                && normalizedIdentifier(candidate.turnId) == turnID
+        }
+    }
+
+    private static func isToolBurstCandidate(_ message: CodexMessage) -> Bool {
+        guard message.role == .system else {
+            return false
+        }
+
+        switch message.kind {
+        case .toolActivity, .commandExecution:
+            return true
+        case .thinking, .chat, .plan, .userInputPrompt, .fileChange, .subagentAction:
+            return false
+        }
+    }
+
+    // Late turn ids can arrive mid-stream, so only split when both rows already
+    // have distinct stable turn ids.
+    private static func canShareToolBurst(previous: CodexMessage, incoming: CodexMessage) -> Bool {
+        let previousTurnID = normalizedIdentifier(previous.turnId)
+        let incomingTurnID = normalizedIdentifier(incoming.turnId)
+
+        guard let previousTurnID, let incomingTurnID else {
+            return true
+        }
+
+        return previousTurnID == incomingTurnID
+    }
+
+    private static func normalizedIdentifier(_ value: String?) -> String? {
+        guard let value else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/CodexMobile/CodexMobile/Views/Turn/TurnTimelineView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnTimelineView.swift
@@ -2,7 +2,7 @@
 // Purpose: Renders timeline scrolling, bottom-anchor behavior and the footer container.
 // Layer: View Component
 // Exports: TurnTimelineView
-// Depends on: SwiftUI, TurnTimelineReducer, TurnScrollStateTracker, MessageRow
+// Depends on: SwiftUI, TurnTimelineRenderProjection, TurnTimelineReducer, MessageRow
 
 import SwiftUI
 import UIKit
@@ -13,116 +13,15 @@ struct AssistantBlockAccessoryState: Equatable {
     let blockDiffText: String?
     let blockDiffEntries: [TurnFileChangeSummaryEntry]?
     let blockRevertPresentation: AssistantRevertPresentation?
-}
 
-// ─── Tool Burst Projection ─────────────────────────────────────
-
-struct TurnTimelineToolBurstGroup: Identifiable, Equatable {
-    static let collapsedVisibleCount = 5
-
-    let id: String
-    let messages: [CodexMessage]
-
-    init(messages: [CodexMessage]) {
-        self.messages = messages
-        self.id = "tool-burst:\(messages.first?.id ?? "unknown")"
-    }
-
-    var pinnedMessages: [CodexMessage] {
-        Array(messages.prefix(Self.collapsedVisibleCount))
-    }
-
-    var overflowMessages: [CodexMessage] {
-        Array(messages.dropFirst(Self.collapsedVisibleCount))
-    }
-
-    var hiddenCount: Int {
-        overflowMessages.count
-    }
-}
-
-enum TurnTimelineRenderItem: Identifiable, Equatable {
-    case message(CodexMessage)
-    case toolBurst(TurnTimelineToolBurstGroup)
-
-    var id: String {
-        switch self {
-        case .message(let message):
-            return message.id
-        case .toolBurst(let group):
-            return group.id
-        }
-    }
-}
-
-enum TurnTimelineRenderProjection {
-    // Groups long contiguous tool-call runs into one stable container so the main
-    // timeline height stays bounded without introducing nested scrolling.
-    static func project(messages: [CodexMessage]) -> [TurnTimelineRenderItem] {
-        var items: [TurnTimelineRenderItem] = []
-        var bufferedToolMessages: [CodexMessage] = []
-
-        func flushBufferedToolMessages() {
-            guard !bufferedToolMessages.isEmpty else { return }
-            if bufferedToolMessages.count > TurnTimelineToolBurstGroup.collapsedVisibleCount {
-                items.append(.toolBurst(TurnTimelineToolBurstGroup(messages: bufferedToolMessages)))
-            } else {
-                items.append(contentsOf: bufferedToolMessages.map(TurnTimelineRenderItem.message))
-            }
-            bufferedToolMessages.removeAll(keepingCapacity: true)
-        }
-
-        for message in messages {
-            guard isToolBurstCandidate(message) else {
-                flushBufferedToolMessages()
-                items.append(.message(message))
-                continue
-            }
-
-            if let previous = bufferedToolMessages.last,
-               !canShareToolBurst(previous: previous, incoming: message) {
-                flushBufferedToolMessages()
-            }
-
-            bufferedToolMessages.append(message)
-        }
-
-        flushBufferedToolMessages()
-        return items
-    }
-
-    private static func isToolBurstCandidate(_ message: CodexMessage) -> Bool {
-        guard message.role == .system else {
-            return false
-        }
-
-        switch message.kind {
-        case .toolActivity, .commandExecution:
-            return true
-        case .thinking, .chat, .plan, .userInputPrompt, .fileChange, .subagentAction:
-            return false
-        }
-    }
-
-    // Late turn ids can arrive mid-stream, so only split when both rows already
-    // have distinct stable turn ids.
-    private static func canShareToolBurst(previous: CodexMessage, incoming: CodexMessage) -> Bool {
-        let previousTurnID = normalizedIdentifier(previous.turnId)
-        let incomingTurnID = normalizedIdentifier(incoming.turnId)
-
-        guard let previousTurnID, let incomingTurnID else {
-            return true
-        }
-
-        return previousTurnID == incomingTurnID
-    }
-
-    private static func normalizedIdentifier(_ value: String?) -> String? {
-        guard let value else {
-            return nil
-        }
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
+    func replacingCopyText(_ copyText: String?) -> AssistantBlockAccessoryState {
+        AssistantBlockAccessoryState(
+            copyText: copyText,
+            showsRunningIndicator: showsRunningIndicator,
+            blockDiffText: blockDiffText,
+            blockDiffEntries: blockDiffEntries,
+            blockRevertPresentation: blockRevertPresentation
+        )
     }
 }
 
@@ -257,6 +156,80 @@ private struct TurnTimelineToolBurstView: View {
     }
 }
 
+private struct TurnTimelinePreviousMessagesView: View {
+    let group: TurnTimelinePreviousMessagesGroup
+    let isRetryAvailable: Bool
+    let cachedBlockInfoByMessageID: [String: AssistantBlockAccessoryState]
+    let planSessionSource: CodexPlanSessionSource?
+    let allowsAssistantPlanFallbackRecovery: Bool
+    let completedTurnIDs: Set<String>
+    let threadMessagesForPlanMatching: [CodexMessage]
+    let planMatchingFingerprint: Int
+    let newestStreamingMessageID: String?
+    let autoScrollMode: TurnAutoScrollMode
+    let onRetryUserMessage: (String) -> Void
+    let onTapAssistantRevert: (CodexMessage) -> Void
+    let onTapSubagent: (CodexSubagentThreadPresentation) -> Void
+
+    @State private var isExpanded = false
+
+    private var title: String {
+        group.hiddenCount == 1 ? "1 previous message" : "\(group.hiddenCount) previous messages"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.18)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Text(title)
+                        .font(AppFont.title3(weight: .regular))
+                        .foregroundStyle(.secondary)
+                    Image(systemName: "chevron.right")
+                        .font(AppFont.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    Spacer(minLength: 0)
+                }
+                .padding(.bottom, 8)
+                .overlay(alignment: .bottom) {
+                    Rectangle()
+                        .fill(Color.secondary.opacity(0.18))
+                        .frame(height: 1)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(title)
+            .accessibilityHint(isExpanded ? "Collapse previous messages" : "Expand previous messages")
+
+            if isExpanded {
+                ForEach(group.messages) { message in
+                    TurnTimelineMessageRow(
+                        message: message,
+                        isRetryAvailable: isRetryAvailable,
+                        cachedBlockInfoByMessageID: cachedBlockInfoByMessageID,
+                        planSessionSource: planSessionSource,
+                        allowsAssistantPlanFallbackRecovery: allowsAssistantPlanFallbackRecovery,
+                        completedTurnIDs: completedTurnIDs,
+                        threadMessagesForPlanMatching: threadMessagesForPlanMatching,
+                        planMatchingFingerprint: planMatchingFingerprint,
+                        newestStreamingMessageID: newestStreamingMessageID,
+                        autoScrollMode: autoScrollMode,
+                        onRetryUserMessage: onRetryUserMessage,
+                        onTapAssistantRevert: onTapAssistantRevert,
+                        onTapSubagent: onTapSubagent
+                    )
+                }
+            }
+        }
+        .id(group.id)
+    }
+}
+
 private struct TurnTimelineRowsSection: View {
     let shouldWarmRecentTailProgressively: Bool
     let hasEarlierMessages: Bool
@@ -318,6 +291,22 @@ private struct TurnTimelineRowsSection: View {
                 )
             case .toolBurst(let group):
                 TurnTimelineToolBurstView(
+                    group: group,
+                    isRetryAvailable: isRetryAvailable,
+                    cachedBlockInfoByMessageID: cachedBlockInfoByMessageID,
+                    planSessionSource: planSessionSource,
+                    allowsAssistantPlanFallbackRecovery: allowsAssistantPlanFallbackRecovery,
+                    completedTurnIDs: completedTurnIDs,
+                    threadMessagesForPlanMatching: threadMessagesForPlanMatching,
+                    planMatchingFingerprint: planMatchingFingerprint,
+                    newestStreamingMessageID: newestStreamingMessageID,
+                    autoScrollMode: autoScrollMode,
+                    onRetryUserMessage: onRetryUserMessage,
+                    onTapAssistantRevert: onTapAssistantRevert,
+                    onTapSubagent: onTapSubagent
+                )
+            case .previousMessages(let group):
+                TurnTimelinePreviousMessagesView(
                     group: group,
                     isRetryAvailable: isRetryAvailable,
                     cachedBlockInfoByMessageID: cachedBlockInfoByMessageID,
@@ -455,7 +444,10 @@ struct TurnTimelineView<EmptyState: View, Composer: View>: View {
         if key == cachedRenderItemsInputKey, !cachedRenderItems.isEmpty {
             return cachedRenderItems
         }
-        return TurnTimelineRenderProjection.project(messages: Array(visibleMessages))
+        return TurnTimelineRenderProjection.project(
+            messages: Array(visibleMessages),
+            completedTurnIDs: completedTurnIDs
+        )
     }
 
     private var hasEarlierMessages: Bool {
@@ -501,6 +493,7 @@ struct TurnTimelineView<EmptyState: View, Composer: View>: View {
     private func renderItemsInputKey(for messages: ArraySlice<CodexMessage>) -> Int {
         var hasher = Hasher()
         hasher.combine(messages.count)
+        hasher.combine(completedTurnIDs)
         for message in messages {
             hasher.combine(message.id)
             hasher.combine(message.role)
@@ -682,6 +675,11 @@ struct TurnTimelineView<EmptyState: View, Composer: View>: View {
                         debugTimelineLog("latestTurnTerminalState changed to=\(String(describing: latestTurnTerminalState))")
                         recomputeBlockInfoIfNeeded()
                     }
+                    .onChange(of: completedTurnIDs) { _, _ in
+                        debugTimelineLog("completedTurnIDs changed count=\(completedTurnIDs.count)")
+                        recomputeRenderItemsIfNeeded()
+                        recomputeBlockInfoIfNeeded()
+                    }
                     .onChange(of: stoppedTurnIDs) { _, _ in
                         debugTimelineLog("stoppedTurnIDs changed count=\(stoppedTurnIDs.count)")
                         recomputeBlockInfoIfNeeded()
@@ -732,7 +730,10 @@ struct TurnTimelineView<EmptyState: View, Composer: View>: View {
         let key = renderItemsInputKey(for: visibleMessages)
         guard key != cachedRenderItemsInputKey || cachedRenderItems.isEmpty else { return }
         cachedRenderItemsInputKey = key
-        cachedRenderItems = TurnTimelineRenderProjection.project(messages: Array(visibleMessages))
+        cachedRenderItems = TurnTimelineRenderProjection.project(
+            messages: Array(visibleMessages),
+            completedTurnIDs: completedTurnIDs
+        )
     }
 
     private func recomputeBlockInfoIfNeeded() {
@@ -750,12 +751,21 @@ struct TurnTimelineView<EmptyState: View, Composer: View>: View {
             revertStatesByMessageID: assistantRevertStatesByMessageID
         )
 
-        let updated = [String: AssistantBlockAccessoryState](
+        var updated = [String: AssistantBlockAccessoryState](
             uniqueKeysWithValues: zip(visible, cachedBlockInfo).compactMap { message, blockText in
                 guard let blockText else { return nil }
                 return (message.id, blockText)
             }
         )
+        let collapsedFinalMessageIDs = TurnTimelineRenderProjection.collapsedFinalMessageIDs(
+            in: visible,
+            completedTurnIDs: completedTurnIDs
+        )
+        for message in visible where collapsedFinalMessageIDs.contains(message.id) {
+            guard let state = updated[message.id] else { continue }
+            let finalCopyText = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            updated[message.id] = state.replacingCopyText(finalCopyText.isEmpty ? nil : finalCopyText)
+        }
         if updated != cachedBlockInfoByMessageID {
             cachedBlockInfoByMessageID = updated
         }
@@ -774,6 +784,7 @@ struct TurnTimelineView<EmptyState: View, Composer: View>: View {
         hasher.combine(isThreadRunning)
         hasher.combine(activeTurnID)
         hasher.combine(latestTurnTerminalState)
+        hasher.combine(completedTurnIDs)
         hasher.combine(stoppedTurnIDs)
 
         for message in messages {

--- a/CodexMobile/CodexMobileTests/CodexServiceIncomingRunIndicatorTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceIncomingRunIndicatorTests.swift
@@ -42,6 +42,24 @@ final class CodexServiceIncomingRunIndicatorTests: XCTestCase {
         XCTAssertTrue(messages.first?.isStreaming == true)
     }
 
+    func testAssistantDeltaCoalescingMergesCumulativeSnapshotsBeforeFlush() {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let turnID = "turn-\(UUID().uuidString)"
+        let itemID = "item-\(UUID().uuidString)"
+
+        service.enqueueAssistantDelta(threadId: threadID, turnId: turnID, itemId: itemID, delta: "Yes")
+        service.enqueueAssistantDelta(threadId: threadID, turnId: turnID, itemId: itemID, delta: "Yes, the")
+        service.enqueueAssistantDelta(threadId: threadID, turnId: turnID, itemId: itemID, delta: "Yes, the imagegen skill")
+
+        service.flushAllPendingStreamingDeltas()
+
+        let messages = service.messages(for: threadID)
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages.first?.text, "Yes, the imagegen skill")
+        XCTAssertTrue(messages.first?.isStreaming == true)
+    }
+
     func testSystemDeltaCoalescingAppliesThinkingDeltasOnFlush() {
         let service = makeService()
         let threadID = "thread-\(UUID().uuidString)"

--- a/CodexMobile/CodexMobileTests/TurnTimelineReducerTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnTimelineReducerTests.swift
@@ -320,6 +320,111 @@ final class TurnTimelineReducerTests: XCTestCase {
         XCTAssertEqual(messageIDs, ["tool-1", "tool-2"])
     }
 
+    func testTimelineRenderProjectionCollapsesCompletedTurnBeforeFinalAnswer() {
+        let now = Date()
+        let messages = [
+            makeMessage(
+                id: "user",
+                threadID: "thread",
+                role: .user,
+                text: "Check Gmail",
+                createdAt: now,
+                turnID: "turn-1",
+                orderIndex: 1
+            ),
+            makeMessage(
+                id: "status",
+                threadID: "thread",
+                role: .assistant,
+                text: "I'll use the Gmail connector.",
+                createdAt: now.addingTimeInterval(1),
+                turnID: "turn-1",
+                itemID: "status-item",
+                orderIndex: 2
+            ),
+            makeMessage(
+                id: "tool",
+                threadID: "thread",
+                role: .system,
+                kind: .toolActivity,
+                text: "Read inbox",
+                createdAt: now.addingTimeInterval(2),
+                turnID: "turn-1",
+                itemID: "tool-item",
+                orderIndex: 3
+            ),
+            makeMessage(
+                id: "final",
+                threadID: "thread",
+                role: .assistant,
+                text: "Latest TestFlight version: 1.4 (124).",
+                createdAt: now.addingTimeInterval(3),
+                turnID: "turn-1",
+                itemID: "final-item",
+                orderIndex: 4
+            ),
+        ]
+
+        let items = TurnTimelineRenderProjection.project(
+            messages: messages,
+            completedTurnIDs: ["turn-1"]
+        )
+
+        XCTAssertEqual(items.count, 3)
+        guard case .message(let user) = items[0],
+              case .previousMessages(let previousGroup) = items[1],
+              case .message(let final) = items[2] else {
+            return XCTFail("Expected user, previous-messages disclosure, final answer")
+        }
+
+        XCTAssertEqual(user.id, "user")
+        XCTAssertEqual(previousGroup.finalMessageID, "final")
+        XCTAssertEqual(previousGroup.hiddenCount, 2)
+        XCTAssertEqual(previousGroup.messages.map(\.id), ["status", "tool"])
+        XCTAssertEqual(final.id, "final")
+        XCTAssertEqual(
+            TurnTimelineRenderProjection.collapsedFinalMessageIDs(
+                in: messages,
+                completedTurnIDs: ["turn-1"]
+            ),
+            Set(["final"])
+        )
+    }
+
+    func testTimelineRenderProjectionKeepsRunningTurnExpandedBeforeFinalAnswer() {
+        let now = Date()
+        let messages = [
+            makeMessage(
+                id: "status",
+                threadID: "thread",
+                role: .assistant,
+                text: "Working",
+                createdAt: now,
+                turnID: "turn-1",
+                orderIndex: 1
+            ),
+            makeMessage(
+                id: "final",
+                threadID: "thread",
+                role: .assistant,
+                text: "Final",
+                createdAt: now.addingTimeInterval(1),
+                turnID: "turn-1",
+                orderIndex: 2
+            ),
+        ]
+
+        let items = TurnTimelineRenderProjection.project(messages: messages)
+        let messageIDs = items.compactMap { item -> String? in
+            if case .message(let message) = item {
+                return message.id
+            }
+            return nil
+        }
+
+        XCTAssertEqual(messageIDs, ["status", "final"])
+    }
+
     func testRemoveDuplicateAssistantMessagesByTurnAndText() {
         let now = Date()
         let messages = [


### PR DESCRIPTION
## Summary
- Merge assistant streaming deltas before flush so cumulative snapshots stay intact
- Split the timeline projection into a dedicated file and add completed-turn collapsing for pre-final messages
- Update block-copy state when collapsed final answers are shown
- Add unit coverage for delta coalescing and completed-turn projection behavior

## Testing
- Unit tests added for assistant delta coalescing and timeline render projection
- Not run (not requested)