### PR TITLE
Add safe workspace image previews

### DIFF
--- a/CodexMobile/CodexMobile/Services/CodexService+WorkspaceImages.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+WorkspaceImages.swift
@@ -1,0 +1,126 @@
+// FILE: CodexService+WorkspaceImages.swift
+// Purpose: Fetches local workspace/generated images through the paired Mac bridge on demand.
+// Layer: Service extension
+// Exports: WorkspaceImageReadResult, CodexService.readWorkspaceImage
+// Depends on: Foundation, CodexService, JSONValue
+
+import Foundation
+
+struct WorkspaceImageMetadata: Sendable {
+    let path: String
+    let fileName: String
+    let mimeType: String
+    let byteLength: Int
+    let mtimeMs: Double?
+}
+
+struct WorkspaceImageReadResult: Sendable {
+    let path: String
+    let fileName: String
+    let mimeType: String
+    let byteLength: Int
+    let mtimeMs: Double?
+    let data: Data?
+    let isNotModified: Bool
+
+    var metadata: WorkspaceImageMetadata {
+        WorkspaceImageMetadata(
+            path: path,
+            fileName: fileName,
+            mimeType: mimeType,
+            byteLength: byteLength,
+            mtimeMs: mtimeMs
+        )
+    }
+}
+
+extension CodexService {
+    // Loads image bytes only after the user asks to preview them, keeping timeline rows lightweight.
+    func readWorkspaceImage(
+        path: String,
+        cwd: String?,
+        cachedMetadata: WorkspaceImageMetadata? = nil
+    ) async throws -> WorkspaceImageReadResult {
+        let result = try await readWorkspaceImageObject(
+            path: path,
+            cwd: cwd,
+            includeData: true,
+            cachedMetadata: cachedMetadata
+        )
+        let metadata = parseWorkspaceImageMetadata(result: result, fallbackPath: path)
+        if result["notModified"]?.boolValue == true {
+            return WorkspaceImageReadResult(
+                path: metadata.path,
+                fileName: metadata.fileName,
+                mimeType: metadata.mimeType,
+                byteLength: metadata.byteLength,
+                mtimeMs: metadata.mtimeMs,
+                data: nil,
+                isNotModified: true
+            )
+        }
+
+        guard let dataBase64 = result["dataBase64"]?.stringValue else {
+            throw CodexServiceError.invalidResponse("Image preview response did not include image data.")
+        }
+        let data = try await WorkspaceImageBase64Decoder.decode(dataBase64)
+
+        return WorkspaceImageReadResult(
+            path: metadata.path,
+            fileName: metadata.fileName,
+            mimeType: metadata.mimeType,
+            byteLength: metadata.byteLength,
+            mtimeMs: metadata.mtimeMs,
+            data: data,
+            isNotModified: false
+        )
+    }
+
+    private func readWorkspaceImageObject(
+        path: String,
+        cwd: String?,
+        includeData: Bool,
+        cachedMetadata: WorkspaceImageMetadata? = nil
+    ) async throws -> RPCObject {
+        var params: [String: JSONValue] = [
+            "path": .string(path),
+            "includeData": .bool(includeData)
+        ]
+        if let cachedMetadata {
+            params["ifByteLength"] = .integer(cachedMetadata.byteLength)
+            if let mtimeMs = cachedMetadata.mtimeMs {
+                params["ifMtimeMs"] = .double(mtimeMs)
+            }
+        }
+        if let cwd = cwd?.trimmingCharacters(in: .whitespacesAndNewlines), !cwd.isEmpty {
+            params["cwd"] = .string(cwd)
+        }
+
+        let response = try await sendRequest(method: "workspace/readImage", params: .object(params))
+        guard let result = response.result?.objectValue else {
+            throw CodexServiceError.invalidResponse("Image preview response was missing a result.")
+        }
+        return result
+    }
+
+    private func parseWorkspaceImageMetadata(result: RPCObject, fallbackPath path: String) -> WorkspaceImageMetadata {
+        WorkspaceImageMetadata(
+            path: result["path"]?.stringValue ?? path,
+            fileName: result["fileName"]?.stringValue ?? (path as NSString).lastPathComponent,
+            mimeType: result["mimeType"]?.stringValue ?? "image",
+            byteLength: result["byteLength"]?.intValue ?? 0,
+            mtimeMs: result["mtimeMs"]?.doubleValue
+        )
+    }
+}
+
+private enum WorkspaceImageBase64Decoder {
+    static func decode(_ dataBase64: String) async throws -> Data {
+        try await Task.detached(priority: .userInitiated) {
+            guard let data = Data(base64Encoded: dataBase64) else {
+                throw CodexServiceError.invalidResponse("Image preview response did not include valid image data.")
+            }
+            return data
+        }.value
+    }
+}

--- a/CodexMobile/CodexMobile/Views/Turn/CommandExecutionViews.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/CommandExecutionViews.swift
@@ -34,6 +34,368 @@ struct CommandExecutionStatusModel {
     let accent: CommandExecutionStatusAccent
 }
 
+struct CommandOutputImageReference: Identifiable, Equatable {
+    let path: String
+
+    var id: String { path }
+
+    var fileName: String {
+        let basename = (path as NSString).lastPathComponent
+        return basename.isEmpty ? path : basename
+    }
+}
+
+struct AssistantMarkdownImageReference: Identifiable, Equatable {
+    let id: String
+    let path: String
+    let altText: String
+
+    init(path: String, altText: String, occurrenceIndex: Int) {
+        self.id = "\(occurrenceIndex)|\(path)"
+        self.path = path
+        self.altText = altText
+    }
+
+    var fileName: String {
+        let basename = (path as NSString).lastPathComponent
+        return basename.isEmpty ? path : basename
+    }
+
+    var displayTitle: String {
+        let trimmedAlt = altText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedAlt.isEmpty ? "Image" : trimmedAlt
+    }
+}
+
+enum AssistantMarkdownImageReferenceParser {
+    private static let markdownImageRegex = try? NSRegularExpression(pattern: #"!\[([^\]]*)\]\(([^)]+)\)"#)
+
+    static func references(in text: String) -> [AssistantMarkdownImageReference] {
+        var references: [AssistantMarkdownImageReference] = []
+        var isInsideFence = false
+        var occurrenceIndex = 0
+
+        for line in text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init) {
+            if isFenceDelimiter(line) {
+                isInsideFence.toggle()
+                continue
+            }
+            guard !isInsideFence else {
+                continue
+            }
+
+            references.append(contentsOf: validImageMatches(in: line).map { match in
+                defer { occurrenceIndex += 1 }
+                return AssistantMarkdownImageReference(
+                    path: match.path,
+                    altText: match.altText,
+                    occurrenceIndex: occurrenceIndex
+                )
+            })
+        }
+
+        return references
+    }
+
+    static func visibleTextRemovingImageSyntax(from text: String) -> String {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        var isInsideFence = false
+        let transformedLines = lines.compactMap { line -> String? in
+            if isFenceDelimiter(line) {
+                isInsideFence.toggle()
+                return line
+            }
+            guard !isInsideFence else {
+                return line
+            }
+
+            let matches = validImageMatches(in: line)
+            guard !matches.isEmpty else {
+                return line
+            }
+
+            let lineWithoutImageSyntax = NSMutableString(string: line)
+            for match in matches.reversed() {
+                lineWithoutImageSyntax.replaceCharacters(in: match.range, with: "")
+            }
+            if String(lineWithoutImageSyntax).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return nil
+            }
+
+            let transformedLine = NSMutableString(string: line)
+            for match in matches.reversed() {
+                let replacement = replacementText(for: match)
+                transformedLine.replaceCharacters(in: match.range, with: replacement)
+            }
+
+            let nextLine = String(transformedLine)
+            return nextLine.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? nil
+                : nextLine
+        }
+
+        return transformedLines.joined(separator: "\n")
+    }
+
+    private static func markdownImageMatches(in text: String) -> [(range: NSRange, altText: String, path: String)] {
+        guard let regex = markdownImageRegex else {
+            return []
+        }
+
+        let nsText = text as NSString
+        let protectedRanges = TurnMessageRegexCache.inlineCodeRanges(in: text)
+        return regex.matches(in: text, range: NSRange(location: 0, length: nsText.length)).compactMap { match in
+            guard !TurnMessageRegexCache.rangeOverlaps(match.range, protectedRanges: protectedRanges) else {
+                return nil
+            }
+            guard match.numberOfRanges > 2 else { return nil }
+            let alt = nsText.substring(with: match.range(at: 1))
+            let path = nsText.substring(with: match.range(at: 2))
+            return (match.range, alt, normalizedImagePath(path))
+        }
+    }
+
+    private static func validImageMatches(in text: String) -> [(range: NSRange, altText: String, path: String)] {
+        markdownImageMatches(in: text).filter { match in
+            CommandOutputImageReferenceParser.isImagePath(match.path)
+        }
+    }
+
+    private static func isFenceDelimiter(_ line: String) -> Bool {
+        line.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("```")
+    }
+
+    private static func normalizedImagePath(_ raw: String) -> String {
+        var candidate = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\"'`<>"))
+
+        if candidate.hasPrefix("file://") {
+            candidate = String(candidate.dropFirst("file://".count))
+        }
+        return candidate.removingPercentEncoding ?? candidate
+    }
+
+    private static func replacementText(for match: (range: NSRange, altText: String, path: String)) -> String {
+        let trimmedAlt = match.altText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedAlt.isEmpty {
+            return trimmedAlt
+        }
+
+        let basename = (match.path as NSString).lastPathComponent
+        return basename.isEmpty ? "Image" : basename
+    }
+}
+
+enum CommandOutputImageReferenceParser {
+    private static let imageExtensions: Set<String> = [
+        "jpg", "jpeg", "png", "gif", "webp", "heic", "heif"
+    ]
+
+    // Extracts a local image path without touching disk; the bridge validates and reads it on tap.
+    static func firstReference(
+        command: String,
+        outputTail: String,
+        cwd: String? = nil
+    ) -> CommandOutputImageReference? {
+        let listingDirectory = listingDirectory(from: command, cwd: cwd)
+        for candidate in outputCandidates(from: outputTail) {
+            if let path = normalizedImagePath(candidate, relativeTo: listingDirectory ?? cwd) {
+                return CommandOutputImageReference(path: path)
+            }
+        }
+
+        for candidate in commandCandidates(from: command) {
+            if let path = normalizedImagePath(candidate, relativeTo: cwd) {
+                return CommandOutputImageReference(path: path)
+            }
+        }
+
+        return nil
+    }
+
+    private static func outputCandidates(from outputTail: String) -> [String] {
+        var candidates = markdownLinkTargets(in: outputTail)
+        let lines = outputTail
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+        candidates.append(contentsOf: lines)
+        candidates.append(contentsOf: absoluteImagePathMatches(in: outputTail))
+        return candidates
+    }
+
+    private static func commandCandidates(from command: String) -> [String] {
+        shellTokens(from: unwrapShellCommand(command))
+    }
+
+    private static func markdownLinkTargets(in text: String) -> [String] {
+        let pattern = #"!?\[[^\]]*\]\(([^)]+)\)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return []
+        }
+        let nsText = text as NSString
+        return regex.matches(in: text, range: NSRange(location: 0, length: nsText.length)).compactMap { match in
+            guard match.numberOfRanges > 1 else { return nil }
+            return nsText.substring(with: match.range(at: 1))
+        }
+    }
+
+    private static func absoluteImagePathMatches(in text: String) -> [String] {
+        let extensionAlternation = imageExtensions.joined(separator: "|")
+        let pattern = #"(?i)(file://)?(/[^\s\]\)"'`]+\.("#
+            + extensionAlternation
+            + #"))"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return []
+        }
+        let nsText = text as NSString
+        return regex.matches(in: text, range: NSRange(location: 0, length: nsText.length)).compactMap { match in
+            guard match.numberOfRanges > 2 else { return nil }
+            return nsText.substring(with: match.range(at: 2))
+        }
+    }
+
+    private static func normalizedImagePath(_ raw: String, relativeTo baseDirectory: String?) -> String? {
+        var candidate = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\"'`()[]{}<>"))
+
+        while let last = candidate.last, ",.;:".contains(last) {
+            candidate.removeLast()
+        }
+
+        if candidate.hasPrefix("file://") {
+            candidate = String(candidate.dropFirst("file://".count))
+        }
+        candidate = candidate.removingPercentEncoding ?? candidate
+
+        guard isImagePath(candidate) else {
+            return nil
+        }
+
+        if candidate.hasPrefix("/") {
+            return candidate
+        }
+
+        guard let baseDirectory,
+              baseDirectory.hasPrefix("/") else {
+            return nil
+        }
+        return (baseDirectory as NSString).appendingPathComponent(candidate)
+    }
+
+    static func isImagePath(_ path: String) -> Bool {
+        let ext = (path as NSString).pathExtension.lowercased()
+        return imageExtensions.contains(ext)
+    }
+
+    private static func listingDirectory(from command: String, cwd: String?) -> String? {
+        let tokens = shellTokens(from: unwrapShellCommand(command))
+        guard let tool = tokens.first.map({ ($0 as NSString).lastPathComponent.lowercased() }),
+              tool == "ls" else {
+            return nil
+        }
+
+        let pathCandidates = tokens.dropFirst().filter { token in
+            !token.hasPrefix("-")
+        }
+        guard let listedPath = pathCandidates.last else {
+            return cwd
+        }
+        if isImagePath(listedPath) {
+            return (listedPath as NSString).deletingLastPathComponent
+        }
+        if listedPath.hasPrefix("/") {
+            return listedPath
+        }
+        guard let cwd, cwd.hasPrefix("/") else {
+            return nil
+        }
+        return (cwd as NSString).appendingPathComponent(listedPath)
+    }
+
+    private static func unwrapShellCommand(_ raw: String) -> String {
+        let tokens = shellTokens(from: raw)
+        guard !tokens.isEmpty else {
+            return raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        let shellNames = ["bash", "zsh", "sh", "fish"]
+        var shellIndex = 0
+        if tokens.count >= 2 {
+            let first = (tokens[0] as NSString).lastPathComponent.lowercased()
+            let second = (tokens[1] as NSString).lastPathComponent.lowercased()
+            if first == "env", shellNames.contains(second) {
+                shellIndex = 1
+            }
+        }
+
+        let shell = (tokens[shellIndex] as NSString).lastPathComponent.lowercased()
+        guard shellNames.contains(shell) else {
+            return raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        var index = shellIndex + 1
+        while index < tokens.count {
+            let token = tokens[index]
+            if ["-c", "-lc", "-cl", "-ic", "-ci"].contains(token) {
+                let commandStart = index + 1
+                guard commandStart < tokens.count else {
+                    return raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+                return tokens[commandStart...].joined(separator: " ")
+            }
+            index += 1
+        }
+
+        return raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func shellTokens(from value: String) -> [String] {
+        var tokens: [String] = []
+        var buffer = ""
+        var quote: Character?
+        var isEscaping = false
+
+        for character in value {
+            if isEscaping {
+                buffer.append(character)
+                isEscaping = false
+                continue
+            }
+            if character == "\\" {
+                isEscaping = true
+                continue
+            }
+            if let activeQuote = quote {
+                if character == activeQuote {
+                    quote = nil
+                } else {
+                    buffer.append(character)
+                }
+                continue
+            }
+            if character == "\"" || character == "'" {
+                quote = character
+                continue
+            }
+            if character.isWhitespace {
+                if !buffer.isEmpty {
+                    tokens.append(buffer)
+                    buffer = ""
+                }
+                continue
+            }
+            buffer.append(character)
+        }
+
+        if !buffer.isEmpty {
+            tokens.append(buffer)
+        }
+        return tokens
+    }
+}
+
 // MARK: - Card Body
 
 struct CommandExecutionCardBody: View {

--- a/CodexMobile/CodexMobile/Views/Turn/TurnConversationContainerView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnConversationContainerView.swift
@@ -19,6 +19,7 @@ struct TurnConversationContainerView: View {
     let planSessionSource: CodexPlanSessionSource?
     let allowsAssistantPlanFallbackRecovery: Bool
     let threadMessagesForPlanMatching: [CodexMessage]
+    let currentWorkingDirectory: String?
     let errorMessage: String?
     let composerRecoveryAccessory: AnyView?
     let shouldAnchorToAssistantResponse: Binding<Bool>
@@ -96,6 +97,7 @@ struct TurnConversationContainerView: View {
                 planSessionSource: planSessionSource,
                 allowsAssistantPlanFallbackRecovery: allowsAssistantPlanFallbackRecovery,
                 threadMessagesForPlanMatching: threadMessagesForPlanMatching,
+                currentWorkingDirectory: currentWorkingDirectory,
                 isRetryAvailable: !isThreadRunning,
                 errorMessage: errorMessage,
                 hidesErrorMessage: composerRecoveryAccessory != nil,

--- a/CodexMobile/CodexMobile/Views/Turn/TurnMessageCaches.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnMessageCaches.swift
@@ -7,7 +7,7 @@
 //   FileChangeBlockPresentationBuilder, PerFileDiffChunk, PerFileDiffParser, PerFileDiffChunkCache,
 //   CodeCommentDirectiveContentCache, FileChangeGroupingCache
 // Depends on: Foundation, CodexMessage, TurnMessageRegexCache, TurnFileChangeSummaryParser,
-//   TurnDiffLineKind, MarkdownRenderProfile, TurnMermaidRenderer
+//   TurnDiffLineKind, MarkdownRenderProfile, TurnMermaidRenderer, CommandExecutionViews
 
 import Foundation
 
@@ -206,6 +206,8 @@ struct FileChangeRenderState {
 struct MessageRowRenderModel {
     let codeCommentContent: CodeCommentDirectiveContent?
     let mermaidContent: MermaidMarkdownContent?
+    let assistantImageReferences: [AssistantMarkdownImageReference]
+    let assistantTextWithoutImageSyntax: String?
     let fileChangeState: FileChangeRenderState?
     let fileChangeGroups: [FileChangeGroup]
     let thinkingContent: ThinkingDisclosureContent?
@@ -216,6 +218,8 @@ struct MessageRowRenderModel {
     static let empty = MessageRowRenderModel(
         codeCommentContent: nil,
         mermaidContent: nil,
+        assistantImageReferences: [],
+        assistantTextWithoutImageSyntax: nil,
         fileChangeState: nil,
         fileChangeGroups: [],
         thinkingContent: nil,
@@ -243,6 +247,13 @@ enum MessageRowRenderModelCache {
     private static func buildModel(for message: CodexMessage, displayText: String) -> MessageRowRenderModel {
         switch message.role {
         case .assistant:
+            let assistantImageReferences = message.isStreaming
+                ? []
+                : AssistantMarkdownImageReferenceParser.references(in: displayText)
+            let assistantTextWithoutImageSyntax = assistantImageReferences.isEmpty
+                ? nil
+                : AssistantMarkdownImageReferenceParser.visibleTextRemovingImageSyntax(from: displayText)
+            let assistantRenderText = assistantTextWithoutImageSyntax ?? displayText
             // Defer Mermaid parsing until the assistant row is finalized so streaming deltas
             // keep the lightweight append-only path and avoid repeated parser/WebKit churn.
             return MessageRowRenderModel(
@@ -253,8 +264,10 @@ enum MessageRowRenderModelCache {
                     ? nil
                     : MermaidMarkdownContentCache.content(
                         messageID: message.id,
-                        text: displayText
+                        text: assistantRenderText
                     ),
+                assistantImageReferences: assistantImageReferences,
+                assistantTextWithoutImageSyntax: assistantTextWithoutImageSyntax,
                 fileChangeState: nil,
                 fileChangeGroups: [],
                 thinkingContent: nil,
@@ -274,6 +287,8 @@ enum MessageRowRenderModelCache {
                 return MessageRowRenderModel(
                     codeCommentContent: nil,
                     mermaidContent: nil,
+                    assistantImageReferences: [],
+                    assistantTextWithoutImageSyntax: nil,
                     fileChangeState: nil,
                     fileChangeGroups: [],
                     thinkingContent: thinkingText.isEmpty
@@ -293,6 +308,8 @@ enum MessageRowRenderModelCache {
                 return MessageRowRenderModel(
                     codeCommentContent: nil,
                     mermaidContent: nil,
+                    assistantImageReferences: [],
+                    assistantTextWithoutImageSyntax: nil,
                     fileChangeState: fileChangeState,
                     fileChangeGroups: FileChangeGroupingCache.grouped(messageID: message.id, entries: allEntries),
                     thinkingContent: nil,
@@ -306,6 +323,8 @@ enum MessageRowRenderModelCache {
                 return MessageRowRenderModel(
                     codeCommentContent: nil,
                     mermaidContent: nil,
+                    assistantImageReferences: [],
+                    assistantTextWithoutImageSyntax: nil,
                     fileChangeState: nil,
                     fileChangeGroups: [],
                     thinkingContent: nil,

--- a/CodexMobile/CodexMobile/Views/Turn/TurnMessageComponents.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnMessageComponents.swift
@@ -6,6 +6,7 @@
 //   ThinkingDisclosureParser, CodeCommentDirectiveParser, TurnFileChangeSummaryParser,
 //   TurnMessageCaches, TurnMarkdownModels, TurnDiffRenderer, CommandExecutionViews
 
+import ImageIO
 import SwiftUI
 import Textual
 import UIKit
@@ -646,6 +647,123 @@ private enum AttachmentPreviewImageResolver {
     }
 }
 
+private struct AssistantMarkdownImagePreviewButton: View {
+    let reference: AssistantMarkdownImageReference
+    let currentWorkingDirectory: String?
+
+    @Environment(CodexService.self) private var codex
+    @State private var isLoading = false
+    @State private var previewImage: PreviewImagePayload?
+    @State private var previewError: String?
+
+    var body: some View {
+        Button {
+            HapticFeedback.shared.triggerImpactFeedback(style: .light)
+            loadPreview()
+        } label: {
+            HStack(spacing: 8) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(Color(.secondarySystemFill))
+                    if isLoading {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Image(systemName: "photo")
+                            .font(AppFont.system(size: 14, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .frame(width: 32, height: 32)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(reference.displayTitle)
+                        .font(AppFont.caption(weight: .medium))
+                        .foregroundStyle(.secondary)
+                    Text(reference.fileName)
+                        .font(AppFont.mono(.caption))
+                        .foregroundStyle(.primary.opacity(0.78))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+
+                Spacer(minLength: 0)
+
+                Image(systemName: "chevron.right")
+                    .font(AppFont.system(size: 8, weight: .semibold))
+                    .foregroundStyle(.quaternary)
+            }
+            .padding(8)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color(.secondarySystemBackground).opacity(0.55))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(Color(.separator).opacity(0.55), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(isLoading)
+        .fullScreenCover(item: $previewImage) { payload in
+            ZoomableImagePreviewScreen(
+                payload: payload,
+                onDismiss: { previewImage = nil }
+            )
+        }
+        .alert("Image Preview", isPresented: previewErrorIsPresented, actions: {
+            Button("OK", role: .cancel) {
+                previewError = nil
+            }
+        }, message: {
+            Text(previewError ?? "")
+        })
+    }
+
+    private func loadPreview() {
+        guard !isLoading else { return }
+        isLoading = true
+
+        Task { @MainActor in
+            defer { isLoading = false }
+            do {
+                let cachedPreview = await WorkspaceImagePreviewCache.shared.cachedPreview(forPath: reference.path)
+                let result = try await codex.readWorkspaceImage(
+                    path: reference.path,
+                    cwd: currentWorkingDirectory,
+                    cachedMetadata: cachedPreview?.metadata
+                )
+                if result.isNotModified, let cachedPreview {
+                    previewImage = PreviewImagePayload(
+                        image: cachedPreview.payload.image,
+                        title: cachedPreview.metadata.fileName.isEmpty ? reference.fileName : cachedPreview.metadata.fileName
+                    )
+                    return
+                }
+
+                let decodedImage = try await WorkspaceImagePreviewCache.shared.preview(for: result)
+                previewImage = PreviewImagePayload(
+                    image: decodedImage.image,
+                    title: result.fileName.isEmpty ? reference.fileName : result.fileName
+                )
+            } catch {
+                previewError = error.localizedDescription
+            }
+        }
+    }
+
+    private var previewErrorIsPresented: Binding<Bool> {
+        Binding(
+            get: { previewError != nil },
+            set: { isPresented in
+                if !isPresented {
+                    previewError = nil
+                }
+            }
+        )
+    }
+}
+
 // ─── Message row ────────────────────────────────────────────────────
 
 private struct UserBubbleTextBlock<Content: View>: View {
@@ -709,6 +827,7 @@ struct MessageRow: View, Equatable {
     var allowsAssistantPlanFallbackRecovery: Bool = false
     var assistantTurnCompleted: Bool = false
     var threadMessagesForPlanMatching: [CodexMessage] = []
+    var currentWorkingDirectory: String? = nil
     // Narrow token for inferred-plan fallback invalidation; this changes only when the
     // relevant native structured prompts change, not on every unrelated service mutation.
     var planMatchingFingerprint: Int = 0
@@ -731,6 +850,7 @@ struct MessageRow: View, Equatable {
             && lhs.planSessionSource == rhs.planSessionSource
             && lhs.allowsAssistantPlanFallbackRecovery == rhs.allowsAssistantPlanFallbackRecovery
             && lhs.assistantTurnCompleted == rhs.assistantTurnCompleted
+            && lhs.currentWorkingDirectory == rhs.currentWorkingDirectory
             && lhs.planMatchingFingerprint == rhs.planMatchingFingerprint
             && lhs.showsStreamingAnimations == rhs.showsStreamingAnimations
     }
@@ -1054,7 +1174,16 @@ struct MessageRow: View, Equatable {
             }
             return assistantBlockAccessoryState?.copyText
         }()
-        let hasRenderableAssistantContent = !visibleAssistantText.isEmpty || proposedPlan != nil
+        let usesCachedAssistantImageContent = !message.isStreaming && visibleAssistantText == bodyText
+        let assistantImageReferences = usesCachedAssistantImageContent
+            ? renderModel.assistantImageReferences
+            : []
+        let visibleAssistantTextWithoutImageSyntax = assistantImageReferences.isEmpty
+            ? visibleAssistantText
+            : (renderModel.assistantTextWithoutImageSyntax ?? visibleAssistantText)
+        let hasRenderableAssistantContent = !visibleAssistantTextWithoutImageSyntax.isEmpty
+            || proposedPlan != nil
+            || !assistantImageReferences.isEmpty
         return VStack(alignment: .leading, spacing: 8) {
             if let commentContent, commentContent.hasFindings {
                 VStack(alignment: .leading, spacing: 10) {
@@ -1107,17 +1236,28 @@ struct MessageRow: View, Equatable {
                     )
                 } else if message.isStreaming {
                     StreamingAssistantMarkdownTextView(
-                        text: visibleAssistantText,
+                        text: visibleAssistantTextWithoutImageSyntax,
                         enablesSelection: enablesInlineMarkdownSelectionInTimeline,
                         constrainsToAvailableWidth: true
                     )
                 } else {
                     MarkdownTextView(
-                        text: visibleAssistantText,
+                        text: visibleAssistantTextWithoutImageSyntax,
                         profile: .assistantProse,
                         enablesSelection: enablesInlineMarkdownSelectionInTimeline,
                         constrainsToAvailableWidth: true
                     )
+                }
+
+                if !assistantImageReferences.isEmpty {
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(assistantImageReferences) { reference in
+                            AssistantMarkdownImagePreviewButton(
+                                reference: reference,
+                                currentWorkingDirectory: currentWorkingDirectory
+                            )
+                        }
+                    }
                 }
             }
 
@@ -1743,27 +1883,269 @@ private struct CommandExecutionStatusCard: View {
     let itemId: String?
     @Environment(CodexService.self) private var codex
     @State private var isShowingDetailSheet = false
+    @State private var isLoadingImagePreview = false
+    @State private var imagePreviewError: String?
+    @State private var previewImage: PreviewImagePayload?
 
     var body: some View {
-        CommandExecutionCardBody(
-            command: status.command,
-            statusLabel: status.statusLabel,
-            accent: status.accent
-        )
-            .contentShape(Rectangle())
-            .onTapGesture {
-                HapticFeedback.shared.triggerImpactFeedback(style: .light)
-                isShowingDetailSheet = true
+        VStack(alignment: .leading, spacing: 8) {
+            CommandExecutionCardBody(
+                command: status.command,
+                statusLabel: status.statusLabel,
+                accent: status.accent
+            )
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    HapticFeedback.shared.triggerImpactFeedback(style: .light)
+                    isShowingDetailSheet = true
+                }
+
+            if let imageReference {
+                commandImagePreviewButton(for: imageReference)
             }
+        }
             .sheet(isPresented: $isShowingDetailSheet) {
                 CommandExecutionDetailSheet(status: status, details: detailModel)
                     .presentationDetents([.fraction(0.35), .medium])
             }
+            .fullScreenCover(item: $previewImage) { payload in
+                ZoomableImagePreviewScreen(
+                    payload: payload,
+                    onDismiss: { previewImage = nil }
+                )
+            }
+            .alert("Image Preview", isPresented: imagePreviewErrorIsPresented, actions: {
+                Button("OK", role: .cancel) {
+                    imagePreviewError = nil
+                }
+            }, message: {
+                Text(imagePreviewError ?? "")
+            })
     }
 
     private var detailModel: CommandExecutionDetails? {
         guard let itemId else { return nil }
         return codex.commandExecutionDetailsByItemID[itemId]
+    }
+
+    private var imageReference: CommandOutputImageReference? {
+        guard let details = detailModel else {
+            return nil
+        }
+        return CommandOutputImageReferenceParser.firstReference(
+            command: details.fullCommand,
+            outputTail: details.outputTail,
+            cwd: details.cwd
+        )
+    }
+
+    private func commandImagePreviewButton(for reference: CommandOutputImageReference) -> some View {
+        Button {
+            HapticFeedback.shared.triggerImpactFeedback(style: .light)
+            loadImagePreview(reference)
+        } label: {
+            HStack(spacing: 8) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(Color(.secondarySystemFill))
+                    if isLoadingImagePreview {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Image(systemName: "photo")
+                            .font(AppFont.system(size: 14, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .frame(width: 32, height: 32)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Image")
+                        .font(AppFont.caption(weight: .medium))
+                        .foregroundStyle(.secondary)
+                    Text(reference.fileName)
+                        .font(AppFont.mono(.caption))
+                        .foregroundStyle(.primary.opacity(0.78))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+
+                Spacer(minLength: 0)
+
+                Image(systemName: "chevron.right")
+                    .font(AppFont.system(size: 8, weight: .semibold))
+                    .foregroundStyle(.quaternary)
+            }
+            .padding(8)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color(.secondarySystemBackground).opacity(0.55))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(Color(.separator).opacity(0.55), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(isLoadingImagePreview)
+    }
+
+    private func loadImagePreview(_ reference: CommandOutputImageReference) {
+        guard !isLoadingImagePreview else { return }
+        isLoadingImagePreview = true
+
+        Task { @MainActor in
+            defer { isLoadingImagePreview = false }
+            do {
+                let cachedPreview = await WorkspaceImagePreviewCache.shared.cachedPreview(forPath: reference.path)
+                let result = try await codex.readWorkspaceImage(
+                    path: reference.path,
+                    cwd: detailModel?.cwd,
+                    cachedMetadata: cachedPreview?.metadata
+                )
+                if result.isNotModified, let cachedPreview {
+                    previewImage = PreviewImagePayload(
+                        image: cachedPreview.payload.image,
+                        title: cachedPreview.metadata.fileName.isEmpty ? reference.fileName : cachedPreview.metadata.fileName
+                    )
+                    return
+                }
+
+                let decodedImage = try await WorkspaceImagePreviewCache.shared.preview(for: result)
+                previewImage = PreviewImagePayload(
+                    image: decodedImage.image,
+                    title: result.fileName.isEmpty ? reference.fileName : result.fileName
+                )
+            } catch {
+                imagePreviewError = error.localizedDescription
+            }
+        }
+    }
+
+    private var imagePreviewErrorIsPresented: Binding<Bool> {
+        Binding(
+            get: { imagePreviewError != nil },
+            set: { isPresented in
+                if !isPresented {
+                    imagePreviewError = nil
+                }
+            }
+        )
+    }
+}
+
+private struct CachedWorkspaceImagePreview: Sendable {
+    let metadata: WorkspaceImageMetadata
+    let payload: CommandImagePreviewPayload
+}
+
+private final class CommandImagePreviewPayload: @unchecked Sendable {
+    let image: UIImage
+
+    init(image: UIImage) {
+        self.image = image
+    }
+
+    var estimatedMemoryCost: Int {
+        guard let cgImage = image.cgImage else {
+            return 1
+        }
+        return max(cgImage.bytesPerRow * cgImage.height, 1)
+    }
+}
+
+private actor WorkspaceImagePreviewCache {
+    static let shared = WorkspaceImagePreviewCache()
+
+    private let cache = NSCache<NSString, CommandImagePreviewPayload>()
+    private var inFlightPreviews: [String: Task<CommandImagePreviewPayload, Error>] = [:]
+    private var latestMetadataByPath: [String: WorkspaceImageMetadata] = [:]
+    private var latestMetadataAccessOrder: [String] = []
+
+    private init() {
+        cache.countLimit = 24
+        cache.totalCostLimit = 80 * 1024 * 1024
+    }
+
+    func cachedPreview(forPath path: String) -> CachedWorkspaceImagePreview? {
+        guard let metadata = latestMetadataByPath[path],
+              let payload = cache.object(forKey: cacheKey(for: metadata) as NSString) else {
+            return nil
+        }
+        latestMetadataAccessOrder.removeAll { $0 == path }
+        latestMetadataAccessOrder.append(path)
+        return CachedWorkspaceImagePreview(metadata: metadata, payload: payload)
+    }
+
+    func preview(for result: WorkspaceImageReadResult) async throws -> CommandImagePreviewPayload {
+        let key = cacheKey(for: result.metadata)
+        let nsKey = key as NSString
+        if let cached = cache.object(forKey: nsKey) {
+            return cached
+        }
+        if let task = inFlightPreviews[key] {
+            return try await task.value
+        }
+
+        guard let data = result.data else {
+            throw CodexServiceError.invalidResponse("Cached image preview was unavailable.")
+        }
+        let task = Task(priority: .userInitiated) {
+            try await CommandImagePreviewDecoder.decode(data)
+        }
+        inFlightPreviews[key] = task
+        defer { inFlightPreviews[key] = nil }
+
+        let decodedImage = try await task.value
+        cache.setObject(decodedImage, forKey: nsKey, cost: decodedImage.estimatedMemoryCost)
+        rememberMetadata(result.metadata)
+        return decodedImage
+    }
+
+    private func cacheKey(for metadata: WorkspaceImageMetadata) -> String {
+        let mtimeMs = metadata.mtimeMs.map { Int64($0.rounded()) } ?? -1
+        return "\(metadata.path)|\(metadata.byteLength)|\(mtimeMs)"
+    }
+
+    private func rememberMetadata(_ metadata: WorkspaceImageMetadata) {
+        latestMetadataByPath[metadata.path] = metadata
+        latestMetadataAccessOrder.removeAll { $0 == metadata.path }
+        latestMetadataAccessOrder.append(metadata.path)
+
+        while latestMetadataAccessOrder.count > 64, let evictedPath = latestMetadataAccessOrder.first {
+            latestMetadataAccessOrder.removeFirst()
+            latestMetadataByPath[evictedPath] = nil
+        }
+    }
+}
+
+private enum CommandImagePreviewDecoder {
+    private static let maxPreviewPixelDimension = 2_400
+
+    // Downsamples and prepares the preview off the main actor before presenting it.
+    static func decode(_ data: Data) async throws -> CommandImagePreviewPayload {
+        try await Task.detached(priority: .userInitiated) {
+            let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+            guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else {
+                throw CodexServiceError.invalidResponse("The file is not a readable image.")
+            }
+
+            let thumbnailOptions = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceCreateThumbnailWithTransform: true,
+                kCGImageSourceShouldCacheImmediately: true,
+                kCGImageSourceThumbnailMaxPixelSize: maxPreviewPixelDimension,
+            ] as CFDictionary
+
+            if let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions) {
+                return CommandImagePreviewPayload(image: UIImage(cgImage: cgImage))
+            }
+
+            guard let image = UIImage(data: data) else {
+                throw CodexServiceError.invalidResponse("The file is not a readable image.")
+            }
+            return CommandImagePreviewPayload(image: image.preparingForDisplay() ?? image)
+        }.value
     }
 }
 

--- a/CodexMobile/CodexMobile/Views/Turn/TurnMessageComponents.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnMessageComponents.swift
@@ -2103,7 +2103,7 @@ private actor WorkspaceImagePreviewCache {
     }
 
     private func cacheKey(for metadata: WorkspaceImageMetadata) -> String {
-        let mtimeMs = metadata.mtimeMs.map { Int64($0.rounded()) } ?? -1
+        let mtimeMs = metadata.mtimeMs.map { String($0.bitPattern) } ?? "missing"
         return "\(metadata.path)|\(metadata.byteLength)|\(mtimeMs)"
     }
 

--- a/CodexMobile/CodexMobile/Views/Turn/TurnTimelineView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnTimelineView.swift
@@ -134,6 +134,7 @@ private struct TurnTimelineMessageRow: View {
     let allowsAssistantPlanFallbackRecovery: Bool
     let completedTurnIDs: Set<String>
     let threadMessagesForPlanMatching: [CodexMessage]
+    let currentWorkingDirectory: String?
     let planMatchingFingerprint: Int
     let newestStreamingMessageID: String?
     let autoScrollMode: TurnAutoScrollMode
@@ -151,6 +152,7 @@ private struct TurnTimelineMessageRow: View {
             allowsAssistantPlanFallbackRecovery: allowsAssistantPlanFallbackRecovery,
             assistantTurnCompleted: message.turnId.map(completedTurnIDs.contains) ?? false,
             threadMessagesForPlanMatching: threadMessagesForPlanMatching,
+            currentWorkingDirectory: currentWorkingDirectory,
             planMatchingFingerprint: planMatchingFingerprint,
             showsStreamingAnimations: autoScrollMode == .followBottom
                 && message.id == newestStreamingMessageID,
@@ -170,6 +172,7 @@ private struct TurnTimelineToolBurstView: View {
     let allowsAssistantPlanFallbackRecovery: Bool
     let completedTurnIDs: Set<String>
     let threadMessagesForPlanMatching: [CodexMessage]
+    let currentWorkingDirectory: String?
     let planMatchingFingerprint: Int
     let newestStreamingMessageID: String?
     let autoScrollMode: TurnAutoScrollMode
@@ -198,6 +201,7 @@ private struct TurnTimelineToolBurstView: View {
                     allowsAssistantPlanFallbackRecovery: allowsAssistantPlanFallbackRecovery,
                     completedTurnIDs: completedTurnIDs,
                     threadMessagesForPlanMatching: threadMessagesForPlanMatching,
+                    currentWorkingDirectory: currentWorkingDirectory,
                     planMatchingFingerprint: planMatchingFingerprint,
                     newestStreamingMessageID: newestStreamingMessageID,
                     autoScrollMode: autoScrollMode,
@@ -244,6 +248,7 @@ private struct TurnTimelineToolBurstView: View {
                         allowsAssistantPlanFallbackRecovery: allowsAssistantPlanFallbackRecovery,
                         completedTurnIDs: completedTurnIDs,
                         threadMessagesForPlanMatching: threadMessagesForPlanMatching,
+                        currentWorkingDirectory: currentWorkingDirectory,
                         planMatchingFingerprint: planMatchingFingerprint,
                         newestStreamingMessageID: newestStreamingMessageID,
                         autoScrollMode: autoScrollMode,
@@ -267,6 +272,7 @@ private struct TurnTimelineRowsSection: View {
     let allowsAssistantPlanFallbackRecovery: Bool
     let completedTurnIDs: Set<String>
     let threadMessagesForPlanMatching: [CodexMessage]
+    let currentWorkingDirectory: String?
     let planMatchingFingerprint: Int
     let newestStreamingMessageID: String?
     let autoScrollMode: TurnAutoScrollMode
@@ -309,6 +315,7 @@ private struct TurnTimelineRowsSection: View {
                     allowsAssistantPlanFallbackRecovery: allowsAssistantPlanFallbackRecovery,
                     completedTurnIDs: completedTurnIDs,
                     threadMessagesForPlanMatching: threadMessagesForPlanMatching,
+                    currentWorkingDirectory: currentWorkingDirectory,
                     planMatchingFingerprint: planMatchingFingerprint,
                     newestStreamingMessageID: newestStreamingMessageID,
                     autoScrollMode: autoScrollMode,
@@ -325,6 +332,7 @@ private struct TurnTimelineRowsSection: View {
                     allowsAssistantPlanFallbackRecovery: allowsAssistantPlanFallbackRecovery,
                     completedTurnIDs: completedTurnIDs,
                     threadMessagesForPlanMatching: threadMessagesForPlanMatching,
+                    currentWorkingDirectory: currentWorkingDirectory,
                     planMatchingFingerprint: planMatchingFingerprint,
                     newestStreamingMessageID: newestStreamingMessageID,
                     autoScrollMode: autoScrollMode,
@@ -400,6 +408,7 @@ struct TurnTimelineView<EmptyState: View, Composer: View>: View {
     let planSessionSource: CodexPlanSessionSource?
     let allowsAssistantPlanFallbackRecovery: Bool
     let threadMessagesForPlanMatching: [CodexMessage]
+    let currentWorkingDirectory: String?
     let isRetryAvailable: Bool
     let errorMessage: String?
     let hidesErrorMessage: Bool
@@ -563,6 +572,7 @@ struct TurnTimelineView<EmptyState: View, Composer: View>: View {
                                 allowsAssistantPlanFallbackRecovery: allowsAssistantPlanFallbackRecovery,
                                 completedTurnIDs: completedTurnIDs,
                                 threadMessagesForPlanMatching: threadMessagesForPlanMatching,
+                                currentWorkingDirectory: currentWorkingDirectory,
                                 planMatchingFingerprint: planMatchingFingerprint,
                                 newestStreamingMessageID: cachedNewestStreamingMessageID,
                                 autoScrollMode: autoScrollMode,

--- a/CodexMobile/CodexMobile/Views/Turn/TurnView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnView.swift
@@ -108,6 +108,7 @@ struct TurnView: View {
                 planSessionSource: planSessionSource,
                 allowsAssistantPlanFallbackRecovery: planSessionSource == .compatibilityFallback,
                 threadMessagesForPlanMatching: renderSnapshot.planMatchingMessages,
+                currentWorkingDirectory: gitWorkingDirectory,
                 errorMessage: codex.lastErrorMessage,
                 composerRecoveryAccessory: composerRecoveryAccessory,
                 shouldAnchorToAssistantResponse: shouldAnchorToAssistantResponseBinding,

--- a/CodexMobile/CodexMobileTests/TurnMessageCachesTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnMessageCachesTests.swift
@@ -79,6 +79,127 @@ final class TurnMessageCachesTests: XCTestCase {
         XCTAssertEqual(stopped?.statusLabel, "stopped")
     }
 
+    func testCommandOutputImageReferenceParserCombinesLsDirectoryAndOutputFile() {
+        let reference = CommandOutputImageReferenceParser.firstReference(
+            command: "/bin/zsh -lc 'ls -1 /Users/example/.codex/generated_images/turn-123'",
+            outputTail: "hero image.png\nnotes.txt",
+            cwd: "/Users/example/project"
+        )
+
+        XCTAssertEqual(
+            reference?.path,
+            "/Users/example/.codex/generated_images/turn-123/hero image.png"
+        )
+        XCTAssertEqual(reference?.fileName, "hero image.png")
+    }
+
+    func testCommandOutputImageReferenceParserFindsMarkdownImagePath() {
+        let reference = CommandOutputImageReferenceParser.firstReference(
+            command: "echo done",
+            outputTail: "Created ![preview](/Users/example/project/out/mockup.webp)",
+            cwd: "/Users/example/project"
+        )
+
+        XCTAssertEqual(reference?.path, "/Users/example/project/out/mockup.webp")
+    }
+
+    func testAssistantMarkdownImageReferenceParserFindsLocalImage() {
+        let references = AssistantMarkdownImageReferenceParser.references(
+            in: "Here it is:\n![wing](/Users/example/.codex/generated_images/turn/wing.png)"
+        )
+
+        XCTAssertEqual(references.count, 1)
+        XCTAssertEqual(references.first?.path, "/Users/example/.codex/generated_images/turn/wing.png")
+        XCTAssertEqual(references.first?.displayTitle, "wing")
+    }
+
+    func testAssistantMarkdownImageReferenceParserKeepsDuplicatePathsDistinct() {
+        let references = AssistantMarkdownImageReferenceParser.references(
+            in: """
+            ![first](/Users/example/wing.png)
+            ![second](/Users/example/wing.png)
+            """
+        )
+
+        XCTAssertEqual(references.map(\.path), [
+            "/Users/example/wing.png",
+            "/Users/example/wing.png"
+        ])
+        XCTAssertEqual(Set(references.map(\.id)).count, 2)
+    }
+
+    func testAssistantMarkdownImageReferenceParserRemovesImageOnlyLines() {
+        let visibleText = AssistantMarkdownImageReferenceParser.visibleTextRemovingImageSyntax(
+            from: "Before\n![wing](/Users/example/wing.png)\nAfter"
+        )
+
+        XCTAssertEqual(visibleText, "Before\nAfter")
+    }
+
+    func testAssistantMarkdownImageReferenceParserIgnoresCodeExamples() {
+        let text = """
+        Inline `![inline](/Users/example/inline.png)` stays literal.
+
+        ```markdown
+        ![fenced](/Users/example/fenced.png)
+        ```
+
+        ![real](/Users/example/real.png)
+        """
+
+        let references = AssistantMarkdownImageReferenceParser.references(in: text)
+        let visibleText = AssistantMarkdownImageReferenceParser.visibleTextRemovingImageSyntax(from: text)
+
+        XCTAssertEqual(references.map(\.path), ["/Users/example/real.png"])
+        XCTAssertTrue(visibleText.contains("`![inline](/Users/example/inline.png)`"))
+        XCTAssertTrue(visibleText.contains("![fenced](/Users/example/fenced.png)"))
+        XCTAssertFalse(visibleText.contains("![real](/Users/example/real.png)"))
+    }
+
+    func testMessageRowRenderModelCachesAssistantImageReferences() {
+        let text = "Before\n![wing](/Users/example/wing.png)\nAfter"
+        let message = CodexMessage(
+            id: "assistant-image-cache",
+            threadId: "thread-1",
+            role: .assistant,
+            text: text
+        )
+
+        let renderModel = MessageRowRenderModelCache.model(for: message, displayText: text)
+
+        XCTAssertEqual(renderModel.assistantImageReferences.first?.path, "/Users/example/wing.png")
+        XCTAssertEqual(renderModel.assistantTextWithoutImageSyntax, "Before\nAfter")
+    }
+
+    func testMessageRowRenderModelStripsImagesBeforeMermaidParsing() {
+        let text = """
+        Intro
+        ![wing](/Users/example/wing.png)
+        ```mermaid
+        graph TD
+          A --> B
+        ```
+        Outro
+        """
+        let message = CodexMessage(
+            id: "assistant-image-mermaid-cache",
+            threadId: "thread-1",
+            role: .assistant,
+            text: text
+        )
+
+        let renderModel = MessageRowRenderModelCache.model(for: message, displayText: text)
+        let markdownSegments = renderModel.mermaidContent?.segments.compactMap { segment -> String? in
+            if case .markdown(let markdown) = segment.kind {
+                return markdown
+            }
+            return nil
+        } ?? []
+
+        XCTAssertEqual(renderModel.assistantImageReferences.first?.path, "/Users/example/wing.png")
+        XCTAssertFalse(markdownSegments.joined(separator: "\n").contains("![wing]"))
+    }
+
     func testFileChangeRenderCacheSeparatesEqualLengthTexts() {
         let first = FileChangeSystemRenderCache.renderState(
             messageID: "file-change-cache",

--- a/phodex-bridge/src/workspace-handler.js
+++ b/phodex-bridge/src/workspace-handler.js
@@ -13,6 +13,16 @@ const { gitStatus } = require("./git-handler");
 
 const execFileAsync = promisify(execFile);
 const GIT_TIMEOUT_MS = 30_000;
+const MAX_IMAGE_READ_BYTES = 8 * 1024 * 1024;
+const IMAGE_MIME_TYPES_BY_EXTENSION = new Map([
+  [".jpg", "image/jpeg"],
+  [".jpeg", "image/jpeg"],
+  [".png", "image/png"],
+  [".gif", "image/gif"],
+  [".webp", "image/webp"],
+  [".heic", "image/heic"],
+  [".heif", "image/heif"],
+]);
 const repoMutationLocks = new Map();
 
 function handleWorkspaceRequest(rawMessage, sendResponse) {
@@ -54,6 +64,10 @@ function handleWorkspaceRequest(rawMessage, sendResponse) {
 }
 
 async function handleWorkspaceMethod(method, params) {
+  if (method === "workspace/readImage") {
+    return workspaceReadImage(params);
+  }
+
   const cwd = await resolveWorkspaceCwd(params);
   const repoRoot = await resolveRepoRoot(cwd);
 
@@ -65,6 +79,88 @@ async function handleWorkspaceMethod(method, params) {
     default:
       throw workspaceError("unknown_method", `Unknown workspace method: ${method}`);
   }
+}
+
+// Reads only recognized local image files, and only from the bound repo or Codex generated-images cache.
+async function workspaceReadImage(params) {
+  const requestedPath = firstNonEmptyString([params.path, params.filePath, params.localPath]);
+  if (!requestedPath) {
+    throw workspaceError("missing_image_path", "The request must include an image path.");
+  }
+
+  const cwd = firstNonEmptyString([params.cwd, params.currentWorkingDirectory])
+    ? await resolveWorkspaceCwd(params)
+    : null;
+  const imagePath = path.isAbsolute(requestedPath)
+    ? path.resolve(requestedPath)
+    : path.resolve(cwd || process.cwd(), requestedPath);
+  const extension = path.extname(imagePath).toLowerCase();
+  const mimeType = IMAGE_MIME_TYPES_BY_EXTENSION.get(extension);
+  if (!mimeType) {
+    throw workspaceError("unsupported_image_type", "Only local image files can be previewed.");
+  }
+
+  const [realImagePath, realGeneratedImagesRoot] = await Promise.all([
+    realpathOrNull(imagePath),
+    realpathOrNull(path.join(os.homedir(), ".codex", "generated_images")),
+  ]);
+  if (!realImagePath) {
+    throw workspaceError("image_not_found", "The image file no longer exists on this Mac.");
+  }
+
+  const repoRoot = cwd ? await resolveRepoRoot(cwd).catch(() => null) : null;
+  const realRepoRoot = repoRoot ? await realpathOrNull(repoRoot) : null;
+  const isAllowed =
+    (realRepoRoot && isPathInside(realImagePath, realRepoRoot))
+    || (realGeneratedImagesRoot && isPathInside(realImagePath, realGeneratedImagesRoot));
+  if (!isAllowed) {
+    throw workspaceError("image_path_not_allowed", "Only images in this workspace or Codex generated images can be previewed.");
+  }
+
+  const stat = await fs.promises.stat(realImagePath);
+  if (!stat.isFile()) {
+    throw workspaceError("image_not_found", "The image path is not a file.");
+  }
+  if (stat.size > MAX_IMAGE_READ_BYTES) {
+    throw workspaceError(
+      "image_too_large",
+      "This image is too large to send to the phone. Open it on the Mac or move a smaller preview into the workspace."
+    );
+  }
+
+  const includeData = params.includeData !== false && params.metadataOnly !== true;
+  const result = {
+    path: realImagePath,
+    fileName: path.basename(realImagePath),
+    mimeType,
+    byteLength: stat.size,
+    mtimeMs: stat.mtimeMs,
+  };
+  if (!includeData) {
+    return result;
+  }
+  if (isUnchangedImageRead(params, stat)) {
+    return {
+      ...result,
+      notModified: true,
+    };
+  }
+
+  const data = await fs.promises.readFile(realImagePath);
+  return {
+    ...result,
+    byteLength: data.length,
+    dataBase64: data.toString("base64"),
+  };
+}
+
+function isUnchangedImageRead(params, stat) {
+  const cachedByteLength = Number(params.ifByteLength);
+  const cachedMtimeMs = Number(params.ifMtimeMs);
+  return Number.isFinite(cachedByteLength)
+    && Number.isFinite(cachedMtimeMs)
+    && cachedByteLength === stat.size
+    && cachedMtimeMs === stat.mtimeMs;
 }
 
 // Validates the reverse patch against the current tree without writing repo files.
@@ -445,6 +541,19 @@ function isExistingDirectory(candidatePath) {
   }
 }
 
+async function realpathOrNull(candidatePath) {
+  try {
+    return await fs.promises.realpath(candidatePath);
+  } catch {
+    return null;
+  }
+}
+
+function isPathInside(candidatePath, rootPath) {
+  const relative = path.relative(rootPath, candidatePath);
+  return relative === "" || (relative && !relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
 function workspaceError(errorCode, userMessage) {
   const err = new Error(userMessage);
   err.errorCode = errorCode;
@@ -461,4 +570,4 @@ function git(cwd, ...args) {
     });
 }
 
-module.exports = { handleWorkspaceRequest };
+module.exports = { handleWorkspaceMethod, handleWorkspaceRequest };

--- a/phodex-bridge/test/workspace-image.test.js
+++ b/phodex-bridge/test/workspace-image.test.js
@@ -1,0 +1,139 @@
+// FILE: workspace-image.test.js
+// Purpose: Verifies bridge-side local image preview reads stay scoped and size-safe.
+// Layer: Unit test
+// Exports: node:test suite
+// Depends on: node:test, node:assert/strict, fs, os, path, ../src/workspace-handler
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { handleWorkspaceMethod } = require("../src/workspace-handler");
+
+test("workspace/readImage returns base64 image data for a file inside cwd", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-image-"));
+  execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+  const imagePath = path.join(tempDir, "preview.png");
+  const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+  fs.writeFileSync(imagePath, bytes);
+
+  const result = await handleWorkspaceMethod("workspace/readImage", {
+    cwd: tempDir,
+    path: imagePath,
+  });
+
+  assert.equal(result.path, fs.realpathSync(imagePath));
+  assert.equal(result.fileName, "preview.png");
+  assert.equal(result.mimeType, "image/png");
+  assert.equal(result.byteLength, bytes.length);
+  assert.equal(typeof result.mtimeMs, "number");
+  assert.equal(result.dataBase64, bytes.toString("base64"));
+});
+
+test("workspace/readImage can return metadata without image bytes", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-image-"));
+  execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+  const imagePath = path.join(tempDir, "preview.png");
+  const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+  fs.writeFileSync(imagePath, bytes);
+
+  const result = await handleWorkspaceMethod("workspace/readImage", {
+    cwd: tempDir,
+    path: imagePath,
+    includeData: false,
+  });
+
+  assert.equal(result.path, fs.realpathSync(imagePath));
+  assert.equal(result.byteLength, bytes.length);
+  assert.equal(typeof result.mtimeMs, "number");
+  assert.equal(result.dataBase64, undefined);
+});
+
+test("workspace/readImage skips bytes when cached metadata still matches", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-image-"));
+  execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+  const imagePath = path.join(tempDir, "preview.png");
+  const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+  fs.writeFileSync(imagePath, bytes);
+
+  const first = await handleWorkspaceMethod("workspace/readImage", {
+    cwd: tempDir,
+    path: imagePath,
+  });
+  const second = await handleWorkspaceMethod("workspace/readImage", {
+    cwd: tempDir,
+    path: imagePath,
+    ifByteLength: first.byteLength,
+    ifMtimeMs: first.mtimeMs,
+  });
+
+  assert.equal(second.notModified, true);
+  assert.equal(second.byteLength, bytes.length);
+  assert.equal(second.dataBase64, undefined);
+});
+
+test("workspace/readImage does not round cached mtime checks", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-image-"));
+  execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+  const imagePath = path.join(tempDir, "preview.png");
+  const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+  fs.writeFileSync(imagePath, bytes);
+
+  const first = await handleWorkspaceMethod("workspace/readImage", {
+    cwd: tempDir,
+    path: imagePath,
+  });
+  const second = await handleWorkspaceMethod("workspace/readImage", {
+    cwd: tempDir,
+    path: imagePath,
+    ifByteLength: first.byteLength,
+    ifMtimeMs: first.mtimeMs + 0.4,
+  });
+
+  assert.equal(second.notModified, undefined);
+  assert.equal(second.dataBase64, bytes.toString("base64"));
+});
+
+test("workspace/readImage rejects non-image paths", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-image-"));
+  execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+  const textPath = path.join(tempDir, "notes.txt");
+  fs.writeFileSync(textPath, "not an image");
+
+  await assert.rejects(
+    () => handleWorkspaceMethod("workspace/readImage", {
+      cwd: tempDir,
+      path: textPath,
+    }),
+    /Only local image files/
+  );
+});
+
+test("workspace/readImage rejects workspace images when cwd is missing", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-image-"));
+  const imagePath = path.join(tempDir, "preview.png");
+  fs.writeFileSync(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+  await assert.rejects(
+    () => handleWorkspaceMethod("workspace/readImage", {
+      path: imagePath,
+    }),
+    /Only images in this workspace/
+  );
+});
+
+test("workspace/readImage rejects cwd widening outside a repository", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-image-"));
+  const imagePath = path.join(tempDir, "preview.png");
+  fs.writeFileSync(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+  await assert.rejects(
+    () => handleWorkspaceMethod("workspace/readImage", {
+      cwd: "/",
+      path: imagePath,
+    }),
+    /Only images in this workspace/
+  );
+});


### PR DESCRIPTION
## Summary
- Add secure workspace image reads in the bridge, scoped to the current repo or generated images only
- Render assistant image Markdown as tappable preview chips and pass workspace cwd through the turn views
- Cache downsampled previews on iOS and avoid repeated full-image work when the file has not changed
- Improve Markdown parsing so image syntax does not rewrite fenced code examples and Mermaid content stays clean

## Testing
- Swift parse check passed for the touched turn/service files
- Bridge unit tests passed for image read safety and cache invalidation
- Basic diff sanity checks passed