### PR TITLE
Add local image sync and timeline recovery improvements

### DIFF
--- a/CodexMobile/CodexMobile/Services/CodexService+History.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+History.swift
@@ -76,7 +76,7 @@ extension CodexService {
             guard let turnObject = turnValue.objectValue else { continue }
             let turnID = turnObject["id"]?.stringValue
             let turnTimestamp = decodeHistoryTimestamp(from: turnObject)
-            let turnCompleted = isCompletedHistoryTurn(turnObject)
+            let turnCompleted = historyTurnTerminalState(turnObject) == .completed
             let items = turnObject["items"]?.arrayValue ?? []
 
             for itemValue in items {
@@ -132,6 +132,21 @@ extension CodexService {
                         itemId: itemID,
                         createdAt: timestamp,
                         attachments: imageAttachments
+                    )
+
+                case "imagegeneration", "imagegenerationcall", "imagegenerationend", "imageview":
+                    guard let generatedImageText = decodeGeneratedImageMarkdown(from: itemObject) else {
+                        continue
+                    }
+                    appendHistoryMessage(
+                        to: &result,
+                        role: .assistant,
+                        kind: .chat,
+                        text: generatedImageText,
+                        threadId: threadId,
+                        turnId: turnID,
+                        itemId: itemID,
+                        createdAt: timestamp
                     )
 
                 case "reasoning":
@@ -289,6 +304,24 @@ extension CodexService {
         return result
     }
 
+    // Extracts persisted turn outcomes from canonical history so render grouping survives app relaunch.
+    func decodeTurnTerminalStatesFromThreadRead(_ threadObject: [String: JSONValue]) -> [String: CodexTurnTerminalState] {
+        let turns = threadObject["turns"]?.arrayValue ?? []
+        var result: [String: CodexTurnTerminalState] = [:]
+
+        for turnValue in turns {
+            guard let turnObject = turnValue.objectValue,
+                  let turnID = turnObject["id"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !turnID.isEmpty,
+                  let terminalState = historyTurnTerminalState(turnObject) else {
+                continue
+            }
+            result[turnID] = terminalState
+        }
+
+        return result
+    }
+
     func decodeHistoryBaseDate(from threadObject: [String: JSONValue]) -> Date {
         if let rawCreatedAt = threadObject["createdAt"]?.doubleValue {
             return CodexTimestampParser.decodeUnixTimestamp(rawCreatedAt)
@@ -379,6 +412,45 @@ extension CodexService {
         }
 
         return ""
+    }
+
+    func decodeGeneratedImageMarkdown(from itemObject: [String: JSONValue]) -> String? {
+        let imagePath = firstNonEmptyString([
+            itemObject["saved_path"]?.stringValue,
+            itemObject["savedPath"]?.stringValue,
+            itemObject["path"]?.stringValue,
+            itemObject["file_path"]?.stringValue
+        ])?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard let imagePath, Self.isGeneratedImagePath(imagePath) else {
+            return nil
+        }
+
+        return "![Generated image](\(Self.markdownImagePath(imagePath)))"
+    }
+
+    nonisolated static func isGeneratedImagePath(_ path: String) -> Bool {
+        let lowercased = path.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return lowercased.hasSuffix(".png")
+            || lowercased.hasSuffix(".jpg")
+            || lowercased.hasSuffix(".jpeg")
+            || lowercased.hasSuffix(".gif")
+            || lowercased.hasSuffix(".webp")
+            || lowercased.hasSuffix(".heic")
+            || lowercased.hasSuffix(".heif")
+    }
+
+    nonisolated static func markdownImagePath(_ path: String) -> String {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.contains(")") || trimmed.contains(" ") || trimmed.contains("%") {
+            let escaped = trimmed
+                .replacingOccurrences(of: "%", with: "%25")
+                .replacingOccurrences(of: ">", with: "%3E")
+                .replacingOccurrences(of: ")", with: "%29")
+            return "<\(escaped)>"
+        }
+        return trimmed
     }
 
     // Extracts user images from history payload and converts them into renderable thumbnail attachments.
@@ -1426,6 +1498,10 @@ extension CodexService {
     }
 
     func isCompletedHistoryTurn(_ turnObject: [String: JSONValue]) -> Bool {
+        historyTurnTerminalState(turnObject) == .completed
+    }
+
+    func historyTurnTerminalState(_ turnObject: [String: JSONValue]) -> CodexTurnTerminalState? {
         let statusObject = turnObject["status"]?.objectValue
         let rawStatus = firstNonEmptyString([
             turnObject["status"]?.stringValue,
@@ -1435,11 +1511,7 @@ extension CodexService {
             turnObject["result"]?.stringValue,
         ]) ?? ""
 
-        guard let terminalState = threadTerminalState(from: normalizeThreadStatusType(rawStatus)) else {
-            return false
-        }
-
-        return terminalState == .completed
+        return threadTerminalState(from: normalizeThreadStatusType(rawStatus))
     }
 
     // Parses collabAgentToolCall payloads into a stable summary row the timeline can render.

--- a/CodexMobile/CodexMobile/Services/CodexService+Incoming.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Incoming.swift
@@ -177,7 +177,7 @@ extension CodexService {
         switch method {
         case "turn/plan/updated", "item/plan/delta", "item/completed", "serverRequest/resolved":
             debugRuntimeLog(
-                "rpc notification \(method) thread=\(paramsObject?["threadId"]?.stringValue ?? "") turn=\(paramsObject?["turnId"]?.stringValue ?? "") item=\(paramsObject?["itemId"]?.stringValue ?? "")"
+                debugNotificationSummary(method: method, paramsObject: paramsObject)
             )
         default:
             break
@@ -241,7 +241,8 @@ extension CodexService {
              "codex/event/background_event",
              "codex/event/read",
              "codex/event/search",
-             "codex/event/list_files":
+             "codex/event/list_files",
+             "codex/event/image_generation_end":
             if handleLegacyCodexNamedEvent(method: method, paramsObject: paramsObject) {
                 return
             }
@@ -256,6 +257,15 @@ extension CodexService {
 
         case "codex/event":
             if handleLegacyCodexEnvelopeEvent(paramsObject) {
+                return
+            }
+
+        case "image_generation_end":
+            if handleLegacyCodexEventType(
+                eventType: "image_generation_end",
+                payload: paramsObject ?? [:],
+                paramsObject: paramsObject
+            ) {
                 return
             }
 
@@ -1265,9 +1275,52 @@ extension CodexService {
                 payload: payload,
                 paramsObject: paramsObject
             )
+        case "image_generation_end":
+            return handleImageGenerationEndEvent(
+                payload: payload,
+                paramsObject: paramsObject
+            )
         default:
             return false
         }
+    }
+
+    private func handleImageGenerationEndEvent(
+        payload: IncomingParamsObject,
+        paramsObject: IncomingParamsObject?
+    ) -> Bool {
+        let imagePath = firstNonEmptyString([
+            firstStringValue(in: payload, keys: ["saved_path", "savedPath", "path", "file_path"]),
+            firstStringValue(in: paramsObject, keys: ["saved_path", "savedPath", "path", "file_path"])
+        ])
+        guard let imagePath, Self.isGeneratedImagePath(imagePath) else {
+            debugRuntimeLog("generated image event dropped reason=missing-path event=image_generation_end")
+            return false
+        }
+
+        var normalizedParams = paramsObject ?? [:]
+        if normalizedParams["event"] == nil {
+            normalizedParams["event"] = .object(payload)
+        }
+
+        let turnId = extractTurnID(from: normalizedParams)
+        guard let threadId = resolveThreadID(from: normalizedParams, turnIdHint: turnId) else {
+            debugRuntimeLog("generated image event dropped reason=missing-thread event=image_generation_end path=\(URL(fileURLWithPath: imagePath).lastPathComponent)")
+            return false
+        }
+
+        let itemId = firstNonEmptyString([
+            firstStringValue(in: payload, keys: ["call_id", "callId", "id"]),
+            firstStringValue(in: paramsObject, keys: ["itemId", "item_id", "call_id", "callId"])
+        ])
+        appendGeneratedImageReference(
+            threadId: threadId,
+            turnId: turnId,
+            itemId: itemId,
+            imagePath: imagePath
+        )
+        debugRuntimeLog("generated image event appended thread=\(threadId) turn=\(turnId ?? "") item=\(itemId ?? "") path=\(URL(fileURLWithPath: imagePath).lastPathComponent)")
+        return true
     }
 
     // Accepts legacy Codex token_count events, even when the runtime omits thread ids.
@@ -2018,6 +2071,7 @@ extension CodexService {
               !normalizedItemType(type).isEmpty else {
             return false
         }
+        let itemType = normalizedItemType(type)
 
         if object["content"] != nil || object["status"] != nil || object["output"] != nil {
             return true
@@ -2028,8 +2082,41 @@ extension CodexService {
         if object["result"] != nil || object["payload"] != nil || object["data"] != nil {
             return true
         }
+        let hasGeneratedImageIdentityOrPath = object["path"] != nil
+            || object["saved_path"] != nil
+            || object["savedPath"] != nil
+            || object["file_path"] != nil
+            || object["id"] != nil
+            || object["call_id"] != nil
+            || object["callId"] != nil
+        if isCompletedGeneratedImageItemType(itemType), hasGeneratedImageIdentityOrPath {
+            return true
+        }
 
         return false
+    }
+
+    private func debugNotificationSummary(method: String, paramsObject: IncomingParamsObject?) -> String {
+        let eventObject = paramsObject.flatMap { envelopeEventObject(from: $0) }
+        let itemObject = paramsObject.flatMap { extractIncomingItemObject(from: $0, eventObject: eventObject) }
+        let itemType = normalizedItemType(itemObject?["type"]?.stringValue ?? "")
+        let itemId = extractItemID(from: paramsObject, eventObject: eventObject, itemObject: itemObject) ?? ""
+        let nestedItemId = paramsObject?["item"]?.objectValue?["id"]?.stringValue ?? ""
+        let eventType = eventObject?["type"]?.stringValue ?? ""
+        let pathValue = firstNonEmptyString([
+            firstStringValue(in: itemObject, keys: ["saved_path", "savedPath", "path", "file_path"]),
+            firstStringValue(in: eventObject, keys: ["saved_path", "savedPath", "path", "file_path"]),
+            firstStringValue(in: paramsObject, keys: ["saved_path", "savedPath", "path", "file_path"])
+        ])
+        let pathName = pathValue.map { URL(fileURLWithPath: $0).lastPathComponent } ?? ""
+        let resultLength = [
+            itemObject?["result"]?.stringValue?.count,
+            eventObject?["result"]?.stringValue?.count,
+            paramsObject?["result"]?.stringValue?.count,
+        ]
+        .compactMap { $0 }
+        .first ?? 0
+        return "rpc notification \(method) thread=\(paramsObject?["threadId"]?.stringValue ?? "") turn=\(paramsObject?["turnId"]?.stringValue ?? "") item=\(itemId) nestedItem=\(nestedItemId) type=\(itemType) event=\(eventType) path=\(pathName) resultLen=\(resultLength)"
     }
 
     private func extractItemID(

--- a/CodexMobile/CodexMobile/Services/CodexService+IncomingAssistant.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+IncomingAssistant.swift
@@ -105,6 +105,15 @@ extension CodexService {
         }
 
         let itemType = normalizedItemType(itemObject["type"]?.stringValue ?? "")
+        if isCompletedGeneratedImageItemType(itemType) {
+            appendCompletedGeneratedImageItem(
+                itemObject: itemObject,
+                paramsObject: paramsObject,
+                eventObject: eventObject
+            )
+            return
+        }
+
         if handleStructuredItemLifecycle(
             itemObject: itemObject,
             paramsObject: paramsObject,
@@ -154,6 +163,53 @@ extension CodexService {
             itemId: context.identity.itemId,
             text: text
         )
+    }
+
+    func isCompletedGeneratedImageItemType(_ itemType: String) -> Bool {
+        itemType == "imagegeneration"
+            || itemType == "imagegenerationcall"
+            || itemType == "imagegenerationend"
+            || itemType == "imageview"
+    }
+
+    // Converts live generated-image completion items into the same markdown preview used by history.
+    func appendCompletedGeneratedImageItem(
+        itemObject: IncomingParamsObject,
+        paramsObject: IncomingParamsObject,
+        eventObject: IncomingParamsObject?
+    ) {
+        let itemType = normalizedItemType(itemObject["type"]?.stringValue ?? "")
+        let itemId = extractAssistantMessageItemID(
+            paramsObject: paramsObject,
+            eventObject: eventObject,
+            itemObject: itemObject
+        ) ?? ""
+        let imagePath = firstNonEmptyString([
+            firstStringValue(in: itemObject, keys: ["saved_path", "savedPath", "path", "file_path"]),
+            firstStringValue(in: eventObject, keys: ["saved_path", "savedPath", "path", "file_path"]),
+            firstStringValue(in: paramsObject, keys: ["saved_path", "savedPath", "path", "file_path"])
+        ])
+        guard let imagePath, Self.isGeneratedImagePath(imagePath) else {
+            debugRuntimeLog("generated image item dropped type=\(itemType) item=\(itemId) reason=missing-path")
+            return
+        }
+
+        guard let context = resolveAssistantEventContext(
+            paramsObject: paramsObject,
+            eventObject: eventObject,
+            itemObject: itemObject
+        ) else {
+            debugRuntimeLog("generated image item dropped type=\(itemType) item=\(itemId) path=\(URL(fileURLWithPath: imagePath).lastPathComponent) reason=missing-context")
+            return
+        }
+
+        appendGeneratedImageReference(
+            threadId: context.threadId,
+            turnId: context.identity.turnId,
+            itemId: context.identity.itemId,
+            imagePath: imagePath
+        )
+        debugRuntimeLog("generated image item appended type=\(itemType) thread=\(context.threadId) turn=\(context.identity.turnId ?? "") item=\(context.identity.itemId ?? "") path=\(URL(fileURLWithPath: imagePath).lastPathComponent)")
     }
 
     // Creates streaming assistant placeholder when an assistant item starts.

--- a/CodexMobile/CodexMobile/Services/CodexService+Messages.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Messages.swift
@@ -604,7 +604,10 @@ extension CodexService {
         let previousState = latestTurnTerminalStateByThread[threadId]
         latestTurnTerminalStateByThread[threadId] = state
         if let turnId {
-            terminalStateByTurnID[turnId] = state
+            if terminalStateByTurnID[turnId] != state {
+                terminalStateByTurnID[turnId] = state
+                persistTurnTerminalStates()
+            }
         }
         refreshThreadTimelineState(for: threadId)
         triggerRunCompletionHapticIfNeeded(
@@ -905,6 +908,11 @@ extension CodexService {
                 return .skippedForRunningThread
             }
 
+            let historyTerminalStates = decodeTurnTerminalStatesFromThreadRead(threadObject)
+            let didUpdateTerminalStates = mergeHistoryTurnTerminalStates(
+                threadId: threadId,
+                terminalStatesByTurnID: historyTerminalStates
+            )
             let historyMessages = decodeMessagesFromThreadRead(threadId: threadId, threadObject: threadObject)
             registerSubagentThreads(from: historyMessages, parentThreadId: threadId)
             var outcome: ThreadHistoryLoadOutcome = .loadedCanonicalHistory
@@ -940,6 +948,8 @@ extension CodexService {
                     messagesByThread[threadId] = merged
                     persistMessages()
                     updateCurrentOutput(for: threadId)
+                } else if didUpdateTerminalStates {
+                    refreshThreadTimelineState(for: threadId)
                 }
                 if usedRecentWindow {
                     outcome = .loadedRecentWindow
@@ -949,6 +959,8 @@ extension CodexService {
                 } else if !threadHasActiveOrRunningTurn(threadId) {
                     markThreadCanonicalHistoryReconciled(threadId)
                 }
+            } else if didUpdateTerminalStates {
+                refreshThreadTimelineState(for: threadId)
             }
 
             guard !Task.isCancelled,
@@ -2753,6 +2765,11 @@ extension CodexService {
             text: trimmedText
         ) {
             assistantCompletionFingerprintByThread[threadId] = (text: trimmedText, timestamp: now)
+            _ = mergeGeneratedImageArtifactsIntoAssistantMessage(
+                threadId: threadId,
+                turnId: resolvedTurnId,
+                assistantMessageId: replayTerminalMessageId
+            )
             persistMessages()
             if let resolvedTurnId {
                 noteAssistantMessage(
@@ -2777,6 +2794,11 @@ extension CodexService {
             refreshDerivedPlanMetadata(threadId: threadId, messageIndex: duplicateIndex)
             assistantCompletionFingerprintByThread[threadId] = (text: trimmedText, timestamp: now)
             if let resolvedAssistantMessageId = messagesByThread[threadId]?[duplicateIndex].id {
+                _ = mergeGeneratedImageArtifactsIntoAssistantMessage(
+                    threadId: threadId,
+                    turnId: resolvedTurnId,
+                    assistantMessageId: resolvedAssistantMessageId
+                )
                 persistMessages()
                 noteAssistantMessage(
                     threadId: threadId,
@@ -2823,6 +2845,11 @@ extension CodexService {
                 }
                 assistantCompletionFingerprintByThread[threadId] = (text: trimmedText, timestamp: now)
                 if let resolvedAssistantMessageId {
+                    _ = mergeGeneratedImageArtifactsIntoAssistantMessage(
+                        threadId: threadId,
+                        turnId: resolvedTurnId,
+                        assistantMessageId: resolvedAssistantMessageId
+                    )
                     persistMessages()
                     noteAssistantMessage(
                         threadId: threadId,
@@ -2917,6 +2944,14 @@ extension CodexService {
 
         assistantCompletionFingerprintByThread[threadId] = (text: trimmedText, timestamp: now)
 
+        if let resolvedAssistantMessageId {
+            _ = mergeGeneratedImageArtifactsIntoAssistantMessage(
+                threadId: threadId,
+                turnId: resolvedTurnId,
+                assistantMessageId: resolvedAssistantMessageId
+            )
+        }
+
         persistMessages()
         if let resolvedAssistantMessageId {
             noteAssistantMessage(
@@ -2926,6 +2961,131 @@ extension CodexService {
             )
         }
         updateCurrentOutput(for: threadId)
+    }
+
+    // Renders image-generation artifacts as assistant image previews without embedding image bytes.
+    func appendGeneratedImageReference(
+        threadId: String,
+        turnId: String?,
+        itemId: String?,
+        imagePath: String
+    ) {
+        let trimmedPath = imagePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPath.isEmpty else {
+            return
+        }
+
+        let resolvedTurnId = normalizedStreamingItemID(turnId) ?? activeTurnIdByThread[threadId]
+        let resolvedItemId = normalizedStreamingItemID(itemId)
+        if let resolvedTurnId {
+            threadIdByTurnID[resolvedTurnId] = threadId
+        }
+
+        let markdown = "![Generated image](\(Self.markdownImagePath(trimmedPath)))"
+        if var threadMessages = messagesByThread[threadId],
+           let existingIndex = threadMessages.indices.reversed().first(where: { index in
+               let candidate = threadMessages[index]
+               return candidate.role == .assistant
+                   && (
+                       candidate.text.contains(trimmedPath)
+                           || candidate.text.contains(markdown)
+                           || (resolvedItemId != nil && candidate.itemId == resolvedItemId)
+                   )
+           }) {
+            var existing = threadMessages[existingIndex]
+            if !existing.text.contains(trimmedPath) && !existing.text.contains(markdown) {
+                existing.text = existing.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    ? markdown
+                    : "\(existing.text)\n\n\(markdown)"
+            }
+            existing.isStreaming = false
+            if existing.turnId == nil {
+                existing.turnId = resolvedTurnId
+            }
+            if existing.itemId == nil {
+                existing.itemId = resolvedItemId
+            }
+            threadMessages[existingIndex] = existing
+            messagesByThread[threadId] = threadMessages
+            refreshDerivedPlanMetadata(threadId: threadId, messageIndex: existingIndex)
+        } else {
+            let message = CodexMessage(
+                id: Self.stableAssistantMessageID(threadId: threadId, turnId: resolvedTurnId, itemId: resolvedItemId)
+                    ?? UUID().uuidString,
+                threadId: threadId,
+                role: .assistant,
+                text: markdown,
+                turnId: resolvedTurnId,
+                itemId: resolvedItemId,
+                isStreaming: false,
+                deliveryState: .confirmed
+            )
+            appendMessage(message)
+            return
+        }
+
+        persistMessages()
+        updateCurrentOutput(for: threadId)
+    }
+
+    // Folds image-generation artifact rows into the final assistant text for the same turn.
+    private func mergeGeneratedImageArtifactsIntoAssistantMessage(
+        threadId: String,
+        turnId: String?,
+        assistantMessageId: String
+    ) -> Bool {
+        guard let resolvedTurnId = turnId,
+              var threadMessages = messagesByThread[threadId],
+              let targetIndex = threadMessages.firstIndex(where: { $0.id == assistantMessageId }) else {
+            return false
+        }
+
+        let artifactMessages = threadMessages.filter { candidate in
+            candidate.id != assistantMessageId
+                && candidate.role == .assistant
+                && candidate.turnId == resolvedTurnId
+                && Self.isGeneratedImageArtifactOnly(candidate.text)
+        }
+        guard !artifactMessages.isEmpty else {
+            return false
+        }
+
+        var targetMessage = threadMessages[targetIndex]
+        var mergedText = targetMessage.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        for artifact in artifactMessages {
+            let artifactText = artifact.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !artifactText.isEmpty, !mergedText.contains(artifactText) else {
+                continue
+            }
+            mergedText = mergedText.isEmpty ? artifactText : "\(mergedText)\n\n\(artifactText)"
+        }
+        targetMessage.text = mergedText
+        targetMessage.isStreaming = false
+        if targetMessage.turnId == nil {
+            targetMessage.turnId = resolvedTurnId
+        }
+
+        let artifactIds = Set(artifactMessages.map(\.id))
+        threadMessages.removeAll { artifactIds.contains($0.id) }
+        guard let updatedTargetIndex = threadMessages.firstIndex(where: { $0.id == assistantMessageId }) else {
+            return false
+        }
+        threadMessages[updatedTargetIndex] = targetMessage
+        messagesByThread[threadId] = threadMessages
+        refreshDerivedPlanMetadata(threadId: threadId, messageIndex: updatedTargetIndex)
+        return true
+    }
+
+    private static func isGeneratedImageArtifactOnly(_ text: String) -> Bool {
+        let imageReferences = AssistantMarkdownImageReferenceParser.references(in: text)
+        guard !imageReferences.isEmpty else {
+            return false
+        }
+
+        return AssistantMarkdownImageReferenceParser
+            .visibleTextRemovingImageSyntax(from: text)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty
     }
 
     // Suppresses completion replays that resend the whole assistant block already shown around tool rows.
@@ -3322,6 +3482,21 @@ extension CodexService {
             }
         }
     }
+
+    // Persists per-turn terminal state so completed-turn grouping survives app relaunch.
+    func persistTurnTerminalStates() {
+        guard !terminalStateByTurnID.isEmpty else {
+            defaults.removeObject(forKey: Self.turnTerminalStatesDefaultsKey)
+            return
+        }
+
+        guard let data = try? encoder.encode(terminalStateByTurnID) else {
+            defaults.removeObject(forKey: Self.turnTerminalStatesDefaultsKey)
+            return
+        }
+
+        defaults.set(data, forKey: Self.turnTerminalStatesDefaultsKey)
+    }
 }
 
 // ─── Private helpers ──────────────────────────────────────────
@@ -3637,6 +3812,29 @@ extension CodexService {
         )
         stoppedTurnIDsByThread[threadId] = stoppedTurnIDs
         return stoppedTurnIDs
+    }
+
+    // Merges terminal states decoded from thread/read without firing haptics or unread badges.
+    @discardableResult
+    func mergeHistoryTurnTerminalStates(
+        threadId: String,
+        terminalStatesByTurnID historyStates: [String: CodexTurnTerminalState]
+    ) -> Bool {
+        guard !historyStates.isEmpty else {
+            return false
+        }
+
+        var didChange = false
+        for (turnId, state) in historyStates {
+            guard terminalStateByTurnID[turnId] != state else { continue }
+            terminalStateByTurnID[turnId] = state
+            didChange = true
+        }
+
+        if didChange {
+            persistTurnTerminalStates()
+        }
+        return didChange
     }
 
     // Tracks the latest repo-affecting system row so git refresh logic can stay out of the view body.

--- a/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
@@ -7,6 +7,10 @@
 import Foundation
 import UIKit
 
+private final class BackgroundTaskIdentifierBox: @unchecked Sendable {
+    var taskID: UIBackgroundTaskIdentifier = .invalid
+}
+
 extension CodexService {
     struct RunningThreadCatchupOutcome: Equatable {
         let didRefreshTurnState: Bool
@@ -932,6 +936,7 @@ extension CodexService {
     // Starts or ends the iOS grace window that lets a just-backgrounded run finish cleanly.
     func updateBackgroundRunGraceTask() {
         guard !isAppInForeground else {
+            backgroundTurnGraceExpiredUntilForeground = false
             endBackgroundRunGraceTask(reason: "foreground")
             return
         }
@@ -941,13 +946,26 @@ extension CodexService {
             return
         }
 
+        guard !backgroundTurnGraceExpiredUntilForeground else {
+            return
+        }
+
         guard backgroundTurnGraceTaskID == .invalid else {
             return
         }
 
-        let taskID = UIApplication.shared.beginBackgroundTask(withName: "CodexRunGrace") { [weak self] in
+        let taskBox = BackgroundTaskIdentifierBox()
+        let taskID = UIApplication.shared.beginBackgroundTask(withName: "CodexRunGrace") { [weak self, taskBox] in
+            let expiredTaskID = taskBox.taskID
+            guard expiredTaskID != .invalid else {
+                return
+            }
+
+            // UIKit expects the task to end inside the expiration handler, before
+            // we hop back into CodexService's MainActor-isolated state.
+            UIApplication.shared.endBackgroundTask(expiredTaskID)
             Task { @MainActor [weak self] in
-                self?.endBackgroundRunGraceTask(reason: "expired")
+                self?.recordBackgroundRunGraceTaskExpired(taskID: expiredTaskID)
             }
         }
 
@@ -956,8 +974,19 @@ extension CodexService {
             return
         }
 
+        taskBox.taskID = taskID
         backgroundTurnGraceTaskID = taskID
         debugSyncLog("background run grace task started")
+    }
+
+    func recordBackgroundRunGraceTaskExpired(taskID: UIBackgroundTaskIdentifier) {
+        guard backgroundTurnGraceTaskID == taskID else {
+            return
+        }
+
+        backgroundTurnGraceTaskID = .invalid
+        backgroundTurnGraceExpiredUntilForeground = true
+        debugSyncLog("background run grace task ended reason=expired")
     }
 
     func endBackgroundRunGraceTask(reason: String) {

--- a/CodexMobile/CodexMobile/Services/CodexService+WorkspaceImages.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+WorkspaceImages.swift
@@ -12,6 +12,7 @@ struct WorkspaceImageMetadata: Sendable {
     let mimeType: String
     let byteLength: Int
     let mtimeMs: Double?
+    let previewMaxPixelDimension: Int?
 }
 
 struct WorkspaceImageReadResult: Sendable {
@@ -20,6 +21,7 @@ struct WorkspaceImageReadResult: Sendable {
     let mimeType: String
     let byteLength: Int
     let mtimeMs: Double?
+    let previewMaxPixelDimension: Int?
     let data: Data?
     let isNotModified: Bool
 
@@ -29,12 +31,15 @@ struct WorkspaceImageReadResult: Sendable {
             fileName: fileName,
             mimeType: mimeType,
             byteLength: byteLength,
-            mtimeMs: mtimeMs
+            mtimeMs: mtimeMs,
+            previewMaxPixelDimension: previewMaxPixelDimension
         )
     }
 }
 
 extension CodexService {
+    private static let timelineImagePreviewMaxPixelDimension = 1_600
+
     // Loads image bytes only after the user asks to preview them, keeping timeline rows lightweight.
     func readWorkspaceImage(
         path: String,
@@ -45,6 +50,7 @@ extension CodexService {
             path: path,
             cwd: cwd,
             includeData: true,
+            maxPixelDimension: Self.timelineImagePreviewMaxPixelDimension,
             cachedMetadata: cachedMetadata
         )
         let metadata = parseWorkspaceImageMetadata(result: result, fallbackPath: path)
@@ -55,6 +61,7 @@ extension CodexService {
                 mimeType: metadata.mimeType,
                 byteLength: metadata.byteLength,
                 mtimeMs: metadata.mtimeMs,
+                previewMaxPixelDimension: metadata.previewMaxPixelDimension,
                 data: nil,
                 isNotModified: true
             )
@@ -71,6 +78,7 @@ extension CodexService {
             mimeType: metadata.mimeType,
             byteLength: metadata.byteLength,
             mtimeMs: metadata.mtimeMs,
+            previewMaxPixelDimension: metadata.previewMaxPixelDimension,
             data: data,
             isNotModified: false
         )
@@ -80,14 +88,21 @@ extension CodexService {
         path: String,
         cwd: String?,
         includeData: Bool,
+        maxPixelDimension: Int? = nil,
         cachedMetadata: WorkspaceImageMetadata? = nil
     ) async throws -> RPCObject {
         var params: [String: JSONValue] = [
             "path": .string(path),
             "includeData": .bool(includeData)
         ]
+        if let maxPixelDimension {
+            params["maxPixelDimension"] = .integer(maxPixelDimension)
+        }
         if let cachedMetadata {
             params["ifByteLength"] = .integer(cachedMetadata.byteLength)
+            if let previewMaxPixelDimension = cachedMetadata.previewMaxPixelDimension {
+                params["ifPreviewMaxPixelDimension"] = .integer(previewMaxPixelDimension)
+            }
             if let mtimeMs = cachedMetadata.mtimeMs {
                 params["ifMtimeMs"] = .double(mtimeMs)
             }
@@ -109,7 +124,8 @@ extension CodexService {
             fileName: result["fileName"]?.stringValue ?? (path as NSString).lastPathComponent,
             mimeType: result["mimeType"]?.stringValue ?? "image",
             byteLength: result["byteLength"]?.intValue ?? 0,
-            mtimeMs: result["mtimeMs"]?.doubleValue
+            mtimeMs: result["mtimeMs"]?.doubleValue,
+            previewMaxPixelDimension: result["previewMaxPixelDimension"]?.intValue
         )
     }
 }

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -193,7 +193,7 @@ enum CodexNotificationPayloadKeys {
 }
 
 // Tracks the real terminal outcome of a run, including user interruption.
-enum CodexTurnTerminalState: String, Equatable, Sendable {
+enum CodexTurnTerminalState: String, Codable, Equatable, Sendable {
     case completed
     case failed
     case stopped
@@ -446,7 +446,7 @@ final class CodexService {
     @ObservationIgnored var pendingAssistantDeltaContextByStreamID: [String: (threadId: String, turnId: String, itemId: String?)] = [:]
     @ObservationIgnored var pendingAssistantDeltaStreamOrder: [String] = []
     @ObservationIgnored var pendingAssistantDeltaFlushTask: Task<Void, Never>?
-    let assistantDeltaBatchIntervalNanoseconds: UInt64 = 40_000_000
+    let assistantDeltaBatchIntervalNanoseconds: UInt64 = 50_000_000
     // Coalesces multiple invalidateAssistantRevertStates() calls within the same run loop tick into one refresh.
     var coalescedRevertRefreshTask: Task<Void, Never>?
     // Dedupes completion payloads when servers omit turn/item identifiers.
@@ -550,6 +550,7 @@ final class CodexService {
     var shouldAutoReconnectOnForeground = false
     // Test hook so connection handling can model `.inactive` without waiting for real app lifecycle changes.
     @ObservationIgnored var applicationStateProvider: () -> UIApplication.State = { UIApplication.shared.applicationState }
+    var backgroundTurnGraceExpiredUntilForeground = false
     var secureSession: CodexSecureSession?
     var pendingHandshake: CodexPendingHandshake?
     var phoneIdentityState: CodexPhoneIdentityState
@@ -613,6 +614,7 @@ final class CodexService {
     static let pinnedThreadIDsDefaultsKey = "codex.pinnedThreadIDs"
     static let pinnedThreadSnapshotsDefaultsKey = "codex.pinnedThreadSnapshots"
     static let associatedManagedWorktreePathsDefaultsKey = "codex.associatedManagedWorktreePaths"
+    static let turnTerminalStatesDefaultsKey = "codex.turnTerminalStates"
     static let notificationsPromptedDefaultsKey = "codex.notifications.prompted"
     static let keepMacAwakeWhileBridgeRunsDefaultsKey = "codex.keepMacAwakeWhileBridgeRuns"
 
@@ -730,6 +732,16 @@ final class CodexService {
             self.associatedManagedWorktreePathByThreadID = decodedAssociatedManagedWorktreePaths
         } else {
             self.associatedManagedWorktreePathByThreadID = [:]
+        }
+
+        if let savedTurnTerminalStates = defaults.data(forKey: Self.turnTerminalStatesDefaultsKey),
+           let decodedTurnTerminalStates = try? decoder.decode(
+               [String: CodexTurnTerminalState].self,
+               from: savedTurnTerminalStates
+           ) {
+            self.terminalStateByTurnID = decodedTurnTerminalStates
+        } else {
+            self.terminalStateByTurnID = [:]
         }
 
         let savedServiceTier = defaults.string(forKey: Self.selectedServiceTierDefaultsKey)?

--- a/CodexMobile/CodexMobile/Views/Turn/TurnMessageComponents.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnMessageComponents.swift
@@ -652,59 +652,29 @@ private struct AssistantMarkdownImagePreviewButton: View {
     let currentWorkingDirectory: String?
 
     @Environment(CodexService.self) private var codex
+    @Environment(\.colorScheme) private var colorScheme
     @State private var isLoading = false
+    @State private var loadedPreview: PreviewImagePayload?
     @State private var previewImage: PreviewImagePayload?
     @State private var previewError: String?
+    @State private var showsPreviewErrorAlert = false
+    @State private var shouldOpenWhenLoaded = false
+
+    private static let cornerRadius: CGFloat = 18
+    private static let maxWidth: CGFloat = 360
+    private static let placeholderHeight: CGFloat = 200
 
     var body: some View {
         Button {
             HapticFeedback.shared.triggerImpactFeedback(style: .light)
-            loadPreview()
+            openPreview()
         } label: {
-            HStack(spacing: 8) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(Color(.secondarySystemFill))
-                    if isLoading {
-                        ProgressView()
-                            .controlSize(.small)
-                    } else {
-                        Image(systemName: "photo")
-                            .font(AppFont.system(size: 14, weight: .semibold))
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .frame(width: 32, height: 32)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(reference.displayTitle)
-                        .font(AppFont.caption(weight: .medium))
-                        .foregroundStyle(.secondary)
-                    Text(reference.fileName)
-                        .font(AppFont.mono(.caption))
-                        .foregroundStyle(.primary.opacity(0.78))
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                }
-
-                Spacer(minLength: 0)
-
-                Image(systemName: "chevron.right")
-                    .font(AppFont.system(size: 8, weight: .semibold))
-                    .foregroundStyle(.quaternary)
-            }
-            .padding(8)
-            .background(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(Color(.secondarySystemBackground).opacity(0.55))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(Color(.separator).opacity(0.55), lineWidth: 1)
-            )
+            content
         }
         .buttonStyle(.plain)
-        .disabled(isLoading)
+        .task(id: reference.path) {
+            loadPreview(openWhenFinished: false)
+        }
         .fullScreenCover(item: $previewImage) { payload in
             ZoomableImagePreviewScreen(
                 payload: payload,
@@ -720,9 +690,134 @@ private struct AssistantMarkdownImagePreviewButton: View {
         })
     }
 
-    private func loadPreview() {
-        guard !isLoading else { return }
+    @ViewBuilder
+    private var content: some View {
+        if let loadedPreview {
+            loadedImage(loadedPreview)
+        } else if previewError != nil {
+            errorPlaceholder
+        } else {
+            loadingPlaceholder
+        }
+    }
+
+    private func loadedImage(_ payload: PreviewImagePayload) -> some View {
+        Image(uiImage: payload.image)
+            .resizable()
+            .scaledToFit()
+            .frame(maxWidth: Self.maxWidth, alignment: .leading)
+            .clipShape(RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+                    .stroke(Color.primary.opacity(0.06), lineWidth: 0.5)
+            )
+            .shadow(
+                color: Color.black.opacity(colorScheme == .dark ? 0.35 : 0.10),
+                radius: 14,
+                y: 6
+            )
+            .contentShape(RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous))
+    }
+
+    private var loadingPlaceholder: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color(.secondarySystemBackground),
+                            Color(.tertiarySystemBackground)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .overlay {
+                    ShimmerMask()
+                        .mask(
+                            RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+                        )
+                }
+                .overlay(
+                    RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+                        .stroke(Color.primary.opacity(0.05), lineWidth: 0.5)
+                )
+
+            VStack(spacing: 10) {
+                Image(systemName: "sparkles")
+                    .font(AppFont.system(size: 24, weight: .medium))
+                    .foregroundStyle(.primary)
+                    .symbolEffect(.pulse, options: .repeating)
+
+                Text("Generating preview")
+                    .font(AppFont.caption(weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: Self.maxWidth)
+        .frame(height: Self.placeholderHeight)
+    }
+
+    private var errorPlaceholder: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(Color.orange.opacity(0.14))
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(AppFont.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.orange)
+            }
+            .frame(width: 32, height: 32)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Image unavailable")
+                    .font(AppFont.subheadline(weight: .semibold))
+                    .foregroundStyle(.primary)
+                Text(reference.fileName)
+                    .font(AppFont.mono(.caption))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(maxWidth: Self.maxWidth, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+                .stroke(Color.primary.opacity(0.06), lineWidth: 0.5)
+        )
+    }
+
+    private func openPreview() {
+        if let loadedPreview {
+            previewImage = loadedPreview
+            return
+        }
+        shouldOpenWhenLoaded = true
+        loadPreview(openWhenFinished: true)
+    }
+
+    private func loadPreview(openWhenFinished: Bool) {
+        if isLoading {
+            shouldOpenWhenLoaded = shouldOpenWhenLoaded || openWhenFinished
+            return
+        }
+        if let loadedPreview {
+            if openWhenFinished {
+                previewImage = loadedPreview
+            }
+            return
+        }
         isLoading = true
+        if openWhenFinished {
+            shouldOpenWhenLoaded = true
+        }
 
         Task { @MainActor in
             defer { isLoading = false }
@@ -734,29 +829,43 @@ private struct AssistantMarkdownImagePreviewButton: View {
                     cachedMetadata: cachedPreview?.metadata
                 )
                 if result.isNotModified, let cachedPreview {
-                    previewImage = PreviewImagePayload(
+                    let payload = PreviewImagePayload(
                         image: cachedPreview.payload.image,
                         title: cachedPreview.metadata.fileName.isEmpty ? reference.fileName : cachedPreview.metadata.fileName
                     )
+                    finishLoading(payload)
                     return
                 }
 
                 let decodedImage = try await WorkspaceImagePreviewCache.shared.preview(for: result)
-                previewImage = PreviewImagePayload(
+                let payload = PreviewImagePayload(
                     image: decodedImage.image,
                     title: result.fileName.isEmpty ? reference.fileName : result.fileName
                 )
+                finishLoading(payload)
             } catch {
+                let shouldAlert = shouldOpenWhenLoaded
                 previewError = error.localizedDescription
+                shouldOpenWhenLoaded = false
+                showsPreviewErrorAlert = shouldAlert
             }
+        }
+    }
+
+    private func finishLoading(_ payload: PreviewImagePayload) {
+        loadedPreview = payload
+        if shouldOpenWhenLoaded {
+            previewImage = payload
+            shouldOpenWhenLoaded = false
         }
     }
 
     private var previewErrorIsPresented: Binding<Bool> {
         Binding(
-            get: { previewError != nil },
+            get: { previewError != nil && showsPreviewErrorAlert },
             set: { isPresented in
                 if !isPresented {
+                    showsPreviewErrorAlert = false
                     previewError = nil
                 }
             }
@@ -1165,15 +1274,6 @@ struct MessageRow: View, Equatable {
             && visibleAssistantText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && inferredQuestionnaire == nil
             && mermaidContent == nil
-        // Prefer copying the exact assistant block the user can see instead of the
-        // whole non-user turn aggregate assembled by the timeline footer cache.
-        let assistantCopyText: String? = {
-            let trimmedVisibleText = visibleAssistantText.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmedVisibleText.isEmpty {
-                return trimmedVisibleText
-            }
-            return assistantBlockAccessoryState?.copyText
-        }()
         let usesCachedAssistantImageContent = !message.isStreaming && visibleAssistantText == bodyText
         let assistantImageReferences = usesCachedAssistantImageContent
             ? renderModel.assistantImageReferences
@@ -1184,6 +1284,15 @@ struct MessageRow: View, Equatable {
         let hasRenderableAssistantContent = !visibleAssistantTextWithoutImageSyntax.isEmpty
             || proposedPlan != nil
             || !assistantImageReferences.isEmpty
+        // Copy only the visible prose. Image-only artifact rows should not expose a
+        // second copy affordance for the hidden markdown image syntax.
+        let assistantCopyText: String? = {
+            let trimmedVisibleText = visibleAssistantTextWithoutImageSyntax.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmedVisibleText.isEmpty {
+                return trimmedVisibleText
+            }
+            return assistantImageReferences.isEmpty ? assistantBlockAccessoryState?.copyText : nil
+        }()
         return VStack(alignment: .leading, spacing: 8) {
             if let commentContent, commentContent.hasFindings {
                 VStack(alignment: .leading, spacing: 10) {
@@ -1631,7 +1740,7 @@ struct MessageRow: View, Equatable {
         }
 
         assistantDisplayUpdateTask = Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 80_000_000)
+            try? await Task.sleep(nanoseconds: 100_000_000)
             guard !Task.isCancelled else { return }
             throttledAssistantDisplayText = pendingAssistantDisplayText ?? nextText
             assistantDisplayUpdateTask = nil
@@ -2104,7 +2213,8 @@ private actor WorkspaceImagePreviewCache {
 
     private func cacheKey(for metadata: WorkspaceImageMetadata) -> String {
         let mtimeMs = metadata.mtimeMs.map { String($0.bitPattern) } ?? "missing"
-        return "\(metadata.path)|\(metadata.byteLength)|\(mtimeMs)"
+        let previewMax = metadata.previewMaxPixelDimension.map(String.init) ?? "original"
+        return "\(metadata.path)|\(metadata.byteLength)|\(mtimeMs)|\(previewMax)"
     }
 
     private func rememberMetadata(_ metadata: WorkspaceImageMetadata) {

--- a/CodexMobile/CodexMobile/Views/Turn/TurnTimelineReducer.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnTimelineReducer.swift
@@ -134,6 +134,26 @@ enum TurnTimelineReducer {
     // assistant message (thinking/tool → response → thinking/tool). This distinguishes true
     // interleaved flows from single-item turns where events arrived out of order.
     private static func hasInterleavedAssistantActivityFlow(_ turnMessages: [CodexMessage]) -> Bool {
+        // Distinct assistant items with distinct text are real multi-message turns, but
+        // file-change cards still need semantic trailing placement after the final answer.
+        var distinctAssistantTexts: Set<String> = []
+        var distinctAssistantItemIDs: Set<String> = []
+        for message in turnMessages where message.role == .assistant {
+            let text = normalizedMessageText(message.text)
+            if !text.isEmpty {
+                distinctAssistantTexts.insert(text)
+            }
+            if let itemID = normalizedIdentifier(message.itemId) {
+                distinctAssistantItemIDs.insert(itemID)
+            }
+        }
+        let hasFileChangeCard = turnMessages.contains { $0.role == .system && $0.kind == .fileChange }
+        if !hasFileChangeCard,
+           distinctAssistantTexts.count > 1,
+           distinctAssistantItemIDs.count > 1 {
+            return true
+        }
+
         // Check pattern: activity → assistant → activity (system activity on both sides).
         let ordered = turnMessages.sorted { $0.orderIndex < $1.orderIndex }
         var hasActivityBeforeAssistant = false
@@ -611,6 +631,16 @@ enum TurnTimelineReducer {
             }
 
             if let turnId = message.turnId, !turnId.isEmpty {
+                if let exactReplayIndex = result.indices.reversed().first(where: {
+                    shouldMergeExactAssistantReplay(previous: result[$0], incoming: message)
+                }) {
+                    result[exactReplayIndex] = mergedExactAssistantReplay(
+                        previous: result[exactReplayIndex],
+                        incoming: message
+                    )
+                    continue
+                }
+
                 if let replayIndex = result.indices.reversed().first(where: {
                     shouldMergeAssistantReplay(previous: result[$0], incoming: message)
                 }) {
@@ -666,6 +696,40 @@ enum TurnTimelineReducer {
     private struct AssistantTurnTextObservation {
         let createdAt: Date
         let hasStableIdentity: Bool
+    }
+
+    // Folds duplicate final-answer items even when history/live replay assigned different stable item ids.
+    private static func shouldMergeExactAssistantReplay(previous: CodexMessage, incoming: CodexMessage) -> Bool {
+        guard previous.role == .assistant,
+              incoming.role == .assistant,
+              previous.threadId == incoming.threadId,
+              normalizedIdentifier(previous.turnId) == normalizedIdentifier(incoming.turnId) else {
+            return false
+        }
+
+        let previousText = normalizedMessageText(previous.text)
+        let incomingText = normalizedMessageText(incoming.text)
+        guard previousText.count >= 24,
+              previousText == incomingText else {
+            return false
+        }
+
+        return true
+    }
+
+    private static func mergedExactAssistantReplay(previous: CodexMessage, incoming: CodexMessage) -> CodexMessage {
+        var merged = previous
+        merged.isStreaming = previous.isStreaming && incoming.isStreaming
+        if merged.turnId == nil {
+            merged.turnId = incoming.turnId
+        }
+        if normalizedIdentifier(merged.itemId) == nil || isProvisionalAssistantIdentity(merged.itemId) {
+            merged.itemId = incoming.itemId ?? merged.itemId
+        }
+        if incoming.text.count > merged.text.count {
+            merged.text = incoming.text
+        }
+        return merged
     }
 
     // Collapses persisted replay rows where a late delta duplicated part of the final answer.

--- a/CodexMobile/CodexMobile/Views/Turn/TurnTimelineRenderProjection.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnTimelineRenderProjection.swift
@@ -2,7 +2,7 @@
 // Purpose: Builds lightweight render items from raw timeline messages.
 // Layer: View Model / Projection
 // Exports: TurnTimelineRenderProjection, TurnTimelineRenderItem, timeline grouping models
-// Depends on: Foundation, CodexMessage
+// Depends on: Foundation, CodexMessage, AssistantMarkdownImageReferenceParser, CodeCommentDirectiveParser
 
 import Foundation
 
@@ -77,9 +77,9 @@ enum TurnTimelineRenderProjection {
             completedTurnIDs: completedTurnIDs
         )
         let hiddenIndices = Set(finalCollapsePlan.values.flatMap(\.indices))
-        let groupByStartIndex = Dictionary(
-            uniqueKeysWithValues: finalCollapsePlan.values.map { ($0.startIndex, $0) }
-        )
+        let groupByInsertionIndex = finalCollapsePlan.values.reduce(into: [Int: PreviousMessagesCollapse]()) { result, collapse in
+            result[collapse.insertionIndex] = collapse
+        }
 
         func flushBufferedToolMessages() {
             guard !bufferedToolMessages.isEmpty else { return }
@@ -92,7 +92,7 @@ enum TurnTimelineRenderProjection {
         }
 
         for (index, message) in messages.enumerated() {
-            if let group = groupByStartIndex[index] {
+            if let group = groupByInsertionIndex[index] {
                 flushBufferedToolMessages()
                 items.append(.previousMessages(group.group))
             }
@@ -130,7 +130,7 @@ enum TurnTimelineRenderProjection {
     }
 
     private struct PreviousMessagesCollapse {
-        let startIndex: Int
+        let insertionIndex: Int
         let indices: [Int]
         let group: TurnTimelinePreviousMessagesGroup
     }
@@ -144,37 +144,27 @@ enum TurnTimelineRenderProjection {
             return [:]
         }
 
-        let finalAssistantIndexByTurn = messages.indices.reduce(into: [String: Int]()) { result, index in
-            let message = messages[index]
-            guard message.role == .assistant,
-                  !message.isStreaming,
-                  !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-                  let turnID = normalizedIdentifier(message.turnId),
-                  completedTurnIDs.contains(turnID) else {
-                return
-            }
-            result[turnID] = index
-        }
-
+        let resolvedFinalAssistantIndexByTurn = finalAssistantIndexByTurn(
+            in: messages,
+            completedTurnIDs: completedTurnIDs
+        )
         var plan: [Int: PreviousMessagesCollapse] = [:]
-        for (turnID, finalIndex) in finalAssistantIndexByTurn {
+        for (turnID, finalIndex) in resolvedFinalAssistantIndexByTurn {
             let lowerBound = lastUserIndexBefore(finalIndex, in: messages, turnID: turnID).map { $0 + 1 } ?? messages.startIndex
-            let hiddenIndices = messages.indices.filter { index in
-                guard index >= lowerBound, index < finalIndex else {
-                    return false
-                }
-                let candidate = messages[index]
-                return normalizedIdentifier(candidate.turnId) == turnID
-                    && candidate.role != .user
-            }
+            let hiddenIndices = previousMessageIndices(
+                in: messages,
+                turnID: turnID,
+                finalIndex: finalIndex,
+                lowerBound: lowerBound
+            )
 
-            guard let startIndex = hiddenIndices.first else {
+            guard !hiddenIndices.isEmpty else {
                 continue
             }
 
             let hiddenMessages = hiddenIndices.map { messages[$0] }
             plan[finalIndex] = PreviousMessagesCollapse(
-                startIndex: startIndex,
+                insertionIndex: lowerBound,
                 indices: hiddenIndices,
                 group: TurnTimelinePreviousMessagesGroup(
                     finalMessage: messages[finalIndex],
@@ -186,6 +176,49 @@ enum TurnTimelineRenderProjection {
         return plan
     }
 
+    private static func finalAssistantIndexByTurn(
+        in messages: [CodexMessage],
+        completedTurnIDs: Set<String>
+    ) -> [String: Int] {
+        var preferredFinalIndexByTurn: [String: Int] = [:]
+        var fallbackFinalIndexByTurn: [String: Int] = [:]
+
+        for index in messages.indices {
+            let message = messages[index]
+            guard message.role == .assistant,
+                  !message.isStreaming,
+                  !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  let turnID = normalizedIdentifier(message.turnId),
+                  completedTurnIDs.contains(turnID) else {
+                continue
+            }
+
+            fallbackFinalIndexByTurn[turnID] = index
+            if !isAssistantPriorityArtifactOnly(message) {
+                preferredFinalIndexByTurn[turnID] = index
+            }
+        }
+
+        return preferredFinalIndexByTurn.merging(fallbackFinalIndexByTurn) { preferred, _ in preferred }
+    }
+
+    private static func previousMessageIndices(
+        in messages: [CodexMessage],
+        turnID: String,
+        finalIndex: Int,
+        lowerBound: Int
+    ) -> [Int] {
+        messages.indices.filter { index in
+            guard index >= lowerBound, index != finalIndex else {
+                return false
+            }
+            let candidate = messages[index]
+            return normalizedIdentifier(candidate.turnId) == turnID
+                && candidate.role != .user
+                && !isPriorityVisibleMessage(candidate)
+        }
+    }
+
     private static func lastUserIndexBefore(_ index: Int, in messages: [CodexMessage], turnID: String) -> Int? {
         messages.indices.reversed().first { candidateIndex in
             guard candidateIndex < index else {
@@ -195,6 +228,45 @@ enum TurnTimelineRenderProjection {
             return candidate.role == .user
                 && normalizedIdentifier(candidate.turnId) == turnID
         }
+    }
+
+    // Keeps user-critical artifacts visible beside the final answer instead of burying them in the disclosure.
+    private static func isPriorityVisibleMessage(_ message: CodexMessage) -> Bool {
+        if message.role == .system {
+            switch message.kind {
+            case .fileChange, .subagentAction, .userInputPrompt:
+                return true
+            case .thinking, .toolActivity, .commandExecution, .chat, .plan:
+                return false
+            }
+        }
+
+        return isAssistantPriorityArtifactOnly(message)
+    }
+
+    private static func isAssistantPriorityArtifactOnly(_ message: CodexMessage) -> Bool {
+        guard message.role == .assistant, !message.isStreaming else {
+            return false
+        }
+
+        let text = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            return false
+        }
+
+        let imageReferences = AssistantMarkdownImageReferenceParser.references(in: text)
+        if !imageReferences.isEmpty {
+            let textWithoutImages = AssistantMarkdownImageReferenceParser
+                .visibleTextRemovingImageSyntax(from: text)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if textWithoutImages.isEmpty {
+                return true
+            }
+        }
+
+        let codeCommentContent = CodeCommentDirectiveParser.parse(from: text)
+        return codeCommentContent.hasFindings
+            && codeCommentContent.fallbackText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private static func isToolBurstCandidate(_ message: CodexMessage) -> Bool {

--- a/CodexMobile/CodexMobile/Views/Turn/TurnTimelineView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnTimelineView.swift
@@ -192,7 +192,7 @@ private struct TurnTimelinePreviousMessagesView: View {
             } label: {
                 HStack(spacing: 8) {
                     Text(title)
-                        .font(AppFont.title3(weight: .regular))
+                        .font(AppFont.body(weight: .regular))
                         .foregroundStyle(.secondary)
                     Image(systemName: "chevron.right")
                         .font(AppFont.system(size: 14, weight: .semibold))
@@ -764,21 +764,17 @@ struct TurnTimelineView<EmptyState: View, Composer: View>: View {
             revertStatesByMessageID: assistantRevertStatesByMessageID
         )
 
-        var updated = [String: AssistantBlockAccessoryState](
+        let initialBlockInfoByMessageID = [String: AssistantBlockAccessoryState](
             uniqueKeysWithValues: zip(visible, cachedBlockInfo).compactMap { message, blockText in
                 guard let blockText else { return nil }
                 return (message.id, blockText)
             }
         )
-        let collapsedFinalMessageIDs = TurnTimelineRenderProjection.collapsedFinalMessageIDs(
-            in: visible,
+        let updated = Self.rehomeCollapsedFinalAccessoryStates(
+            initialBlockInfoByMessageID,
+            messages: visible,
             completedTurnIDs: completedTurnIDs
         )
-        for message in visible where collapsedFinalMessageIDs.contains(message.id) {
-            guard let state = updated[message.id] else { continue }
-            let finalCopyText = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
-            updated[message.id] = state.replacingCopyText(finalCopyText.isEmpty ? nil : finalCopyText)
-        }
         if updated != cachedBlockInfoByMessageID {
             cachedBlockInfoByMessageID = updated
         }
@@ -1292,6 +1288,72 @@ struct TurnTimelineView<EmptyState: View, Composer: View>: View {
             i = blockStart - 1
         }
         return result
+    }
+
+    static func rehomeCollapsedFinalAccessoryStates(
+        _ statesByMessageID: [String: AssistantBlockAccessoryState],
+        messages: [CodexMessage],
+        completedTurnIDs: Set<String>
+    ) -> [String: AssistantBlockAccessoryState] {
+        let collapsedFinalMessageIDs = TurnTimelineRenderProjection.collapsedFinalMessageIDs(
+            in: messages,
+            completedTurnIDs: completedTurnIDs
+        )
+        guard !collapsedFinalMessageIDs.isEmpty else {
+            return statesByMessageID
+        }
+
+        var updated = statesByMessageID
+        for finalIndex in messages.indices where collapsedFinalMessageIDs.contains(messages[finalIndex].id) {
+            let finalMessage = messages[finalIndex]
+            let sourceState = updated[finalMessage.id] ?? collapsedBlockAccessoryState(
+                forFinalIndex: finalIndex,
+                messages: messages,
+                statesByMessageID: updated
+            )
+            guard let sourceState else { continue }
+
+            let finalCopyText = finalMessage.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            updated[finalMessage.id] = sourceState.replacingCopyText(finalCopyText.isEmpty ? nil : finalCopyText)
+        }
+        return updated
+    }
+
+    // When late tool rows are collapsed after the final answer, their block action
+    // state still belongs on the visible final row.
+    private static func collapsedBlockAccessoryState(
+        forFinalIndex finalIndex: Int,
+        messages: [CodexMessage],
+        statesByMessageID: [String: AssistantBlockAccessoryState]
+    ) -> AssistantBlockAccessoryState? {
+        let finalMessage = messages[finalIndex]
+        let finalTurnID = normalizedTurnID(finalMessage.turnId)
+        var blockStart = finalIndex
+        while blockStart > messages.startIndex && messages[blockStart - 1].role != .user {
+            blockStart -= 1
+        }
+
+        var blockEnd = finalIndex
+        while blockEnd < messages.index(before: messages.endIndex) && messages[blockEnd + 1].role != .user {
+            blockEnd += 1
+        }
+
+        for index in stride(from: blockEnd, through: blockStart, by: -1) {
+            let candidate = messages[index]
+            guard candidate.id != finalMessage.id else { continue }
+            if let finalTurnID, normalizedTurnID(candidate.turnId) != finalTurnID {
+                continue
+            }
+            if let state = statesByMessageID[candidate.id] {
+                return state
+            }
+        }
+        return nil
+    }
+
+    private static func normalizedTurnID(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
     }
 
     // Keeps Copy aligned with real run completion instead of per-message streaming heuristics.

--- a/CodexMobile/CodexMobileTests/CodexServiceIncomingCommandExecutionTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceIncomingCommandExecutionTests.swift
@@ -199,6 +199,42 @@ final class CodexServiceIncomingCommandExecutionTests: XCTestCase {
         XCTAssertEqual(history[0].turnId, turnID)
     }
 
+    func testHistoryRestoresGeneratedImageEndAndImageViewItems() {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let turnID = "turn-\(UUID().uuidString)"
+        let history = service.decodeMessagesFromThreadRead(
+            threadId: threadID,
+            threadObject: [
+                "createdAt": .string("2026-03-12T10:00:00Z"),
+                "turns": .array([
+                    .object([
+                        "id": .string(turnID),
+                        "items": .array([
+                            .object([
+                                "id": .string("image-end"),
+                                "type": .string("image_generation_end"),
+                                "saved_path": .string("/Users/example/generated end.png"),
+                            ]),
+                            .object([
+                                "id": .string("image-view"),
+                                "type": .string("imageView"),
+                                "path": .string("/Users/example/viewed image.png"),
+                            ]),
+                        ]),
+                    ]),
+                ]),
+            ]
+        )
+
+        XCTAssertEqual(history.count, 2)
+        XCTAssertEqual(history.map(\.itemId), ["image-end", "image-view"])
+        XCTAssertEqual(history.map(\.text), [
+            "![Generated image](</Users/example/generated end.png>)",
+            "![Generated image](</Users/example/viewed image.png>)",
+        ])
+    }
+
     func testHistoryDecodesNumericStringMicrosecondTimestamps() {
         let service = makeService()
         let threadID = "thread-\(UUID().uuidString)"
@@ -1658,6 +1694,203 @@ final class CodexServiceIncomingCommandExecutionTests: XCTestCase {
         XCTAssertEqual(history[0].kind, .commandExecution)
         XCTAssertEqual(history[0].text, "Context compacted")
         XCTAssertEqual(history[0].turnId, turnID)
+    }
+
+    func testLegacyNamedImageGenerationEndAppendsGeneratedImagePreview() {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let turnID = "turn-\(UUID().uuidString)"
+        let itemID = "image-\(UUID().uuidString)"
+        let imagePath = "/Users/example/generated image.png"
+
+        service.handleNotification(
+            method: "codex/event/image_generation_end",
+            params: .object([
+                "conversationId": .string(threadID),
+                "id": .string(turnID),
+                "msg": .object([
+                    "type": .string("image_generation_end"),
+                    "call_id": .string(itemID),
+                    "turn_id": .string(turnID),
+                    "saved_path": .string(imagePath),
+                ]),
+            ])
+        )
+
+        let imageRows = service.messages(for: threadID).filter {
+            $0.role == .assistant && $0.itemId == itemID
+        }
+        XCTAssertEqual(imageRows.count, 1)
+        XCTAssertEqual(imageRows[0].turnId, turnID)
+        XCTAssertEqual(imageRows[0].text, "![Generated image](</Users/example/generated image.png>)")
+    }
+
+    func testCompletedImageGenerationItemAppendsGeneratedImagePreview() {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let turnID = "turn-\(UUID().uuidString)"
+        let itemID = "image-\(UUID().uuidString)"
+        let imagePath = "/Users/example/generated image.png"
+
+        service.handleNotification(
+            method: "item/completed",
+            params: .object([
+                "threadId": .string(threadID),
+                "turnId": .string(turnID),
+                "item": .object([
+                    "id": .string(itemID),
+                    "type": .string("image_generation_call"),
+                    "saved_path": .string(imagePath),
+                ]),
+            ])
+        )
+
+        let imageRows = service.messages(for: threadID).filter {
+            $0.role == .assistant && $0.itemId == itemID
+        }
+        XCTAssertEqual(imageRows.count, 1)
+        XCTAssertEqual(imageRows[0].turnId, turnID)
+        XCTAssertEqual(imageRows[0].text, "![Generated image](</Users/example/generated image.png>)")
+    }
+
+    func testCompletedImageViewItemAppendsGeneratedImagePreview() {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let turnID = "turn-\(UUID().uuidString)"
+        let itemID = "image-\(UUID().uuidString)"
+        let imagePath = "/Users/example/generated image.png"
+
+        service.handleNotification(
+            method: "item/completed",
+            params: .object([
+                "threadId": .string(threadID),
+                "turnId": .string(turnID),
+                "item": .object([
+                    "id": .string(itemID),
+                    "type": .string("imageView"),
+                    "path": .string(imagePath),
+                ]),
+            ])
+        )
+
+        let imageRows = service.messages(for: threadID).filter {
+            $0.role == .assistant && $0.itemId == itemID
+        }
+        XCTAssertEqual(imageRows.count, 1)
+        XCTAssertEqual(imageRows[0].turnId, turnID)
+        XCTAssertEqual(imageRows[0].text, "![Generated image](</Users/example/generated image.png>)")
+    }
+
+    func testDirectCompletedImageViewItemAppendsGeneratedImagePreview() {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let turnID = "turn-\(UUID().uuidString)"
+        let itemID = "image-\(UUID().uuidString)"
+        let imagePath = "/Users/example/generated image.png"
+
+        service.handleNotification(
+            method: "item/completed",
+            params: .object([
+                "threadId": .string(threadID),
+                "turnId": .string(turnID),
+                "id": .string(itemID),
+                "type": .string("imageView"),
+                "path": .string(imagePath),
+            ])
+        )
+
+        let imageRows = service.messages(for: threadID).filter {
+            $0.role == .assistant && $0.itemId == itemID
+        }
+        XCTAssertEqual(imageRows.count, 1)
+        XCTAssertEqual(imageRows[0].turnId, turnID)
+        XCTAssertEqual(imageRows[0].text, "![Generated image](</Users/example/generated image.png>)")
+    }
+
+    func testCompletedImageGenerationItemTypeAppendsGeneratedImagePreview() {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let turnID = "turn-\(UUID().uuidString)"
+        let itemID = "image-\(UUID().uuidString)"
+        let imagePath = "/Users/example/generated image.png"
+
+        service.handleNotification(
+            method: "item/completed",
+            params: .object([
+                "threadId": .string(threadID),
+                "turnId": .string(turnID),
+                "item": .object([
+                    "id": .string(itemID),
+                    "type": .string("image_generation"),
+                    "path": .string(imagePath),
+                    "result": .string("iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"),
+                ]),
+            ])
+        )
+
+        let imageRows = service.messages(for: threadID).filter {
+            $0.role == .assistant && $0.itemId == itemID
+        }
+        XCTAssertEqual(imageRows.count, 1)
+        XCTAssertEqual(imageRows[0].turnId, turnID)
+        XCTAssertEqual(imageRows[0].text, "![Generated image](</Users/example/generated image.png>)")
+    }
+
+    func testTurnTerminalStatePersistsCompletedGroupingAfterRelaunch() {
+        let suiteName = "CodexServiceIncomingCommandExecutionTests.persist.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let threadID = "thread-\(UUID().uuidString)"
+        let turnID = "turn-\(UUID().uuidString)"
+        let messages = [
+            CodexMessage(
+                id: "user",
+                threadId: threadID,
+                role: .user,
+                text: "make an icon",
+                turnId: turnID
+            ),
+            CodexMessage(
+                id: "preamble",
+                threadId: threadID,
+                role: .assistant,
+                text: "Using imagegen...",
+                turnId: turnID,
+                itemId: "status"
+            ),
+            CodexMessage(
+                id: "final",
+                threadId: threadID,
+                role: .assistant,
+                text: "Done.",
+                turnId: turnID,
+                itemId: "final"
+            ),
+        ]
+
+        let firstService = CodexService(defaults: defaults)
+        firstService.messagesByThread[threadID] = messages
+        firstService.recordTurnTerminalState(threadId: threadID, turnId: turnID, state: .completed)
+
+        let reloadedService = CodexService(defaults: defaults)
+        reloadedService.messagesByThread[threadID] = messages
+        reloadedService.refreshThreadTimelineState(for: threadID)
+        Self.retainedServices.append(firstService)
+        Self.retainedServices.append(reloadedService)
+
+        let snapshot = reloadedService.timelineState(for: threadID).renderSnapshot
+        let renderItems = TurnTimelineRenderProjection.project(
+            messages: snapshot.messages,
+            completedTurnIDs: snapshot.completedTurnIDs
+        )
+
+        XCTAssertEqual(reloadedService.turnTerminalState(for: turnID), .completed)
+        XCTAssertTrue(snapshot.completedTurnIDs.contains(turnID))
+        XCTAssertTrue(renderItems.contains {
+            if case .previousMessages = $0 { return true }
+            return false
+        })
     }
 
     private func makeService() -> CodexService {

--- a/CodexMobile/CodexMobileTests/TurnMessageCachesTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnMessageCachesTests.swift
@@ -156,6 +156,21 @@ final class TurnMessageCachesTests: XCTestCase {
         XCTAssertFalse(visibleText.contains("![real](/Users/example/real.png)"))
     }
 
+    func testAssistantMarkdownImageReferenceParserReadsEscapedAnglePathWithClosingParenthesis() {
+        let path = "/Users/example/generated images/final)%20 mock.png"
+        let markdownPath = CodexService.markdownImagePath(path)
+        let text = "![Generated image](\(markdownPath))"
+
+        let references = AssistantMarkdownImageReferenceParser.references(in: text)
+
+        XCTAssertEqual(markdownPath, "</Users/example/generated images/final%29%2520 mock.png>")
+        XCTAssertEqual(references.map(\.path), [path])
+        XCTAssertEqual(
+            CodexService.markdownImagePath("/Users/example/final%20mock.png"),
+            "</Users/example/final%2520mock.png>"
+        )
+    }
+
     func testMessageRowRenderModelCachesAssistantImageReferences() {
         let text = "Before\n![wing](/Users/example/wing.png)\nAfter"
         let message = CodexMessage(

--- a/CodexMobile/CodexMobileTests/TurnTimelineReducerTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnTimelineReducerTests.swift
@@ -391,6 +391,257 @@ final class TurnTimelineReducerTests: XCTestCase {
         )
     }
 
+    func testTimelineProjectionKeepsPreviousMessagesChronologicalForMultiAssistantTurns() {
+        let now = Date()
+        let rawMessages = [
+            makeMessage(
+                id: "user",
+                threadID: "thread",
+                role: .user,
+                text: "Check Gmail",
+                createdAt: now,
+                turnID: "turn-1",
+                orderIndex: 1
+            ),
+            makeMessage(
+                id: "status",
+                threadID: "thread",
+                role: .assistant,
+                text: "I'll use the Gmail connector.",
+                createdAt: now.addingTimeInterval(1),
+                turnID: "turn-1",
+                itemID: "status-item",
+                orderIndex: 2
+            ),
+            makeMessage(
+                id: "tool",
+                threadID: "thread",
+                role: .system,
+                kind: .toolActivity,
+                text: "Read inbox",
+                createdAt: now.addingTimeInterval(2),
+                turnID: "turn-1",
+                itemID: "tool-item",
+                orderIndex: 3
+            ),
+            makeMessage(
+                id: "final-a",
+                threadID: "thread",
+                role: .assistant,
+                text: "The latest Remodex TestFlight inbox email says: Version 1.4, build 126.",
+                createdAt: now.addingTimeInterval(3),
+                turnID: "turn-1",
+                itemID: "final-item-a",
+                orderIndex: 4
+            ),
+            makeMessage(
+                id: "final-b",
+                threadID: "thread",
+                role: .assistant,
+                text: "The latest Remodex TestFlight inbox email says: Version 1.4, build 126.",
+                createdAt: now.addingTimeInterval(4),
+                turnID: "turn-1",
+                itemID: "final-item-b",
+                orderIndex: 5
+            ),
+        ]
+
+        let projectedMessages = TurnTimelineReducer.project(messages: rawMessages).messages
+        XCTAssertEqual(projectedMessages.map(\.id), ["user", "status", "tool", "final-a"])
+
+        let items = TurnTimelineRenderProjection.project(
+            messages: projectedMessages,
+            completedTurnIDs: ["turn-1"]
+        )
+
+        guard case .message(let user) = items[0],
+              case .previousMessages(let previousGroup) = items[1],
+              case .message(let final) = items[2] else {
+            return XCTFail("Expected user, previous-messages disclosure, final answer")
+        }
+
+        XCTAssertEqual(user.id, "user")
+        XCTAssertEqual(previousGroup.messages.map(\.id), ["status", "tool"])
+        XCTAssertEqual(final.id, "final-a")
+    }
+
+    func testTimelineProjectionKeepsPriorityArtifactsVisibleOutsidePreviousMessages() {
+        let now = Date()
+        let messages = [
+            makeMessage(
+                id: "user",
+                threadID: "thread",
+                role: .user,
+                text: "Build the feature",
+                createdAt: now,
+                turnID: "turn-1",
+                orderIndex: 1
+            ),
+            makeMessage(
+                id: "thinking",
+                threadID: "thread",
+                role: .system,
+                kind: .thinking,
+                text: "Reasoning",
+                createdAt: now.addingTimeInterval(1),
+                turnID: "turn-1",
+                orderIndex: 2
+            ),
+            makeMessage(
+                id: "assistant-status",
+                threadID: "thread",
+                role: .assistant,
+                text: "I am checking the repo.",
+                createdAt: now.addingTimeInterval(2),
+                turnID: "turn-1",
+                itemID: "status-item",
+                orderIndex: 3
+            ),
+            makeMessage(
+                id: "tool",
+                threadID: "thread",
+                role: .system,
+                kind: .toolActivity,
+                text: "Read Sources/App.swift",
+                createdAt: now.addingTimeInterval(3),
+                turnID: "turn-1",
+                orderIndex: 4
+            ),
+            makeMessage(
+                id: "file-change",
+                threadID: "thread",
+                role: .system,
+                kind: .fileChange,
+                text: "Path: Sources/App.swift\nKind: update\nTotals: +1 -0",
+                createdAt: now.addingTimeInterval(4),
+                turnID: "turn-1",
+                orderIndex: 5
+            ),
+            makeMessage(
+                id: "image",
+                threadID: "thread",
+                role: .assistant,
+                text: "![Generated image](/Users/example/generated.png)",
+                createdAt: now.addingTimeInterval(5),
+                turnID: "turn-1",
+                itemID: "image-item",
+                orderIndex: 6
+            ),
+            makeMessage(
+                id: "comment-card",
+                threadID: "thread",
+                role: .assistant,
+                text: #"::code-comment{title="[P2] Keep artifact visible" body="The action card should stay visible outside previous messages." file="Sources/App.swift" start=10 end=12 priority=2 confidence=0.82}"#,
+                createdAt: now.addingTimeInterval(5.5),
+                turnID: "turn-1",
+                itemID: "comment-item",
+                orderIndex: 7
+            ),
+            makeMessage(
+                id: "final",
+                threadID: "thread",
+                role: .assistant,
+                text: "Done. The feature is ready.",
+                createdAt: now.addingTimeInterval(6),
+                turnID: "turn-1",
+                itemID: "final-item",
+                orderIndex: 8
+            ),
+            makeMessage(
+                id: "post-tool",
+                threadID: "thread",
+                role: .system,
+                kind: .toolActivity,
+                text: "Late metadata refresh",
+                createdAt: now.addingTimeInterval(7),
+                turnID: "turn-1",
+                orderIndex: 9
+            ),
+        ]
+
+        let items = TurnTimelineRenderProjection.project(
+            messages: messages,
+            completedTurnIDs: ["turn-1"]
+        )
+
+        XCTAssertEqual(items.map(\.id), [
+            "user",
+            "previous-messages:final",
+            "file-change",
+            "image",
+            "comment-card",
+            "final",
+        ])
+        guard case .previousMessages(let previousGroup) = items[1] else {
+            return XCTFail("Expected previous messages disclosure before priority artifacts")
+        }
+        XCTAssertEqual(previousGroup.messages.map(\.id), ["thinking", "assistant-status", "tool", "post-tool"])
+    }
+
+    func testTimelineProjectionDoesNotTreatImageOnlyArtifactAsFinalAnswer() {
+        let now = Date()
+        let messages = [
+            makeMessage(
+                id: "user",
+                threadID: "thread",
+                role: .user,
+                text: "Create an image",
+                createdAt: now,
+                turnID: "turn-1",
+                orderIndex: 1
+            ),
+            makeMessage(
+                id: "status",
+                threadID: "thread",
+                role: .assistant,
+                text: "Generating it now.",
+                createdAt: now.addingTimeInterval(1),
+                turnID: "turn-1",
+                itemID: "status-item",
+                orderIndex: 2
+            ),
+            makeMessage(
+                id: "final",
+                threadID: "thread",
+                role: .assistant,
+                text: "Here is the final result.",
+                createdAt: now.addingTimeInterval(2),
+                turnID: "turn-1",
+                itemID: "final-item",
+                orderIndex: 3
+            ),
+            makeMessage(
+                id: "image",
+                threadID: "thread",
+                role: .assistant,
+                text: "![Generated image](/Users/example/generated.png)",
+                createdAt: now.addingTimeInterval(3),
+                turnID: "turn-1",
+                itemID: "image-item",
+                orderIndex: 4
+            ),
+        ]
+
+        let items = TurnTimelineRenderProjection.project(
+            messages: messages,
+            completedTurnIDs: ["turn-1"]
+        )
+
+        XCTAssertEqual(items.map(\.id), [
+            "user",
+            "previous-messages:final",
+            "final",
+            "image",
+        ])
+        XCTAssertEqual(
+            TurnTimelineRenderProjection.collapsedFinalMessageIDs(
+                in: messages,
+                completedTurnIDs: ["turn-1"]
+            ),
+            Set(["final"])
+        )
+    }
+
     func testTimelineRenderProjectionKeepsRunningTurnExpandedBeforeFinalAnswer() {
         let now = Date()
         let messages = [
@@ -1517,6 +1768,66 @@ final class TurnTimelineReducerTests: XCTestCase {
         ])
     }
 
+    func testEnforceIntraTurnOrderKeepsFileChangeAfterFinalAssistantWhenStatusTextPrecedesIt() {
+        let now = Date()
+        var order = 0
+        func nextOrder() -> Int { order += 1; return order }
+
+        let messages = [
+            makeMessage(
+                id: "user-1",
+                threadID: "thread",
+                role: .user,
+                kind: .chat,
+                text: "Change the app",
+                createdAt: now,
+                turnID: "turn-1",
+                orderIndex: nextOrder()
+            ),
+            makeMessage(
+                id: "assistant-status",
+                threadID: "thread",
+                role: .assistant,
+                kind: .chat,
+                text: "Working on it",
+                createdAt: now.addingTimeInterval(1),
+                turnID: "turn-1",
+                itemID: "status-item",
+                orderIndex: nextOrder()
+            ),
+            makeMessage(
+                id: "file-change",
+                threadID: "thread",
+                role: .system,
+                kind: .fileChange,
+                text: "Path: Sources/App.swift\nKind: update\nTotals: +1 -0",
+                createdAt: now.addingTimeInterval(2),
+                turnID: "turn-1",
+                itemID: "file-change-item",
+                orderIndex: nextOrder()
+            ),
+            makeMessage(
+                id: "assistant-final",
+                threadID: "thread",
+                role: .assistant,
+                kind: .chat,
+                text: "Done",
+                createdAt: now.addingTimeInterval(3),
+                turnID: "turn-1",
+                itemID: "final-item",
+                orderIndex: nextOrder()
+            ),
+        ]
+
+        let reordered = TurnTimelineReducer.enforceIntraTurnOrder(in: messages)
+        XCTAssertEqual(reordered.map(\.id), [
+            "user-1",
+            "assistant-status",
+            "assistant-final",
+            "file-change",
+        ])
+    }
+
     func testEnforceIntraTurnOrderKeepsSteerUserNearBottomOfInterleavedTurn() {
         let now = Date()
         var order = 0
@@ -1970,7 +2281,7 @@ final class TurnTimelineReducerTests: XCTestCase {
             stoppedTurnIDs: []
         )
 
-        XCTAssertEqual(blockInfo, ["Completed response"])
+        XCTAssertEqual(blockInfo[0]?.copyText, "Completed response")
     }
 
     func testAssistantBlockInfoHidesCopyWhenLatestRunStopped() {
@@ -2070,6 +2381,91 @@ final class TurnTimelineReducerTests: XCTestCase {
         )
         XCTAssertEqual(blockInfo[2]?.blockDiffEntries?.first?.additions, 1)
         XCTAssertEqual(blockInfo[2]?.blockDiffEntries?.first?.deletions, 0)
+    }
+
+    func testCollapsedFinalMessageKeepsBlockDiffActionsWhenLateActivityIsHidden() {
+        let now = Date()
+        let messages = [
+            makeMessage(
+                id: "user",
+                threadID: "thread",
+                role: .user,
+                kind: .chat,
+                text: "Fix the bug",
+                createdAt: now,
+                turnID: "turn-1",
+                orderIndex: 1
+            ),
+            makeMessage(
+                id: "file-change",
+                threadID: "thread",
+                role: .system,
+                kind: .fileChange,
+                text: """
+                Status: completed
+
+                Path: Sources/App.swift
+                Kind: update
+                Totals: +1 -0
+                """,
+                createdAt: now.addingTimeInterval(1),
+                turnID: "turn-1",
+                orderIndex: 2
+            ),
+            makeMessage(
+                id: "final",
+                threadID: "thread",
+                role: .assistant,
+                kind: .chat,
+                text: "Done.",
+                createdAt: now.addingTimeInterval(2),
+                turnID: "turn-1",
+                itemID: "final-item",
+                orderIndex: 3
+            ),
+            makeMessage(
+                id: "late-tool",
+                threadID: "thread",
+                role: .system,
+                kind: .toolActivity,
+                text: "Late metadata refresh",
+                createdAt: now.addingTimeInterval(3),
+                turnID: "turn-1",
+                orderIndex: 4
+            ),
+        ]
+
+        let blockInfo = TurnTimelineView<EmptyView, EmptyView>.assistantBlockInfo(
+            for: messages,
+            activeTurnID: nil,
+            isThreadRunning: false,
+            latestTurnTerminalState: .completed,
+            stoppedTurnIDs: []
+        )
+        let initialStates = [String: AssistantBlockAccessoryState](
+            uniqueKeysWithValues: zip(messages, blockInfo).compactMap { message, state in
+                guard let state else { return nil }
+                return (message.id, state)
+            }
+        )
+
+        let rehousedStates = TurnTimelineView<EmptyView, EmptyView>.rehomeCollapsedFinalAccessoryStates(
+            initialStates,
+            messages: messages,
+            completedTurnIDs: ["turn-1"]
+        )
+
+        XCTAssertEqual(
+            TurnTimelineRenderProjection.project(
+                messages: messages,
+                completedTurnIDs: ["turn-1"]
+            ).map(\.id),
+            ["user", "previous-messages:final", "file-change", "final"]
+        )
+        XCTAssertNil(initialStates["final"]?.blockDiffEntries)
+        XCTAssertEqual(rehousedStates["final"]?.copyText, "Done.")
+        XCTAssertEqual(rehousedStates["final"]?.blockDiffEntries?.count, 1)
+        XCTAssertEqual(rehousedStates["final"]?.blockDiffEntries?.first?.path, "Sources/App.swift")
     }
 
     func testAssistantBlockInfoMergesDifferentSnapshotsForSameFile() {

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -2,11 +2,12 @@
 // Purpose: Runs Codex locally, bridges relay traffic, and coordinates desktop refreshes for Codex.app.
 // Layer: CLI service
 // Exports: startBridge
-// Depends on: ws, crypto, os, ./qr, ./codex-desktop-refresher, ./codex-transport, ./rollout-watch, ./voice-handler, ./ios-app-compatibility
+// Depends on: ws, crypto, os, ./codex-home, ./qr, ./codex-desktop-refresher, ./codex-transport, ./rollout-watch, ./voice-handler, ./ios-app-compatibility
 
 const WebSocket = require("ws");
 const { randomBytes } = require("crypto");
 const { execFile, spawn } = require("child_process");
+const path = require("path");
 const os = require("os");
 const { promisify } = require("util");
 const {
@@ -31,6 +32,7 @@ const {
 const { createBridgePackageVersionStatusReader } = require("./package-version-status");
 const { createPushNotificationServiceClient } = require("./push-notification-service-client");
 const { createPushNotificationTracker } = require("./push-notification-tracker");
+const { resolveCodexGeneratedImagesRoot } = require("./codex-home");
 const {
   loadOrCreateBridgeDeviceState,
   rememberLastSeenPhoneAppVersion,
@@ -529,7 +531,10 @@ function startBridge({
 
   // Encrypts bridge-generated responses instead of letting the relay see plaintext.
   function sendApplicationResponse(rawMessage) {
-    secureTransport.queueOutboundApplicationMessage(rawMessage, sendRelayWireMessage);
+    secureTransport.queueOutboundApplicationMessage(
+      sanitizeRelayBoundCodexMessage(rawMessage),
+      sendRelayWireMessage
+    );
   }
 
   // Mirrors accepted local renames back to the phone using the existing push-event shape.
@@ -712,7 +717,7 @@ function startBridge({
     const parsed = safeParseJSON(rawMessage);
     const responseId = parsed?.id;
     if (responseId == null) {
-      return rawMessage;
+      return sanitizeLiveGeneratedImageMessageForRelay(rawMessage);
     }
 
     const trackedRequest = relaySanitizedResponseMethodsById.get(String(responseId));
@@ -1370,13 +1375,20 @@ function sanitizeThreadHistoryImagesForRelay(rawMessage, requestMethod) {
     }
 
     let turnDidChange = false;
+    const threadId = normalizeNonEmptyString(thread.id)
+      || normalizeNonEmptyString(thread.threadId)
+      || normalizeNonEmptyString(thread.thread_id);
+
     const sanitizedItems = turn.items.map((item) => {
       if (!item || typeof item !== "object") {
         return item;
       }
 
       let itemDidChange = false;
-      let sanitizedItem = item;
+      let sanitizedItem = annotateImageGenerationHistoryItem(item, threadId);
+      if (sanitizedItem !== item) {
+        itemDidChange = true;
+      }
 
       if (Array.isArray(item.content)) {
         const sanitizedContent = item.content.map((contentItem) => {
@@ -1438,6 +1450,84 @@ function sanitizeThreadHistoryImagesForRelay(rawMessage, requestMethod) {
   return trimThreadPayloadForRelay(parseBridgeJSON(sanitizedPayload), null) ?? sanitizedPayload;
 }
 
+// Annotates live image-generation notifications so the phone can render a local-file
+// preview and does not receive the bulky inline base64 result over the relay.
+function sanitizeLiveGeneratedImageMessageForRelay(rawMessage) {
+  const parsed = parseBridgeJSON(rawMessage);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return rawMessage;
+  }
+
+  const params = parsed.params;
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return rawMessage;
+  }
+
+  const sanitizedParams = sanitizeLiveGeneratedImageParams(params);
+  if (sanitizedParams === params) {
+    return rawMessage;
+  }
+
+  return JSON.stringify({
+    ...parsed,
+    params: sanitizedParams,
+  });
+}
+
+function sanitizeLiveGeneratedImageParams(params) {
+  const threadId = liveGeneratedImageThreadId(params);
+  let nextParams = params;
+  let didChange = false;
+
+  const item = params.item;
+  if (item && typeof item === "object" && !Array.isArray(item)) {
+    const sanitizedItem = annotateImageGenerationPayload(item, threadId);
+    if (sanitizedItem !== item) {
+      nextParams = { ...nextParams, item: sanitizedItem };
+      didChange = true;
+    }
+  }
+
+  const event = params.event;
+  if (event && typeof event === "object" && !Array.isArray(event)) {
+    const sanitizedEvent = sanitizeNestedGeneratedImagePayloads(event, threadId);
+    if (sanitizedEvent !== event) {
+      nextParams = { ...nextParams, event: sanitizedEvent };
+      didChange = true;
+    }
+  }
+
+  const sanitizedDirectParams = annotateImageGenerationPayload(nextParams, threadId);
+  if (sanitizedDirectParams !== nextParams) {
+    nextParams = sanitizedDirectParams;
+    didChange = true;
+  }
+
+  return didChange ? nextParams : params;
+}
+
+function sanitizeNestedGeneratedImagePayloads(value, threadId) {
+  let nextValue = annotateImageGenerationPayload(value, threadId);
+  let didChange = nextValue !== value;
+
+  for (const key of ["item", "payload", "data"]) {
+    const nested = nextValue?.[key];
+    if (!nested || typeof nested !== "object" || Array.isArray(nested)) {
+      continue;
+    }
+    const sanitizedNested = sanitizeNestedGeneratedImagePayloads(nested, threadId);
+    if (sanitizedNested !== nested) {
+      if (!didChange) {
+        nextValue = { ...nextValue };
+        didChange = true;
+      }
+      nextValue[key] = sanitizedNested;
+    }
+  }
+
+  return didChange ? nextValue : value;
+}
+
 // Drops huge replacement-history blobs from compaction items because the phone only needs
 // the compacted marker itself, not the entire pre-compaction transcript snapshot.
 function sanitizeCompactionHistoryItem(item) {
@@ -1478,6 +1568,108 @@ function omitCompactionReplacementHistory(value) {
   }
 
   return didChange ? nextValue : value;
+}
+
+function annotateImageGenerationHistoryItem(item, threadId) {
+  if (!item || typeof item !== "object") {
+    return item;
+  }
+
+  const normalizedType = normalizeRelayHistoryContentType(item.type);
+  if (!isGeneratedImageRelayType(normalizedType)) {
+    return item;
+  }
+
+  return annotateImageGenerationPayload(item, threadId);
+}
+
+function annotateImageGenerationPayload(item, threadId) {
+  if (!item || typeof item !== "object" || Array.isArray(item)) {
+    return item;
+  }
+
+  const normalizedType = normalizeRelayHistoryContentType(item.type);
+  if (!isGeneratedImageRelayType(normalizedType)) {
+    return item;
+  }
+
+  let nextItem = item;
+  let didChange = false;
+  const existingPath = normalizeNonEmptyString(item.saved_path)
+    || normalizeNonEmptyString(item.savedPath)
+    || normalizeNonEmptyString(item.path)
+    || normalizeNonEmptyString(item.file_path);
+  const generatedPath = existingPath || generatedImagePathForHistoryItem(item, threadId);
+  if (generatedPath && !existingPath) {
+    nextItem = {
+      ...nextItem,
+      saved_path: generatedPath,
+    };
+    didChange = true;
+  }
+
+  if (typeof nextItem.result === "string" && nextItem.result.length > 0) {
+    const {
+      result: _result,
+      ...withoutInlineResult
+    } = nextItem;
+    nextItem = {
+      ...withoutInlineResult,
+      result_elided_for_relay: true,
+    };
+    didChange = true;
+  }
+
+  return didChange ? nextItem : item;
+}
+
+function generatedImagePathForHistoryItem(item, threadId) {
+  const resolvedThreadId = normalizeNonEmptyString(threadId);
+  const normalizedType = normalizeRelayHistoryContentType(item.type);
+  const callId = normalizedType === "imagegenerationend"
+    ? normalizeNonEmptyString(item.call_id)
+      || normalizeNonEmptyString(item.callId)
+      || normalizeNonEmptyString(item.itemId)
+      || normalizeNonEmptyString(item.item_id)
+      || normalizeNonEmptyString(item.id)
+    : normalizeNonEmptyString(item.id)
+      || normalizeNonEmptyString(item.call_id)
+      || normalizeNonEmptyString(item.callId)
+      || normalizeNonEmptyString(item.itemId)
+      || normalizeNonEmptyString(item.item_id);
+  if (!resolvedThreadId || !callId) {
+    return "";
+  }
+
+  return path.join(resolveCodexGeneratedImagesRoot(), resolvedThreadId, `${callId}.png`);
+}
+
+function isGeneratedImageRelayType(normalizedType) {
+  return normalizedType === "imagegeneration"
+    || normalizedType === "imagegenerationcall"
+    || normalizedType === "imagegenerationend"
+    || normalizedType === "imageview";
+}
+
+function liveGeneratedImageThreadId(params) {
+  const event = params?.event && typeof params.event === "object" && !Array.isArray(params.event)
+    ? params.event
+    : null;
+  const item = params?.item && typeof params.item === "object" && !Array.isArray(params.item)
+    ? params.item
+    : null;
+
+  return normalizeNonEmptyString(params?.threadId)
+    || normalizeNonEmptyString(params?.thread_id)
+    || normalizeNonEmptyString(params?.conversationId)
+    || normalizeNonEmptyString(params?.conversation_id)
+    || normalizeNonEmptyString(event?.threadId)
+    || normalizeNonEmptyString(event?.thread_id)
+    || normalizeNonEmptyString(event?.conversationId)
+    || normalizeNonEmptyString(event?.conversation_id)
+    || normalizeNonEmptyString(item?.threadId)
+    || normalizeNonEmptyString(item?.thread_id)
+    || "";
 }
 
 // Converts `data:image/...` history content into a tiny placeholder the iPhone can render safely.
@@ -1811,6 +2003,7 @@ module.exports = {
   createMacOSBridgeWakeAssertion,
   hasRelayConnectionGoneStale,
   persistBridgePreferences,
+  sanitizeLiveGeneratedImageMessageForRelay,
   sanitizeThreadHistoryImagesForRelay,
   startBridge,
 };

--- a/phodex-bridge/src/codex-home.js
+++ b/phodex-bridge/src/codex-home.js
@@ -1,0 +1,21 @@
+// FILE: codex-home.js
+// Purpose: Resolves local Codex cache paths shared by bridge services.
+// Layer: CLI helper
+// Exports: resolveCodexHome, resolveCodexGeneratedImagesRoot
+// Depends on: os, path
+
+const os = require("os");
+const path = require("path");
+
+function resolveCodexHome() {
+  return process.env.CODEX_HOME || path.join(os.homedir(), ".codex");
+}
+
+function resolveCodexGeneratedImagesRoot() {
+  return path.join(resolveCodexHome(), "generated_images");
+}
+
+module.exports = {
+  resolveCodexGeneratedImagesRoot,
+  resolveCodexHome,
+};

--- a/phodex-bridge/src/rollout-live-mirror.js
+++ b/phodex-bridge/src/rollout-live-mirror.js
@@ -2,14 +2,16 @@
 // Purpose: Mirrors desktop-origin rollout activity back into live bridge notifications for iPhone catch-up.
 // Layer: CLI helper
 // Exports: createRolloutLiveMirrorController
-// Depends on: fs, crypto, ./rollout-watch
+// Depends on: fs, crypto, path, ./rollout-watch, ./codex-home
 
 const fs = require("fs");
 const crypto = require("crypto");
+const path = require("path");
 const {
   findRecentRolloutFileForContextRead,
   resolveSessionsRoot,
 } = require("./rollout-watch");
+const { resolveCodexGeneratedImagesRoot } = require("./codex-home");
 
 const DEFAULT_POLL_INTERVAL_MS = 700;
 const DEFAULT_LOOKUP_TIMEOUT_MS = 5_000;
@@ -391,6 +393,13 @@ function synthesizeNotificationsFromRolloutEntry(entry, state) {
       return notifications;
     }
 
+    if (eventType === "image_generation_end") {
+      notifications.push(...imageGenerationNotifications(state, payload, {
+        preferCallId: true,
+      }));
+      return notifications;
+    }
+
     return [];
   }
 
@@ -399,20 +408,25 @@ function synthesizeNotificationsFromRolloutEntry(entry, state) {
   }
 
   const payload = entry.payload || {};
-  const itemType = readString(payload.type);
+  const itemType = normalizeRolloutItemType(payload.type);
 
   if (itemType === "reasoning") {
     notifications.push(...reasoningNotifications(state, extractReasoningText(payload)));
     return notifications;
   }
 
-  if (itemType === "function_call") {
+  if (itemType === "functioncall") {
     notifications.push(...toolStartNotifications(state, payload));
     return notifications;
   }
 
-  if (itemType === "function_call_output") {
+  if (itemType === "functioncalloutput") {
     notifications.push(...toolOutputNotifications(state, payload));
+    return notifications;
+  }
+
+  if (itemType === "imagegeneration" || itemType === "imagegenerationcall" || itemType === "imagegenerationend" || itemType === "imageview") {
+    notifications.push(...imageGenerationNotifications(state, payload));
     return notifications;
   }
 
@@ -533,6 +547,54 @@ function toolOutputNotifications(state, payload) {
   }));
   state.commandCalls.delete(callId);
   return notifications;
+}
+
+function imageGenerationNotifications(state, payload, { preferCallId = false } = {}) {
+  if (!state.activeTurnId) {
+    return [];
+  }
+
+  const callId = preferCallId
+    ? firstNonEmptyString([
+        readString(payload.call_id),
+        readString(payload.callId),
+        readString(payload.itemId),
+        readString(payload.item_id),
+        readString(payload.id),
+      ])
+    : firstNonEmptyString([
+        readString(payload.id),
+        readString(payload.call_id),
+        readString(payload.callId),
+        readString(payload.itemId),
+        readString(payload.item_id),
+      ]);
+  if (!callId) {
+    return [];
+  }
+
+  const imagePath = firstNonEmptyString([
+    readString(payload.saved_path),
+    readString(payload.savedPath),
+    readString(payload.file_path),
+    readString(payload.path),
+  ]) || generatedImagePathForRolloutItem(state.threadId, callId);
+  if (!imagePath) {
+    return [];
+  }
+
+  return [
+    ...ensureThinkingNotifications(state),
+    createNotification("codex/event/image_generation_end", {
+      threadId: state.threadId,
+      turnId: state.activeTurnId,
+      call_id: callId,
+      itemId: callId,
+      saved_path: imagePath,
+      file_path: imagePath,
+      path: imagePath,
+    }),
+  ];
 }
 
 function ensureThinkingNotifications(state) {
@@ -682,6 +744,20 @@ function buildAgentMessageItemId(threadId, turnId, entry, message) {
     turnId || "turnless",
     `${timestamp}:${messageHash}`
   );
+}
+
+function generatedImagePathForRolloutItem(threadId, callId) {
+  const resolvedThreadId = readString(threadId);
+  const resolvedCallId = readString(callId);
+  if (!resolvedThreadId || !resolvedCallId) {
+    return "";
+  }
+
+  return path.join(resolveCodexGeneratedImagesRoot(), resolvedThreadId, `${resolvedCallId}.png`);
+}
+
+function normalizeRolloutItemType(value) {
+  return readString(value).replace(/[_-]/g, "").toLowerCase();
 }
 
 function resetRunState(state) {

--- a/phodex-bridge/src/workspace-handler.js
+++ b/phodex-bridge/src/workspace-handler.js
@@ -2,18 +2,22 @@
 // Purpose: Executes workspace-scoped reverse patch previews/applies without touching unrelated repo changes.
 // Layer: Bridge handler
 // Exports: handleWorkspaceRequest
-// Depends on: child_process, fs, os, path, ./git-handler
+// Depends on: child_process, fs, os, path, ./codex-home, ./git-handler
 
 const { execFile } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const { promisify } = require("util");
+const { resolveCodexGeneratedImagesRoot } = require("./codex-home");
 const { gitStatus } = require("./git-handler");
 
 const execFileAsync = promisify(execFile);
 const GIT_TIMEOUT_MS = 30_000;
 const MAX_IMAGE_READ_BYTES = 8 * 1024 * 1024;
+const MAX_IMAGE_PREVIEW_READ_BYTES = 2 * 1024 * 1024;
+const MIN_IMAGE_PREVIEW_PIXEL_DIMENSION = 128;
+const MAX_IMAGE_PREVIEW_PIXEL_DIMENSION = 3_200;
 const IMAGE_MIME_TYPES_BY_EXTENSION = new Map([
   [".jpg", "image/jpeg"],
   [".jpeg", "image/jpeg"],
@@ -102,7 +106,7 @@ async function workspaceReadImage(params) {
 
   const [realImagePath, realGeneratedImagesRoot] = await Promise.all([
     realpathOrNull(imagePath),
-    realpathOrNull(path.join(os.homedir(), ".codex", "generated_images")),
+    realpathOrNull(resolveCodexGeneratedImagesRoot()),
   ]);
   if (!realImagePath) {
     throw workspaceError("image_not_found", "The image file no longer exists on this Mac.");
@@ -121,44 +125,97 @@ async function workspaceReadImage(params) {
   if (!stat.isFile()) {
     throw workspaceError("image_not_found", "The image path is not a file.");
   }
-  if (stat.size > MAX_IMAGE_READ_BYTES) {
+  const includeData = params.includeData !== false && params.metadataOnly !== true;
+  const maxPixelDimension = normalizedPreviewPixelDimension(params);
+  if (stat.size > MAX_IMAGE_READ_BYTES && !maxPixelDimension) {
     throw workspaceError(
       "image_too_large",
       "This image is too large to send to the phone. Open it on the Mac or move a smaller preview into the workspace."
     );
   }
 
-  const includeData = params.includeData !== false && params.metadataOnly !== true;
   const result = {
     path: realImagePath,
     fileName: path.basename(realImagePath),
     mimeType,
     byteLength: stat.size,
     mtimeMs: stat.mtimeMs,
+    previewMaxPixelDimension: maxPixelDimension || undefined,
   };
   if (!includeData) {
     return result;
   }
-  if (isUnchangedImageRead(params, stat)) {
+  if (isUnchangedImageRead(params, stat, maxPixelDimension)) {
     return {
       ...result,
       notModified: true,
     };
   }
 
-  const data = await fs.promises.readFile(realImagePath);
+  const data = maxPixelDimension
+    ? await readPreviewImageData(realImagePath, maxPixelDimension)
+    : await fs.promises.readFile(realImagePath);
   return {
     ...result,
-    byteLength: data.length,
+    dataByteLength: data.length,
     dataBase64: data.toString("base64"),
   };
 }
 
-function isUnchangedImageRead(params, stat) {
+function normalizedPreviewPixelDimension(params) {
+  const requested = Number(params.maxPixelDimension || params.previewMaxPixelDimension);
+  if (!Number.isFinite(requested) || requested <= 0) {
+    return null;
+  }
+  return Math.min(
+    MAX_IMAGE_PREVIEW_PIXEL_DIMENSION,
+    Math.max(MIN_IMAGE_PREVIEW_PIXEL_DIMENSION, Math.round(requested))
+  );
+}
+
+async function readPreviewImageData(imagePath, maxPixelDimension) {
+  let previewData;
+  try {
+    previewData = await downsampleImageWithSips(imagePath, maxPixelDimension);
+  } catch {
+    throw workspaceError(
+      "image_preview_failed",
+      "This image could not be converted into a lightweight phone preview."
+    );
+  }
+  if (!previewData || previewData.length === 0 || previewData.length > MAX_IMAGE_PREVIEW_READ_BYTES) {
+    throw workspaceError(
+      "image_preview_too_large",
+      "This image preview is still too large to send to the phone."
+    );
+  }
+  return previewData;
+}
+
+async function downsampleImageWithSips(imagePath, maxPixelDimension) {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "remodex-image-preview-"));
+  const outputPath = path.join(tempDir, `preview${path.extname(imagePath) || ".png"}`);
+  try {
+    await execFileAsync("sips", ["-Z", String(maxPixelDimension), imagePath, "--out", outputPath], {
+      timeout: 15_000,
+      maxBuffer: 1024 * 1024,
+    });
+    return await fs.promises.readFile(outputPath);
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function isUnchangedImageRead(params, stat, maxPixelDimension) {
   const cachedByteLength = Number(params.ifByteLength);
   const cachedMtimeMs = Number(params.ifMtimeMs);
+  const cachedPreviewMaxPixelDimension = Number(params.ifPreviewMaxPixelDimension || params.ifMaxPixelDimension);
+  const previewDimensionMatches = maxPixelDimension
+    ? Number.isFinite(cachedPreviewMaxPixelDimension) && cachedPreviewMaxPixelDimension === maxPixelDimension
+    : !Number.isFinite(cachedPreviewMaxPixelDimension);
   return Number.isFinite(cachedByteLength)
     && Number.isFinite(cachedMtimeMs)
+    && previewDimensionMatches
     && cachedByteLength === stat.size
     && cachedMtimeMs === stat.mtimeMs;
 }

--- a/phodex-bridge/test/bridge.test.js
+++ b/phodex-bridge/test/bridge.test.js
@@ -2,15 +2,19 @@
 // Purpose: Verifies relay watchdog helpers used to recover from stale sleep/wake sockets.
 // Layer: Unit test
 // Exports: node:test suite
-// Depends on: node:test, node:assert/strict, ../src/bridge
+// Depends on: node:test, node:assert/strict, fs, os, path, ../src/bridge
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
 const {
   buildHeartbeatBridgeStatus,
   createMacOSBridgeWakeAssertion,
   hasRelayConnectionGoneStale,
   persistBridgePreferences,
+  sanitizeLiveGeneratedImageMessageForRelay,
   sanitizeThreadHistoryImagesForRelay,
 } = require("../src/bridge");
 
@@ -168,6 +172,267 @@ test("sanitizeThreadHistoryImagesForRelay replaces input_image history data URLs
     type: "input_image",
     url: "remodex://history-image-elided",
   });
+});
+
+test("sanitizeThreadHistoryImagesForRelay annotates generated image calls with local paths", () => {
+  const rawMessage = JSON.stringify({
+    id: "req-thread-generated-image",
+    result: {
+      thread: {
+        id: "thread-generated-image",
+        turns: [
+          {
+            id: "turn-1",
+            items: [
+              {
+                id: "ig_123",
+                type: "image_generation_call",
+                status: "generating",
+                result: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  const sanitized = JSON.parse(
+    sanitizeThreadHistoryImagesForRelay(rawMessage, "thread/read")
+  );
+  const item = sanitized.result.thread.turns[0].items[0];
+
+  assert.equal(
+    item.saved_path,
+    path.join(os.homedir(), ".codex", "generated_images", "thread-generated-image", "ig_123.png")
+  );
+  assert.equal(item.result, undefined);
+  assert.equal(item.result_elided_for_relay, true);
+});
+
+test("sanitizeThreadHistoryImagesForRelay annotates image generation items with local paths", () => {
+  const rawMessage = JSON.stringify({
+    id: "req-thread-image-generation",
+    result: {
+      thread: {
+        id: "thread-image-generation",
+        turns: [
+          {
+            id: "turn-1",
+            items: [
+              {
+                id: "ig_generation",
+                type: "image_generation",
+                result: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  const sanitized = JSON.parse(
+    sanitizeThreadHistoryImagesForRelay(rawMessage, "thread/read")
+  );
+  const item = sanitized.result.thread.turns[0].items[0];
+
+  assert.equal(
+    item.saved_path,
+    path.join(os.homedir(), ".codex", "generated_images", "thread-image-generation", "ig_generation.png")
+  );
+  assert.equal(item.result, undefined);
+  assert.equal(item.result_elided_for_relay, true);
+});
+
+test("sanitizeThreadHistoryImagesForRelay annotates image end history with local paths", () => {
+  const rawMessage = JSON.stringify({
+    id: "req-thread-generated-image-end",
+    result: {
+      thread: {
+        id: "thread-generated-image-end",
+        turns: [
+          {
+            id: "turn-1",
+            items: [
+              {
+                id: "turn-1",
+                type: "image_generation_end",
+                call_id: "ig_end",
+                result: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  const sanitized = JSON.parse(
+    sanitizeThreadHistoryImagesForRelay(rawMessage, "thread/read")
+  );
+  const item = sanitized.result.thread.turns[0].items[0];
+
+  assert.equal(
+    item.saved_path,
+    path.join(os.homedir(), ".codex", "generated_images", "thread-generated-image-end", "ig_end.png")
+  );
+  assert.equal(item.result, undefined);
+  assert.equal(item.result_elided_for_relay, true);
+});
+
+test("sanitizeThreadHistoryImagesForRelay uses CODEX_HOME for generated image fallbacks", (t) => {
+  const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-codex-home-"));
+  const previousCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = codexHome;
+  t.after(() => {
+    if (previousCodexHome == null) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = previousCodexHome;
+    }
+    fs.rmSync(codexHome, { recursive: true, force: true });
+  });
+
+  const rawMessage = JSON.stringify({
+    id: "req-thread-generated-image-codex-home",
+    result: {
+      thread: {
+        id: "thread-generated-image-home",
+        turns: [
+          {
+            id: "turn-1",
+            items: [
+              {
+                id: "ig_home",
+                type: "imageView",
+                result: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  const sanitized = JSON.parse(
+    sanitizeThreadHistoryImagesForRelay(rawMessage, "thread/read")
+  );
+  const item = sanitized.result.thread.turns[0].items[0];
+
+  assert.equal(
+    item.saved_path,
+    path.join(codexHome, "generated_images", "thread-generated-image-home", "ig_home.png")
+  );
+  assert.equal(item.result, undefined);
+  assert.equal(item.result_elided_for_relay, true);
+});
+
+test("sanitizeThreadHistoryImagesForRelay preserves generated image file_path without saved_path", () => {
+  const rawMessage = JSON.stringify({
+    id: "req-thread-generated-image-file-path",
+    result: {
+      thread: {
+        id: "thread-generated-image",
+        turns: [
+          {
+            id: "turn-1",
+            items: [
+              {
+                id: "ig_123",
+                type: "image_generation_call",
+                file_path: "/tmp/real-generated-image.png",
+                status: "completed",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  const sanitized = JSON.parse(
+    sanitizeThreadHistoryImagesForRelay(rawMessage, "thread/read")
+  );
+  const item = sanitized.result.thread.turns[0].items[0];
+
+  assert.equal(item.file_path, "/tmp/real-generated-image.png");
+  assert.equal(item.saved_path, undefined);
+});
+
+test("sanitizeLiveGeneratedImageMessageForRelay annotates completed image items", () => {
+  const rawMessage = JSON.stringify({
+    method: "item/completed",
+    params: {
+      threadId: "thread-live-image",
+      turnId: "turn-1",
+      item: {
+        id: "ig_live",
+        type: "image_generation_call",
+        result: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+      },
+    },
+  });
+
+  const sanitized = JSON.parse(sanitizeLiveGeneratedImageMessageForRelay(rawMessage));
+  const item = sanitized.params.item;
+
+  assert.equal(
+    item.saved_path,
+    path.join(os.homedir(), ".codex", "generated_images", "thread-live-image", "ig_live.png")
+  );
+  assert.equal(item.result, undefined);
+  assert.equal(item.result_elided_for_relay, true);
+});
+
+test("sanitizeLiveGeneratedImageMessageForRelay elides nested completed image items", () => {
+  const rawMessage = JSON.stringify({
+    method: "item/completed",
+    params: {
+      threadId: "thread-live-nested-image",
+      turnId: "turn-1",
+      event: {
+        type: "item_completed",
+        item: {
+          id: "ig_nested",
+          type: "image_generation",
+          result: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+        },
+      },
+    },
+  });
+
+  const sanitized = JSON.parse(sanitizeLiveGeneratedImageMessageForRelay(rawMessage));
+  const item = sanitized.params.event.item;
+
+  assert.equal(
+    item.saved_path,
+    path.join(os.homedir(), ".codex", "generated_images", "thread-live-nested-image", "ig_nested.png")
+  );
+  assert.equal(item.result, undefined);
+  assert.equal(item.result_elided_for_relay, true);
+});
+
+test("sanitizeLiveGeneratedImageMessageForRelay uses call id for image end events", () => {
+  const rawMessage = JSON.stringify({
+    method: "image_generation_end",
+    params: {
+      type: "image_generation_end",
+      threadId: "thread-live-event",
+      id: "turn-1",
+      call_id: "ig_event",
+      result: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+    },
+  });
+
+  const sanitized = JSON.parse(sanitizeLiveGeneratedImageMessageForRelay(rawMessage));
+
+  assert.equal(
+    sanitized.params.saved_path,
+    path.join(os.homedir(), ".codex", "generated_images", "thread-live-event", "ig_event.png")
+  );
+  assert.equal(sanitized.params.result, undefined);
+  assert.equal(sanitized.params.result_elided_for_relay, true);
 });
 
 test("sanitizeThreadHistoryImagesForRelay leaves unrelated RPC payloads unchanged", () => {

--- a/phodex-bridge/test/rollout-live-mirror.test.js
+++ b/phodex-bridge/test/rollout-live-mirror.test.js
@@ -2,7 +2,7 @@
 // Purpose: Verifies desktop-origin rollout replay/live tailing emits thinking and tool-call notifications for iPhone only.
 // Layer: Unit test
 // Exports: node:test suite
-// Depends on: node:test, node:assert/strict, ../src/rollout-live-mirror
+// Depends on: node:test, node:assert/strict, fs, os, path, ../src/rollout-live-mirror
 
 const fs = require("node:fs");
 const os = require("node:os");
@@ -124,6 +124,205 @@ test("desktop-origin bootstrap replays the pending user message and final assist
     outbound[3].params.itemId,
     "rollout-agent-message:thread-chat:turn-chat:2026-03-15T19:47:40.000Z:73e01b91e228"
   );
+});
+
+test("desktop-origin active runs mirror generated image previews", async (t) => {
+  const { homeDir } = createTemporaryRolloutHome({
+    threadId: "thread-image",
+    originator: "Codex Desktop",
+    source: "desktop",
+    lines: [
+      taskStarted("turn-image"),
+      imageGenerationCall("ig_123"),
+    ],
+  });
+  const previousCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = homeDir;
+  t.after(() => {
+    restoreCodexHome(previousCodexHome);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  const outbound = [];
+  const controller = createRolloutLiveMirrorController({
+    sendApplicationResponse(message) {
+      outbound.push(JSON.parse(message));
+    },
+    pollIntervalMs: 5,
+    idleTimeoutMs: 50,
+  });
+  t.after(() => controller.stopAll());
+
+  controller.observeInbound(JSON.stringify({
+    method: "thread/resume",
+    params: {
+      threadId: "thread-image",
+    },
+  }));
+
+  await wait(30);
+
+  assert.deepEqual(
+    outbound.map((message) => message.method),
+    [
+      "turn/started",
+      "item/reasoning/textDelta",
+      "codex/event/image_generation_end",
+    ]
+  );
+  assert.equal(outbound[2].params.call_id, "ig_123");
+  assert.equal(outbound[2].params.itemId, "ig_123");
+  assert.equal(outbound[2].params.turnId, "turn-image");
+  assert.equal(
+    outbound[2].params.saved_path,
+    path.join(homeDir, "generated_images", "thread-image", "ig_123.png")
+  );
+});
+
+test("desktop-origin active runs mirror imageView items", async (t) => {
+  const { homeDir } = createTemporaryRolloutHome({
+    threadId: "thread-image-view",
+    originator: "Codex Desktop",
+    source: "desktop",
+    lines: [
+      taskStarted("turn-image-view"),
+      imageViewItem("view_123", "/tmp/generated view.png"),
+    ],
+  });
+  const previousCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = homeDir;
+  t.after(() => {
+    restoreCodexHome(previousCodexHome);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  const outbound = [];
+  const controller = createRolloutLiveMirrorController({
+    sendApplicationResponse(message) {
+      outbound.push(JSON.parse(message));
+    },
+    pollIntervalMs: 5,
+    idleTimeoutMs: 50,
+  });
+  t.after(() => controller.stopAll());
+
+  controller.observeInbound(JSON.stringify({
+    method: "thread/resume",
+    params: {
+      threadId: "thread-image-view",
+    },
+  }));
+
+  await wait(30);
+
+  assert.deepEqual(
+    outbound.map((message) => message.method),
+    [
+      "turn/started",
+      "item/reasoning/textDelta",
+      "codex/event/image_generation_end",
+    ]
+  );
+  assert.equal(outbound[2].params.call_id, "view_123");
+  assert.equal(outbound[2].params.saved_path, "/tmp/generated view.png");
+});
+
+test("desktop-origin active runs mirror image_generation items", async (t) => {
+  const { homeDir } = createTemporaryRolloutHome({
+    threadId: "thread-image-generation",
+    originator: "Codex Desktop",
+    source: "desktop",
+    lines: [
+      taskStarted("turn-image-generation"),
+      imageGenerationItem("ig_generation", "/tmp/generated item.png"),
+    ],
+  });
+  const previousCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = homeDir;
+  t.after(() => {
+    restoreCodexHome(previousCodexHome);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  const outbound = [];
+  const controller = createRolloutLiveMirrorController({
+    sendApplicationResponse(message) {
+      outbound.push(JSON.parse(message));
+    },
+    pollIntervalMs: 5,
+    idleTimeoutMs: 50,
+  });
+  t.after(() => controller.stopAll());
+
+  controller.observeInbound(JSON.stringify({
+    method: "thread/resume",
+    params: {
+      threadId: "thread-image-generation",
+    },
+  }));
+
+  await wait(30);
+
+  assert.deepEqual(
+    outbound.map((message) => message.method),
+    [
+      "turn/started",
+      "item/reasoning/textDelta",
+      "codex/event/image_generation_end",
+    ]
+  );
+  assert.equal(outbound[2].params.call_id, "ig_generation");
+  assert.equal(outbound[2].params.saved_path, "/tmp/generated item.png");
+});
+
+test("desktop-origin active runs mirror generated image end events without response items", async (t) => {
+  const { homeDir } = createTemporaryRolloutHome({
+    threadId: "thread-image-event",
+    originator: "Codex Desktop",
+    source: "desktop",
+    lines: [
+      taskStarted("turn-image-event"),
+      imageGenerationEnd("turn-image-event", "ig_event", "/tmp/generated event.png"),
+    ],
+  });
+  const previousCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = homeDir;
+  t.after(() => {
+    restoreCodexHome(previousCodexHome);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  const outbound = [];
+  const controller = createRolloutLiveMirrorController({
+    sendApplicationResponse(message) {
+      outbound.push(JSON.parse(message));
+    },
+    pollIntervalMs: 5,
+    idleTimeoutMs: 50,
+  });
+  t.after(() => controller.stopAll());
+
+  controller.observeInbound(JSON.stringify({
+    method: "thread/resume",
+    params: {
+      threadId: "thread-image-event",
+    },
+  }));
+
+  await wait(30);
+
+  assert.deepEqual(
+    outbound.map((message) => message.method),
+    [
+      "turn/started",
+      "item/reasoning/textDelta",
+      "codex/event/image_generation_end",
+    ]
+  );
+  assert.equal(outbound[2].params.call_id, "ig_event");
+  assert.equal(outbound[2].params.itemId, "ig_event");
+  assert.equal(outbound[2].params.turnId, "turn-image-event");
+  assert.equal(outbound[2].params.saved_path, "/tmp/generated event.png");
 });
 
 test("phone-origin rollouts do not emit mirrored updates", async (t) => {
@@ -302,6 +501,59 @@ function functionCallOutput(callId, output) {
       type: "function_call_output",
       call_id: callId,
       output,
+    },
+  });
+}
+
+function imageGenerationCall(itemId) {
+  return JSON.stringify({
+    timestamp: "2026-03-15T19:47:39.500Z",
+    type: "response_item",
+    payload: {
+      id: itemId,
+      type: "image_generation_call",
+      status: "completed",
+      result: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+    },
+  });
+}
+
+function imageGenerationEnd(turnId, callId, savedPath) {
+  return JSON.stringify({
+    timestamp: "2026-03-15T19:47:39.500Z",
+    type: "event_msg",
+    payload: {
+      type: "image_generation_end",
+      id: turnId,
+      turn_id: turnId,
+      call_id: callId,
+      saved_path: savedPath,
+      result: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+    },
+  });
+}
+
+function imageViewItem(itemId, imagePath) {
+  return JSON.stringify({
+    timestamp: "2026-03-15T19:47:39.500Z",
+    type: "response_item",
+    payload: {
+      id: itemId,
+      type: "imageView",
+      path: imagePath,
+    },
+  });
+}
+
+function imageGenerationItem(itemId, imagePath) {
+  return JSON.stringify({
+    timestamp: "2026-03-15T19:47:39.500Z",
+    type: "response_item",
+    payload: {
+      id: itemId,
+      type: "image_generation",
+      path: imagePath,
+      result: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
     },
   });
 }

--- a/phodex-bridge/test/workspace-image.test.js
+++ b/phodex-bridge/test/workspace-image.test.js
@@ -12,6 +12,11 @@ const os = require("os");
 const path = require("path");
 const { handleWorkspaceMethod } = require("../src/workspace-handler");
 
+const validOnePixelPNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+  "base64"
+);
+
 test("workspace/readImage returns base64 image data for a file inside cwd", async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-image-"));
   execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
@@ -74,6 +79,76 @@ test("workspace/readImage skips bytes when cached metadata still matches", async
   assert.equal(second.dataBase64, undefined);
 });
 
+test("workspace/readImage accepts bounded preview reads", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-image-"));
+  execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+  const imagePath = path.join(tempDir, "preview.png");
+  const bytes = validOnePixelPNG;
+  fs.writeFileSync(imagePath, bytes);
+
+  const result = await handleWorkspaceMethod("workspace/readImage", {
+    cwd: tempDir,
+    path: imagePath,
+    maxPixelDimension: 1600,
+  });
+
+  assert.equal(result.path, fs.realpathSync(imagePath));
+  assert.equal(result.byteLength, bytes.length);
+  assert.equal(result.previewMaxPixelDimension, 1600);
+  assert.equal(typeof result.dataBase64, "string");
+  assert.ok(Buffer.from(result.dataBase64, "base64").length > 0);
+});
+
+test("workspace/readImage revalidates cached preview dimensions", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-image-"));
+  execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+  const imagePath = path.join(tempDir, "preview.png");
+  fs.writeFileSync(imagePath, validOnePixelPNG);
+
+  const first = await handleWorkspaceMethod("workspace/readImage", {
+    cwd: tempDir,
+    path: imagePath,
+    maxPixelDimension: 1600,
+  });
+  const samePreview = await handleWorkspaceMethod("workspace/readImage", {
+    cwd: tempDir,
+    path: imagePath,
+    maxPixelDimension: 1600,
+    ifByteLength: first.byteLength,
+    ifMtimeMs: first.mtimeMs,
+    ifPreviewMaxPixelDimension: first.previewMaxPixelDimension,
+  });
+  const differentPreview = await handleWorkspaceMethod("workspace/readImage", {
+    cwd: tempDir,
+    path: imagePath,
+    maxPixelDimension: 1200,
+    ifByteLength: first.byteLength,
+    ifMtimeMs: first.mtimeMs,
+    ifPreviewMaxPixelDimension: first.previewMaxPixelDimension,
+  });
+
+  assert.equal(samePreview.notModified, true);
+  assert.equal(differentPreview.notModified, undefined);
+  assert.equal(differentPreview.previewMaxPixelDimension, 1200);
+  assert.equal(typeof differentPreview.dataBase64, "string");
+});
+
+test("workspace/readImage does not fall back to original bytes when preview conversion fails", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-image-"));
+  execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+  const imagePath = path.join(tempDir, "corrupt.png");
+  fs.writeFileSync(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+  await assert.rejects(
+    () => handleWorkspaceMethod("workspace/readImage", {
+      cwd: tempDir,
+      path: imagePath,
+      maxPixelDimension: 1600,
+    }),
+    /lightweight phone preview/
+  );
+});
+
 test("workspace/readImage does not round cached mtime checks", async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-image-"));
   execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
@@ -122,6 +197,33 @@ test("workspace/readImage rejects workspace images when cwd is missing", async (
     }),
     /Only images in this workspace/
   );
+});
+
+test("workspace/readImage allows generated images under CODEX_HOME", async (t) => {
+  const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-codex-home-"));
+  const previousCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = codexHome;
+  t.after(() => {
+    if (previousCodexHome == null) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = previousCodexHome;
+    }
+    fs.rmSync(codexHome, { recursive: true, force: true });
+  });
+
+  const imageDir = path.join(codexHome, "generated_images", "thread-1");
+  fs.mkdirSync(imageDir, { recursive: true });
+  const imagePath = path.join(imageDir, "ig_123.png");
+  const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+  fs.writeFileSync(imagePath, bytes);
+
+  const result = await handleWorkspaceMethod("workspace/readImage", {
+    path: imagePath,
+  });
+
+  assert.equal(result.path, fs.realpathSync(imagePath));
+  assert.equal(result.dataBase64, bytes.toString("base64"));
 });
 
 test("workspace/readImage rejects cwd widening outside a repository", async () => {


### PR DESCRIPTION
## Summary
- Add support for syncing and rendering workspace images through the local bridge and mobile service layers
- Tighten incoming message, history, and sync handling to keep turn timelines consistent during live updates
- Expand coverage for command execution, message caching, rollout mirroring, and workspace image flows

## Testing
- Added and updated unit tests for bridge, rollout live mirroring, workspace image handling, service incoming execution, turn message caches, and timeline reduction
- Not run (not requested)