### PR TITLE
Refine fast mode model picker

### DIFF
--- a/CodexMobile/CodexMobile/Models/CodexModelOption.swift
+++ b/CodexMobile/CodexMobile/Models/CodexModelOption.swift
@@ -176,8 +176,6 @@ private enum CodexModelCapabilityResolver {
         "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
-        "gpt-5.3-codex",
-        "gpt-5.3-codex-spark",
         "gpt-5.2-codex",
         "gpt-5.2",
     ]

--- a/CodexMobile/CodexMobile/Models/CodexModelOption.swift
+++ b/CodexMobile/CodexMobile/Models/CodexModelOption.swift
@@ -2,7 +2,7 @@
 // Purpose: Represents one model entry returned by model/list.
 // Layer: Model
 // Exports: CodexModelOption
-// Depends on: Foundation, CodexReasoningEffortOption
+// Depends on: Foundation, CodexReasoningEffortOption, CodexServiceTier
 
 import Foundation
 
@@ -12,6 +12,7 @@ struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
     let displayName: String
     let description: String
     let isDefault: Bool
+    let supportsFastMode: Bool
     let supportedReasoningEfforts: [CodexReasoningEffortOption]
     let defaultReasoningEffort: String?
 
@@ -21,6 +22,7 @@ struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
         displayName: String,
         description: String,
         isDefault: Bool,
+        supportsFastMode: Bool = false,
         supportedReasoningEfforts: [CodexReasoningEffortOption],
         defaultReasoningEffort: String?
     ) {
@@ -29,6 +31,7 @@ struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
         self.displayName = displayName
         self.description = description
         self.isDefault = isDefault
+        self.supportsFastMode = supportsFastMode
         self.supportedReasoningEfforts = supportedReasoningEfforts
         self.defaultReasoningEffort = defaultReasoningEffort
     }
@@ -36,11 +39,21 @@ struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case id
         case model
+        case slug
+        case name
         case displayName
         case displayNameSnake = "display_name"
         case description
         case isDefault
         case isDefaultSnake = "is_default"
+        case supportsFastMode
+        case supportsFastModeSnake = "supports_fast_mode"
+        case fastMode
+        case fastModeSnake = "fast_mode"
+        case fastServiceTier
+        case fastServiceTierSnake = "fast_service_tier"
+        case additionalSpeedTiers
+        case additionalSpeedTiersSnake = "additional_speed_tiers"
         case supportedReasoningEfforts
         case supportedReasoningEffortsSnake = "supported_reasoning_efforts"
         case defaultReasoningEffort
@@ -51,16 +64,18 @@ struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         let modelValue = try container.decodeIfPresent(String.self, forKey: .model)
+        let slugValue = try container.decodeIfPresent(String.self, forKey: .slug)
         let idValue = try container.decodeIfPresent(String.self, forKey: .id)
-        let rawModel = modelValue ?? idValue ?? ""
+        let rawModel = modelValue ?? slugValue ?? idValue ?? ""
         let normalizedModel = rawModel.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        let rawID = idValue ?? normalizedModel
+        let rawID = idValue ?? slugValue ?? normalizedModel
 
         let normalizedID = rawID.trimmingCharacters(in: .whitespacesAndNewlines)
         let displayNameValue = try container.decodeIfPresent(String.self, forKey: .displayName)
         let displayNameSnakeValue = try container.decodeIfPresent(String.self, forKey: .displayNameSnake)
-        let rawDisplayName = displayNameValue ?? displayNameSnakeValue ?? normalizedModel
+        let nameValue = try container.decodeIfPresent(String.self, forKey: .name)
+        let rawDisplayName = displayNameValue ?? displayNameSnakeValue ?? nameValue ?? normalizedModel
 
         let normalizedDisplayName = rawDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
         let rawDescription = (try container.decodeIfPresent(String.self, forKey: .description)) ?? ""
@@ -85,16 +100,61 @@ struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
 
         let camelDefaultFlag = try container.decodeIfPresent(Bool.self, forKey: .isDefault)
         let snakeDefaultFlag = try container.decodeIfPresent(Bool.self, forKey: .isDefaultSnake)
+        let explicitFastMode = Self.decodeExplicitFastMode(from: container)
+        let additionalSpeedTiers = Self.decodeAdditionalSpeedTiers(from: container)
 
         id = normalizedID.isEmpty ? normalizedModel : normalizedID
         model = normalizedModel
         displayName = normalizedDisplayName.isEmpty ? normalizedModel : normalizedDisplayName
         description = rawDescription.trimmingCharacters(in: .whitespacesAndNewlines)
         isDefault = camelDefaultFlag ?? snakeDefaultFlag ?? false
+        supportsFastMode = CodexModelCapabilityResolver.supportsFastMode(
+            model: normalizedModel,
+            id: normalizedID,
+            explicitFastMode: explicitFastMode,
+            additionalSpeedTiers: additionalSpeedTiers
+        )
         supportedReasoningEfforts = normalizedEfforts
 
         let normalizedDefault = defaultEffort?.trimmingCharacters(in: .whitespacesAndNewlines)
         defaultReasoningEffort = (normalizedDefault?.isEmpty == true) ? nil : normalizedDefault
+    }
+
+    // Codex model/list has shipped several field spellings; keep this parser
+    // data-driven so the main decoder stays small enough for Swift's type checker.
+    private static func decodeExplicitFastMode(
+        from container: KeyedDecodingContainer<CodingKeys>
+    ) -> Bool? {
+        let keys: [CodingKeys] = [
+            .supportsFastMode,
+            .supportsFastModeSnake,
+            .fastMode,
+            .fastModeSnake,
+            .fastServiceTier,
+            .fastServiceTierSnake,
+        ]
+
+        for key in keys {
+            if let value = try? container.decodeIfPresent(Bool.self, forKey: key) {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private static func decodeAdditionalSpeedTiers(
+        from container: KeyedDecodingContainer<CodingKeys>
+    ) -> [String] {
+        let camelTiers = (try? container.decodeIfPresent([String].self, forKey: .additionalSpeedTiers)) ?? []
+        let snakeTiers = (try? container.decodeIfPresent([String].self, forKey: .additionalSpeedTiersSnake)) ?? []
+        return camelTiers + snakeTiers
+    }
+
+    func supportsServiceTier(_ serviceTier: CodexServiceTier) -> Bool {
+        switch serviceTier {
+        case .fast:
+            return supportsFastMode
+        }
     }
 
     func encode(to encoder: Encoder) throws {
@@ -104,7 +164,53 @@ struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
         try container.encode(displayName, forKey: .displayName)
         try container.encode(description, forKey: .description)
         try container.encode(isDefault, forKey: .isDefault)
+        try container.encode(supportsFastMode, forKey: .supportsFastMode)
         try container.encode(supportedReasoningEfforts, forKey: .supportedReasoningEfforts)
         try container.encodeIfPresent(defaultReasoningEffort, forKey: .defaultReasoningEffort)
+    }
+}
+
+private enum CodexModelCapabilityResolver {
+    // Mirrors the desktop capability table only when older bridges omit explicit model speed metadata.
+    private static let staticFastModeModelIdentifiers: Set<String> = [
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+        "gpt-5.2-codex",
+        "gpt-5.2",
+    ]
+
+    static func supportsFastMode(
+        model: String,
+        id: String,
+        explicitFastMode: Bool?,
+        additionalSpeedTiers: [String]
+    ) -> Bool {
+        if let explicitFastMode {
+            return explicitFastMode
+        }
+        if supportsServiceTier(.fast, in: additionalSpeedTiers) {
+            return true
+        }
+        return staticFastModeFallback(for: [model, id])
+    }
+
+    private static func supportsServiceTier(
+        _ serviceTier: CodexServiceTier,
+        in additionalSpeedTiers: [String]
+    ) -> Bool {
+        additionalSpeedTiers.contains { tier in
+            tier.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == serviceTier.rawValue
+        }
+    }
+
+    private static func staticFastModeFallback(for identifiers: [String]) -> Bool {
+        identifiers.contains { identifier in
+            staticFastModeModelIdentifiers.contains(
+                identifier.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            )
+        }
     }
 }

--- a/CodexMobile/CodexMobile/Models/CodexReasoningEffortOption.swift
+++ b/CodexMobile/CodexMobile/Models/CodexReasoningEffortOption.swift
@@ -20,18 +20,28 @@ struct CodexReasoningEffortOption: Identifiable, Codable, Hashable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case reasoningEffort
         case reasoningEffortSnake = "reasoning_effort"
+        case value
+        case label
         case description
     }
 
     init(from decoder: Decoder) throws {
+        if let singleValue = try? decoder.singleValueContainer().decode(String.self) {
+            reasoningEffort = singleValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            description = ""
+            return
+        }
+
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         let camelEffort = try container.decodeIfPresent(String.self, forKey: .reasoningEffort)
         let snakeEffort = try container.decodeIfPresent(String.self, forKey: .reasoningEffortSnake)
-        let effort = camelEffort ?? snakeEffort ?? ""
+        let valueEffort = try container.decodeIfPresent(String.self, forKey: .value)
+        let effort = camelEffort ?? snakeEffort ?? valueEffort ?? ""
 
         reasoningEffort = effort.trimmingCharacters(in: .whitespacesAndNewlines)
-        description = (try container.decodeIfPresent(String.self, forKey: .description) ?? "")
+        let label = try container.decodeIfPresent(String.self, forKey: .label)
+        description = (try container.decodeIfPresent(String.self, forKey: .description) ?? label ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 

--- a/CodexMobile/CodexMobile/Services/CodexService+RuntimeConfig.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+RuntimeConfig.swift
@@ -134,7 +134,7 @@ extension CodexService {
     }
 
     func setSelectedServiceTier(_ serviceTier: CodexServiceTier?) {
-        selectedServiceTier = serviceTier
+        selectedServiceTier = normalizedServiceTierForSelectedModel(serviceTier)
         persistRuntimeSelections()
     }
 
@@ -143,8 +143,9 @@ extension CodexService {
             return
         }
 
+        let normalizedServiceTier = normalizedServiceTierForSelectedModel(serviceTier)
         mutateThreadRuntimeOverride(for: normalizedThreadID) { override in
-            override.serviceTierRawValue = serviceTier?.rawValue
+            override.serviceTierRawValue = normalizedServiceTier?.rawValue
             override.overridesServiceTier = true
         }
     }
@@ -186,6 +187,10 @@ extension CodexService {
 
     func selectedGitWriterModelOption() -> CodexModelOption? {
         selectedGitWriterModelOption(from: availableModels)
+    }
+
+    func selectedModelSupportsServiceTier(_ serviceTier: CodexServiceTier) -> Bool {
+        selectedModelOption()?.supportsServiceTier(serviceTier) == true
     }
 
     func gitWriterModelIdentifier() -> String? {
@@ -252,12 +257,18 @@ extension CodexService {
     }
 
     func effectiveServiceTier(for threadId: String? = nil) -> CodexServiceTier? {
+        let candidate: CodexServiceTier?
         if let threadOverride = threadRuntimeOverride(for: threadId),
            threadOverride.overridesServiceTier {
-            return threadOverride.serviceTier
+            candidate = threadOverride.serviceTier
+        } else {
+            candidate = selectedServiceTier
         }
 
-        return selectedServiceTier
+        guard let candidate else {
+            return nil
+        }
+        return selectedModelSupportsServiceTier(candidate) ? candidate : nil
     }
 
     func runtimeServiceTierForTurn(threadId: String? = nil) -> String? {
@@ -452,8 +463,14 @@ private extension CodexService {
             } else {
                 selectedReasoningEffort = resolvedModel.supportedReasoningEfforts.first?.reasoningEffort
             }
+
+            if let selectedServiceTier,
+               !resolvedModel.supportsServiceTier(selectedServiceTier) {
+                self.selectedServiceTier = nil
+            }
         } else {
             selectedReasoningEffort = nil
+            selectedServiceTier = nil
         }
 
         if let selectedGitWriterModelId,
@@ -477,6 +494,16 @@ private extension CodexService {
         }
 
         return nil
+    }
+
+    func normalizedServiceTierForSelectedModel(_ serviceTier: CodexServiceTier?) -> CodexServiceTier? {
+        guard let serviceTier else {
+            return nil
+        }
+        guard let selectedModel = selectedModelOption() else {
+            return serviceTier
+        }
+        return selectedModel.supportsServiceTier(serviceTier) ? serviceTier : nil
     }
 
     func selectedGitWriterModelOption(
@@ -505,6 +532,13 @@ private extension CodexService {
     }
 
     func fallbackModel(from models: [CodexModelOption]) -> CodexModelOption? {
+        // Prefer GPT-5.5 when the bridge advertises it; the rest of the app treats
+        // it as the canonical default regardless of the bridge's `isDefault` flag.
+        if let preferred = models.first(where: {
+            $0.id.lowercased() == "gpt-5.5" || $0.model.lowercased() == "gpt-5.5"
+        }) {
+            return preferred
+        }
         if let defaultModel = models.first(where: { $0.isDefault }) {
             return defaultModel
         }

--- a/CodexMobile/CodexMobile/Services/CodexService+RuntimeConfig.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+RuntimeConfig.swift
@@ -413,6 +413,16 @@ extension CodexService {
             || message.contains("onrequest")
             || message.contains("on-request")
     }
+
+    func normalizedServiceTierForSelectedModel(_ serviceTier: CodexServiceTier?) -> CodexServiceTier? {
+        guard let serviceTier else {
+            return nil
+        }
+        guard let selectedModel = selectedModelOption() else {
+            return serviceTier
+        }
+        return selectedModel.supportsServiceTier(serviceTier) ? serviceTier : nil
+    }
 }
 
 private extension CodexService {
@@ -494,16 +504,6 @@ private extension CodexService {
         }
 
         return nil
-    }
-
-    func normalizedServiceTierForSelectedModel(_ serviceTier: CodexServiceTier?) -> CodexServiceTier? {
-        guard let serviceTier else {
-            return nil
-        }
-        guard let selectedModel = selectedModelOption() else {
-            return serviceTier
-        }
-        return selectedModel.supportsServiceTier(serviceTier) ? serviceTier : nil
     }
 
     func selectedGitWriterModelOption(

--- a/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
@@ -105,7 +105,7 @@ extension CodexService {
         let normalizedPreferredProjectPath = CodexThreadStartProjectBinding.normalizedProjectPath(preferredProjectPath)
         // Brand-new chats start from app defaults; per-chat overrides are inherited only on continuation.
         let explicitServiceTier = runtimeOverride?.overridesServiceTier == true
-            ? runtimeOverride?.serviceTierRawValue
+            ? normalizedServiceTierForSelectedModel(runtimeOverride?.serviceTier)?.rawValue
             : runtimeServiceTierForTurn()
         var includesServiceTier = explicitServiceTier != nil
 

--- a/CodexMobile/CodexMobile/Views/SettingsView.swift
+++ b/CodexMobile/CodexMobile/Views/SettingsView.swift
@@ -105,18 +105,20 @@ struct SettingsView: View {
                 .disabled(runtimeReasoningOptions.isEmpty)
             }
 
-            HStack {
-                Text("Speed")
-                Spacer()
-                Picker("Speed", selection: runtimeServiceTierSelection) {
-                    Text("Normal").tag(runtimeNormalValue)
-                    ForEach(CodexServiceTier.allCases, id: \.rawValue) { tier in
-                        Text(tier.displayName).tag(tier.rawValue)
+            if codex.selectedModelSupportsServiceTier(.fast) {
+                HStack {
+                    Text("Speed")
+                    Spacer()
+                    Picker("Speed", selection: runtimeServiceTierSelection) {
+                        Text("Normal").tag(runtimeNormalValue)
+                        ForEach(CodexServiceTier.allCases, id: \.rawValue) { tier in
+                            Text(tier.displayName).tag(tier.rawValue)
+                        }
                     }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                    .tint(settingsAccentColor)
                 }
-                .pickerStyle(.menu)
-                .labelsHidden()
-                .tint(settingsAccentColor)
             }
 
             HStack {

--- a/CodexMobile/CodexMobile/Views/Turn/ComposerBottomBar.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/ComposerBottomBar.swift
@@ -1,5 +1,5 @@
 // FILE: ComposerBottomBar.swift
-// Purpose: Bottom bar with attachment/model/reasoning/access menus, queue controls, and send button.
+// Purpose: Bottom bar with attachment/runtime/access menus, queue controls, and send button.
 // Layer: View Component
 // Exports: ComposerBottomBar
 // Depends on: SwiftUI, TurnComposerMetaMapper
@@ -8,6 +8,7 @@ import SwiftUI
 
 struct ComposerBottomBar: View {
     @Environment(\.colorScheme) private var colorScheme
+    @State private var showsAllModelsSheet = false
 
     // Data
     let orderedModelOptions: [CodexModelOption]
@@ -39,9 +40,6 @@ struct ComposerBottomBar: View {
     private var metaTextFont: Font { AppFont.subheadline() }
     private var metaSymbolFont: Font { AppFont.system(size: 11, weight: .regular) }
     private let metaSymbolSize: CGFloat = 12
-    private let brainSymbolSize: CGFloat = 8
-    private let reasoningSymbolName = "brain"
-    private let reasoningSymbolIsAsset = true
     private var metaChevronFont: Font { AppFont.system(size: 9, weight: .regular) }
     private let metaVerticalPadding: CGFloat = 6
     private let plusTapTargetSide: CGFloat = 22
@@ -61,8 +59,7 @@ struct ComposerBottomBar: View {
     var body: some View {
         HStack(spacing: 12) {
             attachmentMenu
-            modelMenu
-            reasoningMenu
+            runtimeMenu
             if isPlanModeArmed {
                 Divider()
                     .frame(height: 16)
@@ -128,6 +125,21 @@ struct ComposerBottomBar: View {
         .padding(.horizontal, 16)
         .padding(.bottom, 4)
         .padding(.top, 2)
+        .sheet(isPresented: $showsAllModelsSheet) {
+            AllModelsSheet(
+                models: orderedModelOptions,
+                selectedModelID: selectedModelID,
+                isLoadingModels: isLoadingModels,
+                modelSupportsFastMode: modelSupportsFastMode,
+                onSelect: { modelID in
+                    HapticFeedback.shared.triggerImpactFeedback(style: .light)
+                    runtimeActions.selectModel(modelID)
+                    showsAllModelsSheet = false
+                }
+            )
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
+        }
     }
 
     private var voiceButtonLabel: some View {
@@ -167,6 +179,15 @@ struct ComposerBottomBar: View {
                 Label("Plan mode", systemImage: "checklist")
             }
 
+            if runtimeState.supportsFastMode {
+                Button {
+                    HapticFeedback.shared.triggerImpactFeedback(style: .light)
+                    toggleFastMode()
+                } label: {
+                    Label("Fast Mode", systemImage: fastModePlusMenuIconName)
+                }
+            }
+
             Section {
                 Button("Photo library") {
                     HapticFeedback.shared.triggerImpactFeedback()
@@ -189,44 +210,15 @@ struct ComposerBottomBar: View {
         }
         .tint(metaLabelColor)
         .disabled(isComposerInteractionLocked)
-        .accessibilityLabel("Attachment and plan options")
+        .accessibilityLabel("Composer options")
     }
 
-    private var modelMenu: some View {
+    // One consolidated runtime pill: Effort + featured models + Speed as flat sections.
+    // The full model list opens in a sheet so we avoid nested SwiftUI Menus, which
+    // can self-dismiss when their label is tapped from inside the parent menu.
+    private var runtimeMenu: some View {
         Menu {
-            Text("Select model")
-            if isLoadingModels {
-                Text("Loading models...")
-            } else if orderedModelOptions.isEmpty {
-                Text("No models available")
-            } else {
-                ForEach(orderedModelOptions, id: \.id) { model in
-                    Button {
-                        HapticFeedback.shared.triggerImpactFeedback(style: .light)
-                        runtimeActions.selectModel(model.id)
-                    } label: {
-                        if selectedModelID == model.id {
-                            Label(TurnComposerMetaMapper.modelTitle(for: model), systemImage: "checkmark")
-                        } else {
-                            Text(TurnComposerMetaMapper.modelTitle(for: model))
-                        }
-                    }
-                }
-            }
-        } label: {
-            composerMenuLabel(
-                title: selectedModelTitle,
-                leadingImageName: runtimeState.showsSpeedBadgeInModelMenu ? "bolt.fill" : nil,
-                leadingImageIsSystem: true
-            )
-        }
-        .fixedSize(horizontal: true, vertical: false)
-        .tint(metaLabelColor)
-    }
-
-    private var reasoningMenu: some View {
-        Menu {
-            Section("Reasoning") {
+            Section("Effort") {
                 if runtimeState.reasoningDisplayOptions.isEmpty {
                     Text("No reasoning options")
                 } else {
@@ -246,36 +238,64 @@ struct ComposerBottomBar: View {
                 }
             }
 
-            Section("Speed") {
-                Button {
-                    HapticFeedback.shared.triggerImpactFeedback(style: .light)
-                    runtimeActions.selectServiceTier(nil)
-                } label: {
-                    if runtimeState.isSelectedServiceTier(nil) {
-                        Label("Normal", systemImage: "checkmark")
-                    } else {
-                        Text("Normal")
+            Section("Change model") {
+                if isLoadingModels {
+                    Text("Loading models...")
+                } else if orderedModelOptions.isEmpty {
+                    Text("No models available")
+                } else {
+                    ForEach(featuredModelOptions, id: \.id) { model in
+                        Button {
+                            HapticFeedback.shared.triggerImpactFeedback(style: .light)
+                            runtimeActions.selectModel(model.id)
+                        } label: {
+                            modelMenuRow(for: model)
+                        }
+                    }
+
+                    if hasNonFeaturedModels {
+                        Button("Other models") {
+                            HapticFeedback.shared.triggerImpactFeedback(style: .light)
+                            DispatchQueue.main.async {
+                                showsAllModelsSheet = true
+                            }
+                        }
                     }
                 }
+            }
 
-                ForEach(CodexServiceTier.allCases, id: \.rawValue) { tier in
+            if runtimeState.supportsFastMode {
+                Section("Speed") {
                     Button {
                         HapticFeedback.shared.triggerImpactFeedback(style: .light)
-                        runtimeActions.selectServiceTier(tier)
+                        runtimeActions.selectServiceTier(nil)
                     } label: {
-                        if runtimeState.isSelectedServiceTier(tier) {
-                            Label(tier.displayName, systemImage: "checkmark")
+                        if runtimeState.isSelectedServiceTier(nil) {
+                            Label("Normal", systemImage: "checkmark")
                         } else {
-                            Text(tier.displayName)
+                            Text("Normal")
+                        }
+                    }
+
+                    ForEach(CodexServiceTier.allCases, id: \.rawValue) { tier in
+                        Button {
+                            HapticFeedback.shared.triggerImpactFeedback(style: .light)
+                            runtimeActions.selectServiceTier(tier)
+                        } label: {
+                            if runtimeState.isSelectedServiceTier(tier) {
+                                Label(tier.displayName, systemImage: "checkmark")
+                            } else {
+                                Text(tier.displayName)
+                            }
                         }
                     }
                 }
             }
         } label: {
             composerMenuLabel(
-                title: runtimeState.selectedReasoningTitle,
-                leadingImageName: reasoningSymbolName,
-                leadingImageIsSystem: false
+                title: compactRuntimeTitle,
+                leadingImageName: runtimeState.showsSpeedBadgeInModelMenu ? "bolt.fill" : nil,
+                leadingImageIsSystem: true
             )
         }
         .fixedSize(horizontal: true, vertical: false)
@@ -297,6 +317,100 @@ struct ComposerBottomBar: View {
         .foregroundStyle(Color(.plan))
     }
 
+    private var compactRuntimeTitle: String {
+        "\(compactModelTitle) \(runtimeState.selectedReasoningTitle)"
+    }
+
+    // Strips the GPT- prefix and converts remaining dashes to spaces so the
+    // pill keeps the family suffix (Codex, Spark, mini, ...) instead of erasing it.
+    private var compactModelTitle: String {
+        let stripped: String
+        if selectedModelTitle.lowercased().hasPrefix("gpt-") {
+            stripped = String(selectedModelTitle.dropFirst("GPT-".count))
+        } else {
+            stripped = selectedModelTitle
+        }
+        return stripped.replacingOccurrences(of: "-", with: " ")
+    }
+
+    // Toggling Fast Mode from the plus menu mirrors the runtime speed menu without adding another visible pill.
+    private func toggleFastMode() {
+        runtimeActions.selectServiceTier(runtimeState.isSelectedServiceTier(.fast) ? nil : .fast)
+    }
+
+    private var fastModePlusMenuIconName: String {
+        runtimeState.isSelectedServiceTier(.fast) ? "bolt.fill" : "bolt"
+    }
+
+    @ViewBuilder
+    private func modelMenuRow(for model: CodexModelOption) -> some View {
+        modelMenuRow(
+            title: TurnComposerMetaMapper.modelTitle(for: model),
+            isSelected: selectedModelID == model.id,
+            supportsFastMode: modelSupportsFastMode(model)
+        )
+    }
+
+    @ViewBuilder
+    private func modelMenuRow(
+        title: String,
+        isSelected: Bool,
+        supportsFastMode: Bool
+    ) -> some View {
+        HStack(spacing: 8) {
+            if isSelected {
+                Image(systemName: "checkmark")
+            }
+            if supportsFastMode {
+                Image(systemName: CodexServiceTier.fast.iconName)
+            }
+            Text(title)
+        }
+    }
+
+    // Mirrors the bridge-provided runtime capability instead of guessing from the model name.
+    private func modelSupportsFastMode(_ model: CodexModelOption) -> Bool {
+        return model.supportsServiceTier(.fast)
+    }
+
+    // The runtime menu inlines only a few "headline" models to stay compact; the
+    // rest live behind the "See all models…" sheet. The currently selected model
+    // is always pinned so the user never loses sight of it.
+    private static let featuredModelIdentifiers: Set<String> = [
+        "gpt-5.5",
+        "gpt-5.4",
+    ]
+
+    private var featuredModelOptions: [CodexModelOption] {
+        var seenIDs = Set<String>()
+        var result: [CodexModelOption] = []
+
+        func append(_ model: CodexModelOption) {
+            guard seenIDs.insert(model.id).inserted else { return }
+            result.append(model)
+        }
+
+        for model in orderedModelOptions where Self.matchesFeaturedIdentifier(model) {
+            append(model)
+        }
+        if let selected = orderedModelOptions.first(where: { $0.id == selectedModelID }) {
+            append(selected)
+        }
+        return result
+    }
+
+    private var hasNonFeaturedModels: Bool {
+        orderedModelOptions.contains { model in
+            !featuredModelOptions.contains(where: { $0.id == model.id })
+        }
+    }
+
+    private static func matchesFeaturedIdentifier(_ model: CodexModelOption) -> Bool {
+        let normalizedID = model.id.lowercased()
+        let normalizedModel = model.model.lowercased()
+        return featuredModelIdentifiers.contains(normalizedID)
+            || featuredModelIdentifiers.contains(normalizedModel)
+    }
 
     private var queueBadge: some View {
         HStack(spacing: 3) {
@@ -352,6 +466,90 @@ struct ComposerBottomBar: View {
         // Keep adjacent menus from borrowing each other's touch region when the
         // phone composer gets tight while the keyboard is up.
         .fixedSize(horizontal: true, vertical: false)
+        .contentShape(Rectangle())
+    }
+}
+
+// Full-list model picker shown when the user taps "See all models…" inside the
+// runtime menu. Lives in a sheet so it sidesteps the SwiftUI nested-Menu bug
+// while still keeping the runtime pill compact.
+private struct AllModelsSheet: View {
+    let models: [CodexModelOption]
+    let selectedModelID: String?
+    let isLoadingModels: Bool
+    let modelSupportsFastMode: (CodexModelOption) -> Bool
+    let onSelect: (String) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isLoadingModels {
+                    ProgressView("Loading models…")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if models.isEmpty {
+                    ContentUnavailableView(
+                        "No models available",
+                        systemImage: "square.stack.3d.up.slash",
+                        description: Text("Reconnect to your local Codex bridge to refresh the model list.")
+                    )
+                } else {
+                    List {
+                        Section {
+                            ForEach(models, id: \.id) { model in
+                                Button {
+                                    onSelect(model.id)
+                                } label: {
+                                    modelRow(for: model)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+                    .listStyle(.insetGrouped)
+                }
+            }
+            .navigationTitle("Choose model")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func modelRow(for model: CodexModelOption) -> some View {
+        let title = TurnComposerMetaMapper.modelTitle(for: model)
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: model.id == selectedModelID ? "checkmark.circle.fill" : "circle")
+                .font(.system(size: 18))
+                .foregroundStyle(model.id == selectedModelID ? Color.accentColor : Color(.tertiaryLabel))
+                .padding(.top, 2)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(title)
+                        .font(AppFont.body(weight: .medium))
+                        .foregroundStyle(Color(.label))
+                    if modelSupportsFastMode(model) {
+                        Image(systemName: CodexServiceTier.fast.iconName)
+                            .font(AppFont.system(size: 11, weight: .regular))
+                            .foregroundStyle(Color(.secondaryLabel))
+                    }
+                }
+                if !model.description.isEmpty {
+                    Text(model.description)
+                        .font(AppFont.subheadline())
+                        .foregroundStyle(Color(.secondaryLabel))
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 4)
         .contentShape(Rectangle())
     }
 }

--- a/CodexMobile/CodexMobile/Views/Turn/TurnComposerMetaMapper.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnComposerMetaMapper.swift
@@ -13,11 +13,13 @@ enum TurnComposerMetaMapper {
     // Returns models sorted using the explicit product order expected by the UI.
     static func orderedModels(from models: [CodexModelOption]) -> [CodexModelOption] {
         let preferredOrder: [String] = [
-            "gpt-5.1-codex-mini",
-            "gpt-5.2",
-            "gpt-5.1-codex-max",
-            "gpt-5.2-codex",
+            "gpt-5.5",
+            "gpt-5.4",
             "gpt-5.3-codex",
+            "gpt-5.2-codex",
+            "gpt-5.1-codex-max",
+            "gpt-5.2",
+            "gpt-5.1-codex-mini",
         ]
         let rankByModel = Dictionary(uniqueKeysWithValues: preferredOrder.enumerated().map { index, value in
             (value, index)

--- a/CodexMobile/CodexMobile/Views/Turn/TurnComposerRuntimeMenuBuilder.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnComposerRuntimeMenuBuilder.swift
@@ -17,7 +17,9 @@ struct TurnComposerRuntimeMenuBuilder {
             children.append(reasoningMenu)
         }
 
-        children.append(makeSpeedMenu())
+        if let speedMenu = makeSpeedMenu() {
+            children.append(speedMenu)
+        }
 
         guard !children.isEmpty else {
             return nil
@@ -52,7 +54,11 @@ struct TurnComposerRuntimeMenuBuilder {
         )
     }
 
-    private func makeSpeedMenu() -> UIMenu {
+    private func makeSpeedMenu() -> UIMenu? {
+        guard runtimeState.supportsFastMode else {
+            return nil
+        }
+
         var children: [UIMenuElement] = [
             UIAction(
                 title: "Normal",

--- a/CodexMobile/CodexMobile/Views/Turn/TurnComposerRuntimeState.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnComposerRuntimeState.swift
@@ -12,13 +12,14 @@ struct TurnComposerRuntimeState {
     let selectedReasoningEffort: String?
     let reasoningMenuDisabled: Bool
     let selectedServiceTier: CodexServiceTier?
+    let supportsFastMode: Bool
 
     var selectedReasoningTitle: String {
         effectiveReasoningEffort.map(TurnComposerMetaMapper.reasoningTitle(for:)) ?? "Select reasoning"
     }
 
     var showsSpeedBadgeInModelMenu: Bool {
-        selectedServiceTier != nil
+        supportsFastMode && selectedServiceTier != nil
     }
 
     func isSelectedReasoning(_ effort: String) -> Bool {
@@ -38,7 +39,8 @@ struct TurnComposerRuntimeState {
             effectiveReasoningEffort: codex.selectedReasoningEffortForSelectedModel(),
             selectedReasoningEffort: codex.selectedReasoningEffort,
             reasoningMenuDisabled: reasoningDisplayOptions.isEmpty || codex.selectedModelOption() == nil,
-            selectedServiceTier: codex.selectedServiceTier
+            selectedServiceTier: codex.effectiveServiceTier(),
+            supportsFastMode: codex.selectedModelSupportsServiceTier(.fast)
         )
     }
 }

--- a/CodexMobile/CodexMobile/Views/Turn/TurnComposerSecondaryBar.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnComposerSecondaryBar.swift
@@ -100,8 +100,8 @@ struct TurnComposerSecondaryBar: View {
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: selectedAccessMode == .fullAccess
-                      ? "exclamationmark.shield"
-                      : "checkmark.shield")
+                      ? "hand.thumbsup"
+                      : "hand.raised")
                     .font(branchTextFont)
 
                 Image(systemName: "chevron.down")

--- a/CodexMobile/CodexMobile/Views/Turn/TurnComposerView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnComposerView.swift
@@ -584,7 +584,7 @@ private struct ComposerPreviewContent: View {
             displayName: "GPT-5.3-Codex",
             description: "Preview model",
             isDefault: false,
-            supportsFastMode: true,
+            supportsFastMode: false,
             supportedReasoningEfforts: [
                 CodexReasoningEffortOption(reasoningEffort: "low", description: ""),
                 CodexReasoningEffortOption(reasoningEffort: "medium", description: ""),

--- a/CodexMobile/CodexMobile/Views/Turn/TurnComposerView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnComposerView.swift
@@ -180,7 +180,7 @@ struct TurnComposerView: View {
                 )
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .adaptiveGlass(.regular, in: RoundedRectangle(cornerRadius: 28))
+            .adaptiveGlass(.regular, in: RoundedRectangle(cornerRadius: 26))
             .overlay(alignment: .topLeading) {
                 Color.clear
                     .frame(maxWidth: .infinity, maxHeight: 0, alignment: .topLeading)
@@ -474,6 +474,10 @@ private struct TurnComposerAccessorySection: View {
     QueuedDraftsPanelPreviewWrapper()
 }
 
+#Preview("Composer Input - Runtime Controls") {
+    ComposerInputRuntimePreviewWrapper()
+}
+
 private struct QueuedDraftsPanelPreviewWrapper: View {
     @State private var input = ""
     @State private var isInputFocused = false
@@ -488,139 +492,289 @@ private struct QueuedDraftsPanelPreviewWrapper: View {
         VStack {
             Spacer()
 
-            TurnComposerView(
+            ComposerPreviewContent(
                 input: $input,
                 isInputFocused: $isInputFocused,
-                accessoryState: TurnComposerAccessoryState(
-                    queuedDrafts: fakeDrafts,
-                    canSteerQueuedDrafts: true,
-                    canRestoreQueuedDrafts: true,
-                    steeringDraftID: nil,
-                    composerAttachments: [],
-                    composerMentionedFiles: [],
-                    composerMentionedSkills: [],
-                    composerMentionedPlugins: [],
-                    composerReviewSelection: nil,
-                    isSubagentsSelectionArmed: true,
-                    isVoiceRecording: false,
-                    voiceAudioLevels: [],
-                    voiceRecordingDuration: 0
-                ),
-                autocompleteState: TurnComposerAutocompleteState(
-                    availableSlashCommands: TurnComposerSlashCommand.allCommands,
-                    fileAutocompleteItems: [],
-                    isFileAutocompleteVisible: false,
-                    isFileAutocompleteLoading: false,
-                    fileAutocompleteQuery: "",
-                    skillAutocompleteItems: [],
-                    isSkillAutocompleteVisible: false,
-                    isSkillAutocompleteLoading: false,
-                    skillAutocompleteQuery: "",
-                    pluginAutocompleteItems: [],
-                    isPluginAutocompleteVisible: false,
-                    isPluginAutocompleteLoading: false,
-                    pluginAutocompleteQuery: "",
-                    slashCommandPanelState: .hidden,
-                    hasComposerContentConflictingWithReview: false,
-                    isThreadRunning: true,
-                    showsGitBranchSelector: false,
-                    isLoadingGitBranchTargets: false,
-                    availableGitBranchTargets: [],
-                    selectedGitBaseBranch: "",
-                    gitDefaultBranch: "main"
-                ),
-                remainingAttachmentSlots: 4,
-                isComposerInteractionLocked: false,
-                isSendDisabled: false,
+                queuedDrafts: fakeDrafts,
+                canSteerQueuedDrafts: true,
+                isSubagentsSelectionArmed: true,
                 isPlanModeArmed: true,
                 queuedCount: 3,
-                isQueuePaused: false,
-                activeTurnID: nil,
-                isThreadRunning: true,
-                isEmptyThread: true,
-                isWorktreeProject: false,
-                orderedModelOptions: [],
-                selectedModelID: nil,
-                selectedModelTitle: "GPT-5.3-Codex",
-                isLoadingModels: false,
-                runtimeState: TurnComposerRuntimeState(
-                    reasoningDisplayOptions: [],
-                    effectiveReasoningEffort: nil,
-                    selectedReasoningEffort: nil,
-                    reasoningMenuDisabled: true,
-                    selectedServiceTier: .fast
-                ),
-                runtimeActions: TurnComposerRuntimeActions(
-                    selectModel: { _ in },
-                    selectAutomaticReasoning: {},
-                    selectReasoning: { _ in },
-                    selectServiceTier: { _ in }
-                ),
-                voiceButtonPresentation: TurnComposerVoiceButtonPresentation(
-                    systemImageName: "mic",
-                    foregroundColor: Color(.secondaryLabel),
-                    backgroundColor: .clear,
-                    accessibilityLabel: "Start voice transcription",
-                    isDisabled: false,
-                    showsProgress: false,
-                    hasCircleBackground: false
-                ),
-                selectedAccessMode: .onRequest,
-                contextWindowUsage: nil,
-                rateLimitBuckets: [],
-                isLoadingRateLimits: false,
-                rateLimitsErrorMessage: nil,
-                shouldAutoRefreshUsageStatus: false,
-                showsGitBranchSelector: false,
-                isGitBranchSelectorEnabled: false,
-                availableGitBranchTargets: [],
-                gitBranchesCheckedOutElsewhere: [],
-                gitWorktreePathsByBranch: [:],
-                selectedGitBaseBranch: "",
-                currentGitBranch: "main",
-                gitDefaultBranch: "main",
-                isLoadingGitBranchTargets: false,
-                isSwitchingGitBranch: false,
-                isCreatingGitWorktree: false,
-                onSelectGitBranch: { _ in },
-                onCreateGitBranch: { _ in },
-                onSelectGitBaseBranch: { _ in },
-                onRefreshGitBranches: {},
-                onRefreshUsageStatus: {},
-                onSelectAccessMode: { _ in },
-                canHandOffToWorktree: false,
-                onTapAddImage: {},
-                onTapTakePhoto: {},
-                onTapVoice: {},
-                onCancelVoiceRecording: {},
-                onTapCreateWorktree: {},
-                onSetPlanModeArmed: { _ in },
-                onRemoveAttachment: { _ in },
-                onStopTurn: { _ in },
-                onInputChangedForFileAutocomplete: { _ in },
-                onInputChangedForSkillAutocomplete: { _ in },
-                onInputChangedForPluginAutocomplete: { _ in },
-                onInputChangedForSlashCommandAutocomplete: { _ in },
-                onSelectFileAutocomplete: { _ in },
-                onSelectSkillAutocomplete: { _ in },
-                onSelectPluginAutocomplete: { _ in },
-                onSelectSlashCommand: { _ in },
-                onSelectCodeReviewTarget: { _ in },
-                onSelectForkDestination: { _ in },
-                onCloseSlashCommandPanel: {},
-                onRemoveMentionedFile: { _ in },
-                onRemoveMentionedSkill: { _ in },
-                onRemoveMentionedPlugin: { _ in },
-                onRemoveComposerReviewSelection: {},
-                onRemoveComposerSubagentsSelection: {},
-                onPasteImageData: { _ in },
-                onResumeQueue: {},
-                onRestoreQueuedDraft: { _ in },
-                onSteerQueuedDraft: { _ in },
-                onRemoveQueuedDraft: { _ in },
-                onSend: {}
+                isThreadRunning: true
             )
         }
+        .safeAreaPadding(.bottom, 20)
         .background(Color(.secondarySystemBackground))
+    }
+}
+
+private struct ComposerInputRuntimePreviewWrapper: View {
+    @State private var input = ""
+    @State private var isInputFocused = false
+
+    var body: some View {
+        VStack {
+            Spacer()
+
+            ComposerPreviewContent(
+                input: $input,
+                isInputFocused: $isInputFocused,
+                queuedDrafts: [],
+                canSteerQueuedDrafts: false,
+                isSubagentsSelectionArmed: false,
+                isPlanModeArmed: false,
+                queuedCount: 0,
+                isThreadRunning: false
+            )
+        }
+        .safeAreaPadding(.bottom, 20)
+        .background(Color(.secondarySystemBackground))
+    }
+}
+
+// Shared preview fixture keeps the sample runtime controls aligned across composer previews.
+private struct ComposerPreviewContent: View {
+    @Binding var input: String
+    @Binding var isInputFocused: Bool
+
+    let queuedDrafts: [QueuedTurnDraft]
+    let canSteerQueuedDrafts: Bool
+    let isSubagentsSelectionArmed: Bool
+    let isPlanModeArmed: Bool
+    let queuedCount: Int
+    let isThreadRunning: Bool
+
+    private let reasoningOptions = TurnComposerMetaMapper.reasoningDisplayOptions(
+        from: ["low", "medium", "high", "xhigh"]
+    )
+
+    private let modelOptions: [CodexModelOption] = [
+        CodexModelOption(
+            id: "gpt-5.5",
+            model: "gpt-5.5",
+            displayName: "GPT-5.5",
+            description: "Preview model",
+            isDefault: true,
+            supportsFastMode: true,
+            supportedReasoningEfforts: [
+                CodexReasoningEffortOption(reasoningEffort: "low", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "medium", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "high", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "xhigh", description: ""),
+            ],
+            defaultReasoningEffort: "high"
+        ),
+        CodexModelOption(
+            id: "gpt-5.4",
+            model: "gpt-5.4",
+            displayName: "GPT-5.4",
+            description: "Preview model",
+            isDefault: false,
+            supportsFastMode: true,
+            supportedReasoningEfforts: [
+                CodexReasoningEffortOption(reasoningEffort: "low", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "medium", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "high", description: ""),
+            ],
+            defaultReasoningEffort: "medium"
+        ),
+        CodexModelOption(
+            id: "gpt-5.3-codex",
+            model: "gpt-5.3-codex",
+            displayName: "GPT-5.3-Codex",
+            description: "Preview model",
+            isDefault: false,
+            supportsFastMode: false,
+            supportedReasoningEfforts: [
+                CodexReasoningEffortOption(reasoningEffort: "low", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "medium", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "high", description: ""),
+            ],
+            defaultReasoningEffort: "high"
+        ),
+        CodexModelOption(
+            id: "gpt-5.2-codex",
+            model: "gpt-5.2-codex",
+            displayName: "GPT-5.2-Codex",
+            description: "Preview model",
+            isDefault: false,
+            supportedReasoningEfforts: [
+                CodexReasoningEffortOption(reasoningEffort: "medium", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "high", description: ""),
+            ],
+            defaultReasoningEffort: "medium"
+        ),
+        CodexModelOption(
+            id: "gpt-5.2",
+            model: "gpt-5.2",
+            displayName: "GPT-5.2",
+            description: "Preview model",
+            isDefault: false,
+            supportedReasoningEfforts: [
+                CodexReasoningEffortOption(reasoningEffort: "low", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "medium", description: ""),
+            ],
+            defaultReasoningEffort: "medium"
+        ),
+        CodexModelOption(
+            id: "gpt-5.1-codex-max",
+            model: "gpt-5.1-codex-max",
+            displayName: "GPT-5.1-Codex-Max",
+            description: "Preview model",
+            isDefault: false,
+            supportedReasoningEfforts: [
+                CodexReasoningEffortOption(reasoningEffort: "medium", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "high", description: ""),
+            ],
+            defaultReasoningEffort: "high"
+        ),
+        CodexModelOption(
+            id: "gpt-5.1-codex-mini",
+            model: "gpt-5.1-codex-mini",
+            displayName: "GPT-5.1-Codex-Mini",
+            description: "Preview model",
+            isDefault: false,
+            supportedReasoningEfforts: [
+                CodexReasoningEffortOption(reasoningEffort: "low", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "medium", description: ""),
+            ],
+            defaultReasoningEffort: "low"
+        ),
+    ]
+
+    var body: some View {
+        TurnComposerView(
+            input: $input,
+            isInputFocused: $isInputFocused,
+            accessoryState: TurnComposerAccessoryState(
+                queuedDrafts: queuedDrafts,
+                canSteerQueuedDrafts: canSteerQueuedDrafts,
+                canRestoreQueuedDrafts: canSteerQueuedDrafts,
+                steeringDraftID: nil,
+                composerAttachments: [],
+                composerMentionedFiles: [],
+                composerMentionedSkills: [],
+                composerMentionedPlugins: [],
+                composerReviewSelection: nil,
+                isSubagentsSelectionArmed: isSubagentsSelectionArmed,
+                isVoiceRecording: false,
+                voiceAudioLevels: [],
+                voiceRecordingDuration: 0
+            ),
+            autocompleteState: TurnComposerAutocompleteState(
+                availableSlashCommands: TurnComposerSlashCommand.allCommands,
+                fileAutocompleteItems: [],
+                isFileAutocompleteVisible: false,
+                isFileAutocompleteLoading: false,
+                fileAutocompleteQuery: "",
+                skillAutocompleteItems: [],
+                isSkillAutocompleteVisible: false,
+                isSkillAutocompleteLoading: false,
+                skillAutocompleteQuery: "",
+                pluginAutocompleteItems: [],
+                isPluginAutocompleteVisible: false,
+                isPluginAutocompleteLoading: false,
+                pluginAutocompleteQuery: "",
+                slashCommandPanelState: .hidden,
+                hasComposerContentConflictingWithReview: false,
+                isThreadRunning: isThreadRunning,
+                showsGitBranchSelector: false,
+                isLoadingGitBranchTargets: false,
+                availableGitBranchTargets: [],
+                selectedGitBaseBranch: "",
+                gitDefaultBranch: "main"
+            ),
+            remainingAttachmentSlots: 4,
+            isComposerInteractionLocked: false,
+            isSendDisabled: false,
+            isPlanModeArmed: isPlanModeArmed,
+            queuedCount: queuedCount,
+            isQueuePaused: false,
+            activeTurnID: nil,
+            isThreadRunning: isThreadRunning,
+            isEmptyThread: true,
+            isWorktreeProject: false,
+            orderedModelOptions: modelOptions,
+            selectedModelID: "gpt-5.5",
+            selectedModelTitle: "GPT-5.5",
+            isLoadingModels: false,
+            runtimeState: TurnComposerRuntimeState(
+                reasoningDisplayOptions: reasoningOptions,
+                effectiveReasoningEffort: "high",
+                selectedReasoningEffort: "high",
+                reasoningMenuDisabled: false,
+                selectedServiceTier: .fast,
+                supportsFastMode: true
+            ),
+            runtimeActions: TurnComposerRuntimeActions(
+                selectModel: { _ in },
+                selectAutomaticReasoning: {},
+                selectReasoning: { _ in },
+                selectServiceTier: { _ in }
+            ),
+            voiceButtonPresentation: TurnComposerVoiceButtonPresentation(
+                systemImageName: "mic",
+                foregroundColor: Color(.secondaryLabel),
+                backgroundColor: .clear,
+                accessibilityLabel: "Start voice transcription",
+                isDisabled: false,
+                showsProgress: false,
+                hasCircleBackground: false
+            ),
+            selectedAccessMode: .onRequest,
+            contextWindowUsage: nil,
+            rateLimitBuckets: [],
+            isLoadingRateLimits: false,
+            rateLimitsErrorMessage: nil,
+            shouldAutoRefreshUsageStatus: false,
+            showsGitBranchSelector: false,
+            isGitBranchSelectorEnabled: false,
+            availableGitBranchTargets: [],
+            gitBranchesCheckedOutElsewhere: [],
+            gitWorktreePathsByBranch: [:],
+            selectedGitBaseBranch: "",
+            currentGitBranch: "main",
+            gitDefaultBranch: "main",
+            isLoadingGitBranchTargets: false,
+            isSwitchingGitBranch: false,
+            isCreatingGitWorktree: false,
+            onSelectGitBranch: { _ in },
+            onCreateGitBranch: { _ in },
+            onSelectGitBaseBranch: { _ in },
+            onRefreshGitBranches: {},
+            onRefreshUsageStatus: {},
+            onSelectAccessMode: { _ in },
+            canHandOffToWorktree: false,
+            onTapAddImage: {},
+            onTapTakePhoto: {},
+            onTapVoice: {},
+            onCancelVoiceRecording: {},
+            onTapCreateWorktree: {},
+            onSetPlanModeArmed: { _ in },
+            onRemoveAttachment: { _ in },
+            onStopTurn: { _ in },
+            onInputChangedForFileAutocomplete: { _ in },
+            onInputChangedForSkillAutocomplete: { _ in },
+            onInputChangedForPluginAutocomplete: { _ in },
+            onInputChangedForSlashCommandAutocomplete: { _ in },
+            onSelectFileAutocomplete: { _ in },
+            onSelectSkillAutocomplete: { _ in },
+            onSelectPluginAutocomplete: { _ in },
+            onSelectSlashCommand: { _ in },
+            onSelectCodeReviewTarget: { _ in },
+            onSelectForkDestination: { _ in },
+            onCloseSlashCommandPanel: {},
+            onRemoveMentionedFile: { _ in },
+            onRemoveMentionedSkill: { _ in },
+            onRemoveMentionedPlugin: { _ in },
+            onRemoveComposerReviewSelection: {},
+            onRemoveComposerSubagentsSelection: {},
+            onPasteImageData: { _ in },
+            onResumeQueue: {},
+            onRestoreQueuedDraft: { _ in },
+            onSteerQueuedDraft: { _ in },
+            onRemoveQueuedDraft: { _ in },
+            onSend: {}
+        )
     }
 }

--- a/CodexMobile/CodexMobile/Views/Turn/TurnComposerView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnComposerView.swift
@@ -584,7 +584,7 @@ private struct ComposerPreviewContent: View {
             displayName: "GPT-5.3-Codex",
             description: "Preview model",
             isDefault: false,
-            supportsFastMode: false,
+            supportsFastMode: true,
             supportedReasoningEfforts: [
                 CodexReasoningEffortOption(reasoningEffort: "low", description: ""),
                 CodexReasoningEffortOption(reasoningEffort: "medium", description: ""),

--- a/CodexMobile/CodexMobileTests/CodexServiceTierTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceTierTests.swift
@@ -59,8 +59,8 @@ final class CodexServiceTierTests: XCTestCase {
             "supportedReasoningEfforts": [{ "value": "medium", "label": "Medium" }]
           },
           {
-            "slug": "gpt-5.3-codex",
-            "name": "GPT-5.3 Codex",
+            "slug": "unknown-model",
+            "name": "Unknown Model",
             "supportsFastMode": false,
             "supportedReasoningEfforts": ["medium"]
           }
@@ -73,7 +73,7 @@ final class CodexServiceTierTests: XCTestCase {
         XCTAssertEqual(models[0].displayName, "GPT-5.5")
         XCTAssertTrue(models[0].supportsFastMode)
         XCTAssertEqual(models[0].supportedReasoningEfforts.first?.reasoningEffort, "medium")
-        XCTAssertEqual(models[1].id, "gpt-5.3-codex")
+        XCTAssertEqual(models[1].id, "unknown-model")
         XCTAssertFalse(models[1].supportsFastMode)
     }
 
@@ -129,7 +129,7 @@ final class CodexServiceTierTests: XCTestCase {
         let service = makeService()
         service.availableModels = [
             makeModel(id: "gpt-5.5", supportsFastMode: true),
-            makeModel(id: "gpt-5.3-codex", supportsFastMode: false),
+            makeModel(id: "gpt-5.1-codex-mini", supportsFastMode: false),
         ]
 
         service.setSelectedModelId("gpt-5.5")
@@ -137,7 +137,7 @@ final class CodexServiceTierTests: XCTestCase {
         XCTAssertEqual(service.selectedServiceTier, .fast)
         XCTAssertEqual(service.effectiveServiceTier(), .fast)
 
-        service.setSelectedModelId("gpt-5.3-codex")
+        service.setSelectedModelId("gpt-5.1-codex-mini")
 
         XCTAssertNil(service.selectedServiceTier)
         XCTAssertNil(service.effectiveServiceTier())

--- a/CodexMobile/CodexMobileTests/CodexServiceTierTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceTierTests.swift
@@ -49,6 +49,100 @@ final class CodexServiceTierTests: XCTestCase {
         )
     }
 
+    func testModelFastCapabilityDecodesFromRuntimeMetadata() throws {
+        let payload = """
+        [
+          {
+            "slug": "gpt-5.5",
+            "name": "GPT-5.5",
+            "additionalSpeedTiers": ["fast"],
+            "supportedReasoningEfforts": [{ "value": "medium", "label": "Medium" }]
+          },
+          {
+            "slug": "gpt-5.3-codex",
+            "name": "GPT-5.3 Codex",
+            "supportsFastMode": false,
+            "supportedReasoningEfforts": ["medium"]
+          }
+        ]
+        """
+
+        let models = try JSONDecoder().decode([CodexModelOption].self, from: Data(payload.utf8))
+
+        XCTAssertEqual(models[0].id, "gpt-5.5")
+        XCTAssertEqual(models[0].displayName, "GPT-5.5")
+        XCTAssertTrue(models[0].supportsFastMode)
+        XCTAssertEqual(models[0].supportedReasoningEfforts.first?.reasoningEffort, "medium")
+        XCTAssertEqual(models[1].id, "gpt-5.3-codex")
+        XCTAssertFalse(models[1].supportsFastMode)
+    }
+
+    func testKnownFastModelsUseStaticFallbackWhenRuntimeMetadataOmitsCapability() throws {
+        let payload = """
+        [
+          {
+            "slug": "gpt-5.4",
+            "name": "GPT-5.4",
+            "supportedReasoningEfforts": ["medium"]
+          },
+          {
+            "slug": "gpt-5.5",
+            "name": "GPT-5.5",
+            "supportedReasoningEfforts": ["medium"]
+          },
+          {
+            "slug": "unknown-model",
+            "name": "Unknown Model",
+            "supportedReasoningEfforts": ["medium"]
+          }
+        ]
+        """
+
+        let models = try JSONDecoder().decode([CodexModelOption].self, from: Data(payload.utf8))
+
+        XCTAssertTrue(models[0].supportsFastMode)
+        XCTAssertTrue(models[1].supportsFastMode)
+        XCTAssertFalse(models[2].supportsFastMode)
+    }
+
+    func testSwitchingBetweenFastCapableModelsKeepsSelectedServiceTier() {
+        let service = makeService()
+        service.availableModels = [
+            makeModel(id: "gpt-5.4", supportsFastMode: true),
+            makeModel(id: "gpt-5.5", supportsFastMode: true),
+        ]
+
+        service.setSelectedModelId("gpt-5.4")
+        service.setSelectedServiceTier(.fast)
+        service.setSelectedModelId("gpt-5.5")
+
+        XCTAssertEqual(service.selectedServiceTier, .fast)
+        XCTAssertEqual(service.effectiveServiceTier(), .fast)
+
+        service.setSelectedModelId("gpt-5.4")
+
+        XCTAssertEqual(service.selectedServiceTier, .fast)
+        XCTAssertEqual(service.effectiveServiceTier(), .fast)
+    }
+
+    func testSwitchingToModelWithoutFastModeClearsSelectedServiceTier() {
+        let service = makeService()
+        service.availableModels = [
+            makeModel(id: "gpt-5.5", supportsFastMode: true),
+            makeModel(id: "gpt-5.3-codex", supportsFastMode: false),
+        ]
+
+        service.setSelectedModelId("gpt-5.5")
+        service.setSelectedServiceTier(.fast)
+        XCTAssertEqual(service.selectedServiceTier, .fast)
+        XCTAssertEqual(service.effectiveServiceTier(), .fast)
+
+        service.setSelectedModelId("gpt-5.3-codex")
+
+        XCTAssertNil(service.selectedServiceTier)
+        XCTAssertNil(service.effectiveServiceTier())
+    }
+
     func testUnsupportedServiceTierDisablesFutureRetriesAndShowsUpdatePromptOnce() async throws {
         let service = makeService()
         service.isConnected = true
@@ -100,13 +194,14 @@ final class CodexServiceTierTests: XCTestCase {
         return service
     }
 
-    private func makeModel() -> CodexModelOption {
+    private func makeModel(id: String = "gpt-5.4", supportsFastMode: Bool = true) -> CodexModelOption {
         CodexModelOption(
-            id: "gpt-5.4",
-            model: "gpt-5.4",
-            displayName: "GPT-5.4",
+            id: id,
+            model: id,
+            displayName: id.uppercased(),
             description: "Test model",
             isDefault: true,
+            supportsFastMode: supportsFastMode,
             supportedReasoningEfforts: [
                 CodexReasoningEffortOption(reasoningEffort: "medium", description: "Medium"),
             ],

--- a/CodexMobile/CodexMobileTests/CodexServiceTierTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceTierTests.swift
@@ -91,6 +91,16 @@ final class CodexServiceTierTests: XCTestCase {
             "supportedReasoningEfforts": ["medium"]
           },
           {
+            "slug": "gpt-5.3-codex",
+            "name": "GPT-5.3 Codex",
+            "supportedReasoningEfforts": ["medium"]
+          },
+          {
+            "slug": "gpt-5.3-codex-spark",
+            "name": "GPT-5.3 Codex Spark",
+            "supportedReasoningEfforts": ["medium"]
+          },
+          {
             "slug": "unknown-model",
             "name": "Unknown Model",
             "supportedReasoningEfforts": ["medium"]
@@ -103,6 +113,8 @@ final class CodexServiceTierTests: XCTestCase {
         XCTAssertTrue(models[0].supportsFastMode)
         XCTAssertTrue(models[1].supportsFastMode)
         XCTAssertFalse(models[2].supportsFastMode)
+        XCTAssertFalse(models[3].supportsFastMode)
+        XCTAssertFalse(models[4].supportsFastMode)
     }
 
     func testSwitchingBetweenFastCapableModelsKeepsSelectedServiceTier() {
@@ -129,7 +141,7 @@ final class CodexServiceTierTests: XCTestCase {
         let service = makeService()
         service.availableModels = [
             makeModel(id: "gpt-5.5", supportsFastMode: true),
-            makeModel(id: "gpt-5.1-codex-mini", supportsFastMode: false),
+            makeModel(id: "gpt-5.3-codex", supportsFastMode: false),
         ]
 
         service.setSelectedModelId("gpt-5.5")
@@ -137,7 +149,7 @@ final class CodexServiceTierTests: XCTestCase {
         XCTAssertEqual(service.selectedServiceTier, .fast)
         XCTAssertEqual(service.effectiveServiceTier(), .fast)
 
-        service.setSelectedModelId("gpt-5.1-codex-mini")
+        service.setSelectedModelId("gpt-5.3-codex")
 
         XCTAssertNil(service.selectedServiceTier)
         XCTAssertNil(service.effectiveServiceTier())

--- a/CodexMobile/CodexMobileTests/CodexThreadRuntimeOverrideTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexThreadRuntimeOverrideTests.swift
@@ -111,6 +111,39 @@ final class CodexThreadRuntimeOverrideTests: XCTestCase {
         XCTAssertEqual(service.effectiveServiceTier(for: "thread-new"), .fast)
     }
 
+    func testStartThreadDropsFastRuntimeOverrideWhenSelectedModelDoesNotSupportFastMode() async throws {
+        let service = makeService()
+        service.isConnected = true
+        service.availableModels = [makeLowOnlyModel()]
+        service.setSelectedModelId("gpt-5.4-low")
+
+        var capturedThreadStartParams: [JSONValue] = []
+        service.requestTransportOverride = { method, params in
+            XCTAssertEqual(method, "thread/start")
+            capturedThreadStartParams.append(params ?? .null)
+            return RPCMessage(
+                id: .string(UUID().uuidString),
+                result: .object([
+                    "thread": .object([
+                        "id": .string("thread-new"),
+                        "cwd": .string("/tmp/project"),
+                    ]),
+                ]),
+                includeJSONRPC: false
+            )
+        }
+
+        let override = CodexThreadRuntimeOverride(
+            reasoningEffort: "low",
+            serviceTierRawValue: "fast",
+            overridesReasoning: true,
+            overridesServiceTier: true
+        )
+        _ = try await service.startThread(runtimeOverride: override)
+
+        XCTAssertNil(capturedThreadStartParams.first?.objectValue?["serviceTier"]?.stringValue)
+    }
+
     func testUnsupportedThreadReasoningOverrideIsNotReportedAsActive() {
         let service = makeService()
         service.availableModels = [makeLowOnlyModel()]
@@ -137,6 +170,7 @@ final class CodexThreadRuntimeOverrideTests: XCTestCase {
             displayName: "GPT-5.4",
             description: "Test model",
             isDefault: true,
+            supportsFastMode: true,
             supportedReasoningEfforts: [
                 CodexReasoningEffortOption(reasoningEffort: "medium", description: "Medium"),
                 CodexReasoningEffortOption(reasoningEffort: "high", description: "High"),


### PR DESCRIPTION
## Summary
- Keep model selection inside the compact runtime picker while moving the full model list to a sheet.
- Decode runtime model capability metadata so Fast Mode only appears and sends when supported.
- Preserve Fast Mode across fast-capable model switches and add regression coverage for capability handling.

## Test plan
- Not run (per repo guardrails: no Xcode tests/build unless explicitly requested).
- Verified `git diff --check` before commit.


Made with [Cursor](https://cursor.com)