### PR TITLE
Compact relay history and relaunch macOS agent cleanly

### DIFF
--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -58,6 +58,7 @@ const STALE_RELAY_STATUS_MESSAGE = "Relay heartbeat stalled; reconnect pending."
 const RELAY_HISTORY_IMAGE_REFERENCE_URL = "remodex://history-image-elided";
 const RELAY_THREAD_PAYLOAD_SOFT_LIMIT_BYTES = 3 * 1024 * 1024;
 const RELAY_HISTORY_TEXT_TAIL_LIMIT_CHARS = 24_000;
+const RELAY_HISTORY_RECENT_TURN_TARGET = 40;
 function startBridge({
   config: explicitConfig = null,
   printPairingQr = true,
@@ -1356,8 +1357,8 @@ function normalizeNonEmptyString(value) {
   return typeof value === "string" && value.trim() ? value.trim() : "";
 }
 
-// Shrinks `thread/read` and `thread/resume` snapshots by eliding bulky history payloads
-// that the iPhone does not render directly (inline images, compaction replacement history).
+// Shrinks `thread/read` and `thread/resume` snapshots for mobile relay delivery.
+// This elides bulky blobs and replaces oversized older history with a compact marker.
 function sanitizeThreadHistoryImagesForRelay(rawMessage, requestMethod) {
   if (requestMethod !== "thread/read" && requestMethod !== "thread/resume") {
     return rawMessage;
@@ -1759,19 +1760,25 @@ function trimThreadPayloadForRelay(parsed, explicitThread = undefined) {
   }
 
   const turns = thread.turns;
-  let trimmedTurns = turns.slice();
+  let trimmedTurns = turns.length > RELAY_HISTORY_RECENT_TURN_TARGET
+    ? turns.slice(-RELAY_HISTORY_RECENT_TURN_TARGET)
+    : turns.slice();
   while (trimmedTurns.length > 1) {
-    trimmedTurns = trimmedTurns.slice(1);
-    const candidateThread = {
-      ...thread,
-      turns: trimmedTurns,
-      historyTailTruncatedForRelay: true,
-    };
+    if (trimmedTurns.length === turns.length) {
+      trimmedTurns = trimmedTurns.slice(1);
+    }
+    const candidateThread = buildRelayHistoryCompactedThread(
+      thread,
+      buildRelayCompactedHistoryTurns(turns, trimmedTurns),
+      Math.max(0, turns.length - trimmedTurns.length),
+      trimmedTurns.length
+    );
     encoded = encodeRelayThreadPayload(parsed, candidateThread);
     if (encoded != null && Buffer.byteLength(encoded, "utf8") <= RELAY_THREAD_PAYLOAD_SOFT_LIMIT_BYTES) {
       return encoded;
     }
     workingThread = candidateThread;
+    trimmedTurns = trimmedTurns.slice(1);
   }
 
   const newestTurn = trimmedTurns[0];
@@ -1782,14 +1789,23 @@ function trimThreadPayloadForRelay(parsed, explicitThread = undefined) {
   let trimmedItems = newestTurn.items.slice();
   while (trimmedItems.length > 1) {
     trimmedItems = trimmedItems.slice(1);
-    const candidateThread = {
-      ...thread,
-      turns: [{
+    const compactedTurnPrefix = buildRelayHistoryCompactionTurn(
+      Math.max(0, turns.length - 1),
+      1,
+      thread
+    );
+    const candidateThread = buildRelayHistoryCompactedThread(
+      thread,
+      compactedTurnPrefix ? [compactedTurnPrefix, {
+        ...newestTurn,
+        items: trimmedItems,
+      }] : [{
         ...newestTurn,
         items: trimmedItems,
       }],
-      historyTailTruncatedForRelay: true,
-    };
+      Math.max(0, turns.length - 1),
+      1
+    );
     encoded = encodeRelayThreadPayload(parsed, candidateThread);
     if (encoded != null && Buffer.byteLength(encoded, "utf8") <= RELAY_THREAD_PAYLOAD_SOFT_LIMIT_BYTES) {
       return encoded;
@@ -1806,28 +1822,93 @@ function trimThreadPayloadForRelay(parsed, explicitThread = undefined) {
     mostRecentItem,
     RELAY_HISTORY_TEXT_TAIL_LIMIT_CHARS
   );
-  let candidateThread = {
-    ...thread,
-    turns: [{
-      ...newestTurn,
-      items: [truncatedItem],
-    }],
-    historyTailTruncatedForRelay: true,
-  };
+  let candidateThread = buildRelayHistoryCompactedThread(
+    thread,
+    [
+      ...buildRelayCompactedHistoryTurns(turns, [newestTurn]).slice(0, -1),
+      {
+        ...newestTurn,
+        items: [truncatedItem],
+      },
+    ],
+    Math.max(0, turns.length - 1),
+    1
+  );
   encoded = encodeRelayThreadPayload(parsed, candidateThread);
   if (encoded != null && Buffer.byteLength(encoded, "utf8") <= RELAY_THREAD_PAYLOAD_SOFT_LIMIT_BYTES) {
     return encoded;
   }
 
-  candidateThread = {
-    ...thread,
-    turns: [{
-      ...newestTurn,
-      items: [compactHistoryItemForRelay(mostRecentItem, RELAY_HISTORY_TEXT_TAIL_LIMIT_CHARS)],
-    }],
-    historyTailTruncatedForRelay: true,
-  };
+  candidateThread = buildRelayHistoryCompactedThread(
+    thread,
+    [
+      ...buildRelayCompactedHistoryTurns(turns, [newestTurn]).slice(0, -1),
+      {
+        ...newestTurn,
+        items: [compactHistoryItemForRelay(mostRecentItem, RELAY_HISTORY_TEXT_TAIL_LIMIT_CHARS)],
+      },
+    ],
+    Math.max(0, turns.length - 1),
+    1
+  );
   return encodeRelayThreadPayload(parsed, candidateThread);
+}
+
+function buildRelayHistoryCompactedThread(thread, turns, omittedTurnCount, keptTurnCount) {
+  return {
+    ...thread,
+    turns,
+    historyTailTruncatedForRelay: true,
+    remodexHistoryCompacted: omittedTurnCount > 0,
+    remodexOmittedTurnCount: omittedTurnCount,
+    remodexKeptTurnCount: keptTurnCount,
+  };
+}
+
+function buildRelayCompactedHistoryTurns(allTurns, keptTurns) {
+  const omittedTurnCount = Math.max(0, allTurns.length - keptTurns.length);
+  const compactionTurn = buildRelayHistoryCompactionTurn(
+    omittedTurnCount,
+    keptTurns.length,
+    allTurns[0]
+  );
+  return compactionTurn ? [compactionTurn, ...keptTurns] : keptTurns;
+}
+
+function buildRelayHistoryCompactionTurn(omittedTurnCount, keptTurnCount, idSource = {}) {
+  if (omittedTurnCount <= 0) {
+    return null;
+  }
+
+  const baseId = normalizeNonEmptyString(idSource?.id)
+    || normalizeNonEmptyString(idSource?.turnId)
+    || normalizeNonEmptyString(idSource?.turn_id)
+    || "history";
+  const text = [
+    "Earlier conversation compacted for mobile loading.",
+    "",
+    `Older turns omitted: ${omittedTurnCount}`,
+    `Recent turns kept: ${keptTurnCount}`,
+    "Full history remains available on the Mac runtime.",
+  ].join("\n");
+
+  return {
+    id: `remodex-history-compacted-${baseId}`,
+    remodexSynthetic: true,
+    remodexHistoryCompacted: true,
+    remodexOmittedTurnCount: omittedTurnCount,
+    remodexKeptTurnCount: keptTurnCount,
+    items: [
+      {
+        id: `remodex-history-compacted-item-${baseId}`,
+        type: "assistant_message",
+        role: "assistant",
+        text,
+        remodexSynthetic: true,
+        remodexHistoryCompacted: true,
+      },
+    ],
+  };
 }
 
 function encodeRelayThreadPayload(parsed, thread) {

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -51,7 +51,8 @@ const { createShortPairingCode, SHORT_PAIRING_CODE_LENGTH } = require("./qr");
 
 const execFileAsync = promisify(execFile);
 const RELAY_WATCHDOG_PING_INTERVAL_MS = 10_000;
-const RELAY_WATCHDOG_STALE_AFTER_MS = 25_000;
+// Keep the watchdog above the relay heartbeat cadence so quiet healthy sockets survive idle gaps.
+const RELAY_WATCHDOG_STALE_AFTER_MS = 70_000;
 const BRIDGE_STATUS_HEARTBEAT_INTERVAL_MS = 5_000;
 const STALE_RELAY_STATUS_MESSAGE = "Relay heartbeat stalled; reconnect pending.";
 const RELAY_HISTORY_IMAGE_REFERENCE_URL = "remodex://history-image-elided";

--- a/phodex-bridge/src/macos-launch-agent.js
+++ b/phodex-bridge/src/macos-launch-agent.js
@@ -319,6 +319,11 @@ function restartLaunchAgent({
     launchAgentDomain(env),
     plistPath,
   ], { stdio: ["ignore", "ignore", "pipe"] });
+  execFileSyncImpl("launchctl", [
+    "kickstart",
+    "-k",
+    launchAgentLabelDomain(env),
+  ], { stdio: ["ignore", "ignore", "pipe"] });
 }
 
 function bootoutLaunchAgent({

--- a/phodex-bridge/test/bridge.test.js
+++ b/phodex-bridge/test/bridge.test.js
@@ -39,6 +39,21 @@ test("hasRelayConnectionGoneStale returns false for fresh or missing activity ti
   assert.equal(hasRelayConnectionGoneStale(Number.NaN), false);
 });
 
+test("hasRelayConnectionGoneStale default threshold tolerates a full quiet minute", () => {
+  assert.equal(
+    hasRelayConnectionGoneStale(1_000, {
+      now: 60_999,
+    }),
+    false
+  );
+  assert.equal(
+    hasRelayConnectionGoneStale(1_000, {
+      now: 71_000,
+    }),
+    true
+  );
+});
+
 test("buildHeartbeatBridgeStatus downgrades stale connected snapshots", () => {
   assert.deepEqual(
     buildHeartbeatBridgeStatus(

--- a/phodex-bridge/test/bridge.test.js
+++ b/phodex-bridge/test/bridge.test.js
@@ -633,7 +633,7 @@ test("sanitizeThreadHistoryImagesForRelay strips bulky compaction replacement hi
   });
 });
 
-test("sanitizeThreadHistoryImagesForRelay trims oversized history down to the newest turn tail", () => {
+test("sanitizeThreadHistoryImagesForRelay compacts oversized history before the newest turn tail", () => {
   const largeText = "A".repeat(4 * 1024 * 1024);
   const rawMessage = JSON.stringify({
     id: "req-thread-tail",
@@ -671,9 +671,54 @@ test("sanitizeThreadHistoryImagesForRelay trims oversized history down to the ne
   );
 
   assert.equal(sanitized.result.thread.historyTailTruncatedForRelay, true);
+  assert.equal(sanitized.result.thread.remodexHistoryCompacted, true);
+  assert.equal(sanitized.result.thread.remodexOmittedTurnCount, 1);
+  assert.equal(sanitized.result.thread.remodexKeptTurnCount, 1);
   assert.deepEqual(
     sanitized.result.thread.turns.map((turn) => turn.id),
-    ["turn-new"]
+    ["remodex-history-compacted-turn-old", "turn-new"]
+  );
+  assert.equal(
+    sanitized.result.thread.turns[0].items[0].text.includes("Older turns omitted: 1"),
+    true
+  );
+});
+
+test("sanitizeThreadHistoryImagesForRelay keeps the newest forty turns when compacting", () => {
+  const largeText = "A".repeat(750 * 1024);
+  const turns = Array.from({ length: 45 }, (_, index) => ({
+    id: `turn-${index + 1}`,
+    items: [
+      {
+        id: `item-${index + 1}`,
+        type: "assistant_message",
+        text: index < 5 ? largeText : `reply ${index + 1}`,
+      },
+    ],
+  }));
+  const rawMessage = JSON.stringify({
+    id: "req-thread-recent-window",
+    result: {
+      thread: {
+        id: "thread-recent-window",
+        turns,
+      },
+    },
+  });
+
+  const sanitized = JSON.parse(
+    sanitizeThreadHistoryImagesForRelay(rawMessage, "thread/read")
+  );
+
+  assert.equal(sanitized.result.thread.remodexHistoryCompacted, true);
+  assert.equal(sanitized.result.thread.remodexOmittedTurnCount, 5);
+  assert.equal(sanitized.result.thread.remodexKeptTurnCount, 40);
+  assert.deepEqual(
+    sanitized.result.thread.turns.map((turn) => turn.id),
+    [
+      "remodex-history-compacted-turn-1",
+      ...turns.slice(5).map((turn) => turn.id),
+    ]
   );
 });
 

--- a/phodex-bridge/test/macos-launch-agent.test.js
+++ b/phodex-bridge/test/macos-launch-agent.test.js
@@ -16,6 +16,7 @@ const {
   resetMacOSBridgePairing,
   resolveLaunchAgentPlistPath,
   runMacOSBridgeService,
+  startMacOSBridgeService,
   stopMacOSBridgeService,
 } = require("../src/macos-launch-agent");
 const {
@@ -105,6 +106,42 @@ test("stopMacOSBridgeService falls back to label bootout when plist bootout fail
         ],
       ],
     ]);
+  });
+});
+
+test("startMacOSBridgeService kickstarts the launch agent after bootstrap", () => {
+  withTempDaemonEnv(({ rootDir }) => {
+    const calls = [];
+    const env = {
+      ...process.env,
+      HOME: rootDir,
+      REMODEX_DEVICE_STATE_DIR: rootDir,
+      REMODEX_RELAY: "ws://127.0.0.1:9000/relay",
+    };
+
+    startMacOSBridgeService({
+      env,
+      platform: "darwin",
+      waitForPairing: false,
+      execFileSyncImpl(command, args) {
+        calls.push([command, args]);
+        if (args[0] === "bootout") {
+          const error = new Error("Could not find service");
+          error.stderr = Buffer.from("Could not find service");
+          throw error;
+        }
+      },
+    });
+
+    assert.deepEqual(
+      calls.map(([command, args]) => [command, args[0], args[1], args[2]]),
+      [
+        ["launchctl", "bootout", `gui/${process.getuid()}`, path.join(rootDir, "Library", "LaunchAgents", "com.remodex.bridge.plist")],
+        ["launchctl", "bootout", `gui/${process.getuid()}/com.remodex.bridge`, undefined],
+        ["launchctl", "bootstrap", `gui/${process.getuid()}`, path.join(rootDir, "Library", "LaunchAgents", "com.remodex.bridge.plist")],
+        ["launchctl", "kickstart", "-k", `gui/${process.getuid()}/com.remodex.bridge`],
+      ]
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Extend the relay watchdog window so healthy idle sockets are not marked stale too early.
- Compact older mobile relay history before trimming the newest turns, preserving a recent-turn window and adding explicit compaction metadata.
- Add a launchctl `kickstart -k` after bootstrap so the macOS launch agent relaunches cleanly.
- Expand tests to cover the new watchdog threshold, history compaction behavior, and launch agent restart flow.

## Testing
- `phodex-bridge/test/bridge.test.js` updated with assertions for stale detection and compacted relay payloads.
- `phodex-bridge/test/macos-launch-agent.test.js` updated to verify `kickstart -k` runs after bootstrap.
- Not run locally.