### PR TITLE
[codex] Fix trusted reconnect recovery

### DIFF
--- a/CodexMobile/CodexMobile/Models/ContextWindowUsage.swift
+++ b/CodexMobile/CodexMobile/Models/ContextWindowUsage.swift
@@ -6,6 +6,9 @@
 import Foundation
 
 struct ContextWindowUsage: Equatable, Sendable {
+    // Fallback for new chats or runtimes that cannot report context usage yet.
+    static let zero = ContextWindowUsage(tokensUsed: 0, tokenLimit: 0)
+
     let tokensUsed: Int
     let tokenLimit: Int
 

--- a/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
@@ -213,7 +213,7 @@ extension CodexService {
         }
     }
 
-    // Clears the remembered relay pairing when the remote Mac session is gone for good.
+    // Clears all remembered relay metadata when the pairing itself is no longer trustworthy.
     func clearSavedRelaySession() {
         SecureStore.deleteValue(for: CodexSecureKeys.relaySessionId)
         SecureStore.deleteValue(for: CodexSecureKeys.relayUrl)
@@ -236,6 +236,26 @@ extension CodexService {
             secureConnectionState = .notPaired
             secureMacFingerprint = nil
         }
+        pendingNotificationOpenThreadID = nil
+        lastPushRegistrationSignature = nil
+        clearTransientConnectionPrompts()
+    }
+
+    // Drops only the per-launch relay session after repeated trusted reconnect failures.
+    func clearStaleSavedRelaySessionForTrustedReconnect() {
+        guard let trustedMac = preferredTrustedMacRecord else {
+            clearSavedRelaySession()
+            return
+        }
+
+        SecureStore.deleteValue(for: CodexSecureKeys.relaySessionId)
+        SecureStore.deleteValue(for: CodexSecureKeys.relayLastAppliedBridgeOutboundSeq)
+        relaySessionId = nil
+        lastAppliedBridgeOutboundSeq = 0
+        shouldForceQRBootstrapOnNextHandshake = false
+        trustedReconnectFailureCount = 0
+        secureConnectionState = .liveSessionUnresolved
+        secureMacFingerprint = codexSecureFingerprint(for: trustedMac.macIdentityPublicKey)
         pendingNotificationOpenThreadID = nil
         lastPushRegistrationSignature = nil
         clearTransientConnectionPrompts()
@@ -627,13 +647,14 @@ extension CodexService {
         return true
     }
 
-    // Drops only the stale saved relay session after repeated secure reconnect failures.
-    // This preserves the trusted Mac record, but stops looping on a dead session id forever.
+    // Preserves trusted Mac identity while removing only the stale per-launch relay session.
     func recoverTrustedReconnectCandidate() {
         if hasSavedRelaySession {
-            clearSavedRelaySession()
-        } else {
+            clearStaleSavedRelaySessionForTrustedReconnect()
+        } else if preferredTrustedMacRecord != nil {
             secureConnectionState = .liveSessionUnresolved
+        } else {
+            clearSavedRelaySession()
         }
         lastErrorMessage = Self.trustedReconnectRecoveryMessage
     }
@@ -645,8 +666,8 @@ extension CodexService {
     ) -> ReceiveErrorDisposition {
         let shouldClearSavedRelaySession = shouldClearSavedRelaySession(for: relayCloseCode)
         let retryableSessionUnavailableMessage = retryableSessionUnavailableMessage(for: relayCloseCode)
-        // Only relay closes that preserve the saved session should stay on the
-        // auto-reconnect path; dead sessions must fall back to QR recovery.
+        // Only relay closes that preserve the saved session should stay on this socket path;
+        // stale live sessions recover through trusted resolve instead of immediate QR.
         let permanentRelayMessage = shouldClearSavedRelaySession
             ? (permanentRelayDisconnectMessage(for: relayCloseCode)
                 ?? "This relay pairing is no longer valid. Scan a new QR code to reconnect.")

--- a/CodexMobile/CodexMobile/Services/CodexService+SecureTransport.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+SecureTransport.swift
@@ -440,6 +440,50 @@ extension CodexService {
     }
 }
 
+enum CodexTrustedSessionResolveURLBuilder {
+    // Builds both proxy-relative and root HTTP resolve routes from the remembered WebSocket relay URL.
+    static func candidates(from relayURL: String) -> [URL] {
+        guard var components = URLComponents(string: relayURL) else {
+            return []
+        }
+
+        normalizeRelayResolveComponents(&components)
+
+        var candidates: [URL] = []
+        let pathComponents = components.path.split(separator: "/").map(String.init)
+        if pathComponents.last == "relay" {
+            let prefix = pathComponents.dropLast()
+            components.path = "/" + (prefix + ["v1", "trusted", "session", "resolve"]).joined(separator: "/")
+        } else {
+            components.path = "/v1/trusted/session/resolve"
+        }
+        if let url = components.url {
+            candidates.append(url)
+        }
+
+        if var rootComponents = URLComponents(string: relayURL) {
+            normalizeRelayResolveComponents(&rootComponents)
+            rootComponents.path = "/v1/trusted/session/resolve"
+            if let rootURL = rootComponents.url,
+               !candidates.contains(where: { $0.absoluteString == rootURL.absoluteString }) {
+                candidates.append(rootURL)
+            }
+        }
+
+        return candidates
+    }
+
+    private static func normalizeRelayResolveComponents(_ components: inout URLComponents) {
+        if components.scheme == "wss" {
+            components.scheme = "https"
+        } else if components.scheme == "ws" {
+            components.scheme = "http"
+        }
+        components.query = nil
+        components.fragment = nil
+    }
+}
+
 private extension CodexService {
     // Centralizes the bridge-update guidance so every mismatch shows the same Mac command.
     func presentBridgeUpdatePrompt(message: String) {
@@ -626,11 +670,35 @@ private extension CodexService {
               !relayURL.isEmpty else {
             throw CodexTrustedSessionResolveError.noTrustedMac
         }
-        let resolveURLs = trustedSessionResolveURLs(from: relayURL)
+        let resolveURLs = CodexTrustedSessionResolveURLBuilder.candidates(from: relayURL)
         guard !resolveURLs.isEmpty else {
             throw CodexTrustedSessionResolveError.invalidResponse("The trusted computer relay URL is invalid.")
         }
 
+        var lastRetriableResolveError: CodexTrustedSessionResolveError?
+        for (index, resolveURL) in resolveURLs.enumerated() {
+            do {
+                return try await sendTrustedSessionResolveRequest(
+                    makeTrustedSessionResolveRequestBody(for: trustedMac),
+                    resolveURL: resolveURL,
+                    relayURL: relayURL
+                )
+            } catch let error as CodexTrustedSessionResolveError {
+                guard shouldTryNextTrustedResolveCandidate(after: error),
+                      index < resolveURLs.count - 1 else {
+                    throw error
+                }
+                lastRetriableResolveError = error
+                continue
+            }
+        }
+
+        throw lastRetriableResolveError ?? CodexTrustedSessionResolveError.unsupportedRelay
+    }
+
+    private func makeTrustedSessionResolveRequestBody(
+        for trustedMac: CodexTrustedMacRecord
+    ) throws -> CodexTrustedSessionResolveRequest {
         let nonce = UUID().uuidString
         let timestamp = Int64(Date().timeIntervalSince1970 * 1_000)
         let transcriptBytes = codexTrustedSessionResolveTranscriptBytes(
@@ -645,7 +713,7 @@ private extension CodexService {
         )
         let signature = try phonePrivateKey.signature(for: transcriptBytes).base64EncodedString()
 
-        let requestBody = CodexTrustedSessionResolveRequest(
+        return CodexTrustedSessionResolveRequest(
             macDeviceId: trustedMac.macDeviceId,
             phoneDeviceId: phoneIdentityState.phoneDeviceId,
             phoneIdentityPublicKey: phoneIdentityState.phoneIdentityPublicKey,
@@ -653,26 +721,15 @@ private extension CodexService {
             timestamp: timestamp,
             signature: signature
         )
+    }
 
-        var lastUnsupportedRelayError: CodexTrustedSessionResolveError?
-        for (index, resolveURL) in resolveURLs.enumerated() {
-            do {
-                return try await sendTrustedSessionResolveRequest(
-                    requestBody,
-                    resolveURL: resolveURL,
-                    relayURL: relayURL
-                )
-            } catch let error as CodexTrustedSessionResolveError {
-                guard case .unsupportedRelay = error,
-                      index < resolveURLs.count - 1 else {
-                    throw error
-                }
-                lastUnsupportedRelayError = error
-                continue
-            }
+    private func shouldTryNextTrustedResolveCandidate(after error: CodexTrustedSessionResolveError) -> Bool {
+        switch error {
+        case .unsupportedRelay, .invalidResponse, .network:
+            return true
+        case .macOffline, .rePairRequired, .noTrustedMac:
+            return false
         }
-
-        throw lastUnsupportedRelayError ?? CodexTrustedSessionResolveError.unsupportedRelay
     }
 
     private func sendTrustedSessionResolveRequest(
@@ -769,48 +826,6 @@ private extension CodexService {
             trustedMacRegistry.records[resolved.macDeviceId] = trustedMac
             SecureStore.writeCodable(trustedMacRegistry, for: CodexSecureKeys.trustedMacRegistry)
         }
-    }
-
-    private func trustedSessionResolveURLs(from relayURL: String) -> [URL] {
-        guard var components = URLComponents(string: relayURL) else {
-            return []
-        }
-
-        if components.scheme == "wss" {
-            components.scheme = "https"
-        } else if components.scheme == "ws" {
-            components.scheme = "http"
-        }
-
-        var candidates: [URL] = []
-        let pathComponents = components.path.split(separator: "/").map(String.init)
-        if pathComponents.last == "relay" {
-            let prefix = pathComponents.dropLast()
-            components.path = "/" + (prefix + ["v1", "trusted", "session", "resolve"]).joined(separator: "/")
-        } else {
-            components.path = "/v1/trusted/session/resolve"
-        }
-        if let url = components.url {
-            candidates.append(url)
-        }
-
-        // Some self-hosted or reverse-proxied relays expose the websocket under a
-        // prefixed path but the HTTP resolve route at the host root. Try that route
-        // only after the relay-relative candidate returns a plain unsupported 404.
-        if var rootComponents = URLComponents(string: relayURL) {
-            if rootComponents.scheme == "wss" {
-                rootComponents.scheme = "https"
-            } else if rootComponents.scheme == "ws" {
-                rootComponents.scheme = "http"
-            }
-            rootComponents.path = "/v1/trusted/session/resolve"
-            if let rootURL = rootComponents.url,
-               !candidates.contains(where: { $0.absoluteString == rootURL.absoluteString }) {
-                candidates.append(rootURL)
-            }
-        }
-
-        return candidates
     }
 
     private var preferredPairingCodeRelayURL: String? {

--- a/CodexMobile/CodexMobile/Services/CodexService+Status.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Status.swift
@@ -46,6 +46,7 @@ extension CodexService {
 
             guard let usageObject = resultObject["usage"]?.objectValue,
                   let usage = extractContextWindowUsage(from: usageObject) else {
+                setDefaultContextWindowUsageIfNeeded(threadId: trimmedThreadID)
                 return
             }
 
@@ -86,6 +87,13 @@ extension CodexService {
 }
 
 private extension CodexService {
+    // Resolves missing context data so fresh chats show 0 instead of an endless loading state.
+    func setDefaultContextWindowUsageIfNeeded(threadId: String) {
+        if contextWindowUsageByThread[threadId] == nil {
+            contextWindowUsageByThread[threadId] = .zero
+        }
+    }
+
     func normalizedUsageStatusThreadID(_ threadId: String?) -> String? {
         guard let rawThreadId = threadId?.trimmingCharacters(in: .whitespacesAndNewlines),
               !rawThreadId.isEmpty else {

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -903,35 +903,25 @@ final class CodexService {
         hasSavedRelaySession || hasTrustedMacReconnectCandidate
     }
 
-    // Chooses the best relay base URL for display-wake recovery, even when only the trusted Mac record remains.
+    // Chooses the relay base URL only when a saved live session can actually carry a wake request.
     var preferredWakeRelayURL: String? {
         guard !isConnected,
-              secureConnectionState != .rePairRequired else {
+              secureConnectionState != .rePairRequired,
+              hasTrustedReconnectContext else {
             return nil
         }
 
-        let candidates = [
-            normalizedRelayURL,
-            preferredTrustedMacRecord?.relayURL?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
-        ]
-
-        for relayURL in candidates {
-            if let relayURL {
-                return relayURL
-            }
-        }
-
-        return nil
+        return normalizedRelayURL
     }
 
-    // Treat any remembered reconnect candidate as wake-capable; the actual wake path will still validate and fail loudly if needed.
+    // Wake needs a concrete live-session URL; trusted-Mac-only recovery should show Reconnect, not Wake Screen.
     var canWakePreferredMacDisplay: Bool {
         guard !isConnected,
               secureConnectionState != .rePairRequired else {
             return false
         }
 
-        return hasReconnectCandidate
+        return preferredWakeRelayURL != nil
     }
 
     // Separates transport readiness from post-connect hydration so the UI can explain delays honestly.

--- a/CodexMobile/CodexMobile/Services/DesktopHandoffService.swift
+++ b/CodexMobile/CodexMobile/Services/DesktopHandoffService.swift
@@ -79,6 +79,13 @@ final class DesktopHandoffService {
             return
         }
 
+        guard codex.canWakePreferredMacDisplay else {
+            throw DesktopHandoffError.bridgeError(
+                code: "saved_pair_required",
+                message: "Reconnect to your paired computer first."
+            )
+        }
+
         guard let reconnectURL = try await preferredReconnectURLForWake() else {
             throw DesktopHandoffError.bridgeError(
                 code: "saved_pair_required",

--- a/CodexMobile/CodexMobile/Views/Home/ContentViewModel.swift
+++ b/CodexMobile/CodexMobile/Views/Home/ContentViewModel.swift
@@ -441,8 +441,10 @@ extension ContentViewModel {
         switch error {
         case .unsupportedRelay:
             if !codex.hasSavedRelaySession {
+                codex.secureConnectionState = .liveSessionUnresolved
                 codex.connectionRecoveryState = .idle
-                codex.lastErrorMessage = "Trusted reconnect is not available from this relay endpoint. Check the relay/proxy, or scan a new QR code."
+                codex.shouldAutoReconnectOnForeground = false
+                codex.lastErrorMessage = "Trusted reconnect is unavailable from this relay endpoint. Update or check the relay/proxy, then reconnect. Scan a new QR code only if this Mac was reset."
                 return .stop
             }
             return .fallbackToSaved
@@ -463,6 +465,7 @@ extension ContentViewModel {
             return .fallbackToSaved
         case .invalidResponse(let message), .network(let message):
             if !codex.hasSavedRelaySession {
+                codex.secureConnectionState = .liveSessionUnresolved
                 codex.lastErrorMessage = message
             }
             return .fallbackToSaved

--- a/CodexMobile/CodexMobile/Views/Shared/UsageStatusSummaryContent.swift
+++ b/CodexMobile/CodexMobile/Views/Shared/UsageStatusSummaryContent.swift
@@ -123,8 +123,8 @@ struct UsageStatusSummaryContent: View {
             if let contextWindowUsage {
                 metricRow(
                     label: "Context",
-                    value: "\(contextWindowUsage.percentRemaining)% left",
-                    detail: "(\(compactTokenCount(contextWindowUsage.tokensUsed)) used / \(compactTokenCount(contextWindowUsage.tokenLimit)))",
+                    value: contextValue(for: contextWindowUsage),
+                    detail: contextDetail(for: contextWindowUsage),
                     monospace: true
                 )
 
@@ -247,6 +247,15 @@ struct UsageStatusSummaryContent: View {
         default:
             return groupedTokenCount(count)
         }
+    }
+
+    private func contextValue(for usage: ContextWindowUsage) -> String {
+        usage.tokenLimit > 0 ? "\(usage.percentRemaining)% left" : "0 used"
+    }
+
+    private func contextDetail(for usage: ContextWindowUsage) -> String? {
+        guard usage.tokenLimit > 0 else { return nil }
+        return "(\(compactTokenCount(usage.tokensUsed)) used / \(compactTokenCount(usage.tokenLimit)))"
     }
 
     private func groupedTokenCount(_ count: Int) -> String {

--- a/CodexMobile/CodexMobile/Views/Turn/TurnMessageComponents.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnMessageComponents.swift
@@ -74,56 +74,55 @@ private struct FileChangeSummaryBox: View {
     let entries: [TurnFileChangeSummaryEntry]
     let fallbackText: String
 
+    // Default to expanded so the recap stays informative without an extra tap;
+    // collapse remains available for long lists or visual decluttering.
+    @State private var isExpanded: Bool = true
+
+    private var canCollapse: Bool {
+        !entries.isEmpty || !fallbackText.isEmpty
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: 6) {
-                Image(systemName: "pencil.line")
-                    .font(AppFont.footnote(weight: .semibold))
-                    .foregroundStyle(.secondary)
+            header
 
-                Text(title)
-                    .font(AppFont.footnote(weight: .semibold))
-                    .foregroundStyle(.secondary)
-            }
-            .padding(.horizontal, 12)
-            .padding(.top, 10)
-            .padding(.bottom, entries.isEmpty ? 10 : 8)
+            if isExpanded {
+                if !entries.isEmpty {
+                    Divider()
 
-            if !entries.isEmpty {
-                Divider()
+                    ForEach(entries.indices, id: \.self) { index in
+                        let entry = entries[index]
+                        let isLastEntry = index == entries.index(before: entries.endIndex)
 
-                ForEach(entries.indices, id: \.self) { index in
-                    let entry = entries[index]
-                    let isLastEntry = index == entries.index(before: entries.endIndex)
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Text(entry.compactPath)
+                                .font(AppFont.subheadline())
+                                .foregroundStyle(.primary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
 
-                    HStack(alignment: .firstTextBaseline, spacing: 8) {
-                        Text(entry.compactPath)
-                            .font(AppFont.subheadline())
-                            .foregroundStyle(.primary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
+                            Spacer(minLength: 8)
 
-                        Spacer(minLength: 8)
+                            if entry.additions > 0 || entry.deletions > 0 {
+                                DiffCountsLabel(additions: entry.additions, deletions: entry.deletions)
+                                    .font(AppFont.mono(.caption))
+                            }
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 9)
 
-                        if entry.additions > 0 || entry.deletions > 0 {
-                            DiffCountsLabel(additions: entry.additions, deletions: entry.deletions)
-                                .font(AppFont.mono(.caption))
+                        if !isLastEntry {
+                            Divider()
+                                .padding(.leading, 12)
                         }
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 9)
-
-                    if !isLastEntry {
-                        Divider()
-                            .padding(.leading, 12)
-                    }
+                } else if !fallbackText.isEmpty {
+                    Text(fallbackText)
+                        .font(AppFont.footnote())
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 12)
+                        .padding(.bottom, 10)
                 }
-            } else if !fallbackText.isEmpty {
-                Text(fallbackText)
-                    .font(AppFont.footnote())
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 12)
-                    .padding(.bottom, 10)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -135,7 +134,50 @@ private struct FileChangeSummaryBox: View {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .stroke(Color(.separator).opacity(0.4), lineWidth: 0.5)
         }
-        .padding(4)
+        .padding(2)
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        let content = HStack(spacing: 6) {
+            Image(systemName: "pencil.line")
+                .font(AppFont.footnote(weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            Text(title)
+                .font(AppFont.footnote(weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: 8)
+
+            if canCollapse {
+                Image(systemName: "chevron.down")
+                    .font(AppFont.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .rotationEffect(.degrees(isExpanded ? 0 : -90))
+                    .accessibilityHidden(true)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 10)
+        .padding(.bottom, isExpanded && !entries.isEmpty ? 8 : 10)
+        .contentShape(Rectangle())
+
+        if canCollapse {
+            Button {
+                withAnimation(.easeInOut(duration: 0.18)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                content
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(title)
+            .accessibilityHint(isExpanded ? "Collapse list" : "Expand list")
+            .accessibilityAddTraits(.isButton)
+        } else {
+            content
+        }
     }
 
     private var title: String {

--- a/CodexMobile/CodexMobileTests/CodexStatusTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexStatusTests.swift
@@ -84,6 +84,42 @@ final class CodexStatusTests: XCTestCase {
         XCTAssertEqual(service.contextWindowUsageByThread["thread-ctx"]?.tokenLimit, 258_400)
     }
 
+    func testRefreshContextWindowUsageFallsBackToZeroWhenUsageMissing() async {
+        let service = makeService()
+        service.isConnected = true
+        service.hasResolvedRateLimitsSnapshot = true
+
+        service.requestTransportOverride = { _, _ in
+            RPCMessage(
+                id: .string(UUID().uuidString),
+                result: .object([
+                    "threadId": .string("thread-new"),
+                ]),
+                includeJSONRPC: false
+            )
+        }
+
+        await service.refreshContextWindowUsage(threadId: "thread-new")
+
+        XCTAssertEqual(service.contextWindowUsageByThread["thread-new"], .zero)
+        XCTAssertFalse(service.shouldAutoRefreshUsageStatus(threadId: "thread-new"))
+    }
+
+    func testRefreshContextWindowUsageKeepsUsageUnknownWhenRequestFails() async {
+        let service = makeService()
+        service.isConnected = true
+        service.hasResolvedRateLimitsSnapshot = true
+
+        service.requestTransportOverride = { _, _ in
+            throw CodexServiceError.disconnected
+        }
+
+        await service.refreshContextWindowUsage(threadId: "thread-new")
+
+        XCTAssertNil(service.contextWindowUsageByThread["thread-new"])
+        XCTAssertTrue(service.shouldAutoRefreshUsageStatus(threadId: "thread-new"))
+    }
+
     func testExtractContextWindowUsageFromTokenCountPayloadPrefersLastUsage() {
         let usage = extractContextWindowUsageFromTokenCountPayload([
             "info": .object([

--- a/CodexMobile/CodexMobileTests/ContentViewModelReconnectTests.swift
+++ b/CodexMobile/CodexMobileTests/ContentViewModelReconnectTests.swift
@@ -23,6 +23,33 @@ final class ContentViewModelReconnectTests: XCTestCase {
         super.tearDown()
     }
 
+    func testTrustedResolveURLCandidatesTryProxyRelativeThenRootRoute() {
+        let candidates = CodexTrustedSessionResolveURLBuilder.candidates(
+            from: "wss://relay.example.com/remodex/relay?stale=1#old"
+        )
+
+        XCTAssertEqual(
+            candidates.map(\.absoluteString),
+            [
+                "https://relay.example.com/remodex/v1/trusted/session/resolve",
+                "https://relay.example.com/v1/trusted/session/resolve",
+            ]
+        )
+    }
+
+    func testTrustedResolveURLCandidatesDoNotDuplicateRootRoute() {
+        let candidates = CodexTrustedSessionResolveURLBuilder.candidates(
+            from: "ws://relay.example.com/relay?stale=1"
+        )
+
+        XCTAssertEqual(
+            candidates.map(\.absoluteString),
+            [
+                "http://relay.example.com/v1/trusted/session/resolve",
+            ]
+        )
+    }
+
     func testPreferredReconnectURLFallsBackToSavedSessionWhenTrustedResolveReportsOffline() async {
         let service = makeService()
         let viewModel = ContentViewModel()
@@ -71,6 +98,93 @@ final class ContentViewModelReconnectTests: XCTestCase {
 
         XCTAssertNil(reconnectURL)
         XCTAssertEqual(service.lastErrorMessage, "Your trusted Mac is offline right now.")
+    }
+
+    func testPreferredReconnectURLStopsWithUnsupportedRelayWithoutForcingRePair() async {
+        let service = makeService()
+        let viewModel = ContentViewModel()
+        let macDeviceID = "mac-\(UUID().uuidString)"
+        let relayURL = "wss://relay.local/relay"
+
+        service.trustedMacRegistry.records[macDeviceID] = CodexTrustedMacRecord(
+            macDeviceId: macDeviceID,
+            macIdentityPublicKey: Data(repeating: 16, count: 32).base64EncodedString(),
+            lastPairedAt: Date(),
+            relayURL: relayURL
+        )
+        service.lastTrustedMacDeviceId = macDeviceID
+        service.shouldAutoReconnectOnForeground = true
+        service.trustedSessionResolverOverride = {
+            throw CodexTrustedSessionResolveError.unsupportedRelay
+        }
+
+        let reconnectURL = await viewModel.preferredReconnectURL(codex: service)
+
+        XCTAssertNil(reconnectURL)
+        XCTAssertEqual(service.secureConnectionState, .liveSessionUnresolved)
+        XCTAssertFalse(service.shouldAutoReconnectOnForeground)
+        XCTAssertEqual(
+            service.lastErrorMessage,
+            "Trusted reconnect is unavailable from this relay endpoint. Update or check the relay/proxy, then reconnect. Scan a new QR code only if this Mac was reset."
+        )
+    }
+
+    func testWakeDisplayRequiresSavedLiveSessionURL() {
+        let service = makeService()
+        let macDeviceID = "mac-\(UUID().uuidString)"
+        let relayURL = "wss://relay.local/relay"
+
+        service.trustedMacRegistry.records[macDeviceID] = CodexTrustedMacRecord(
+            macDeviceId: macDeviceID,
+            macIdentityPublicKey: Data(repeating: 17, count: 32).base64EncodedString(),
+            lastPairedAt: Date(),
+            relayURL: relayURL
+        )
+        service.lastTrustedMacDeviceId = macDeviceID
+
+        XCTAssertTrue(service.hasReconnectCandidate)
+        XCTAssertFalse(service.canWakePreferredMacDisplay)
+
+        service.relaySessionId = "saved-session"
+        service.relayUrl = relayURL
+        service.relayMacDeviceId = macDeviceID
+        service.relayMacIdentityPublicKey = Data(repeating: 17, count: 32).base64EncodedString()
+
+        XCTAssertTrue(service.canWakePreferredMacDisplay)
+    }
+
+    func testRecoverTrustedReconnectCandidatePreservesTrustedMacAndRelayBaseURL() {
+        let service = makeService()
+        let macDeviceID = "mac-\(UUID().uuidString)"
+        let relayURL = "wss://relay.local/relay"
+        let macPublicKey = Data(repeating: 18, count: 32).base64EncodedString()
+
+        service.trustedMacRegistry.records[macDeviceID] = CodexTrustedMacRecord(
+            macDeviceId: macDeviceID,
+            macIdentityPublicKey: macPublicKey,
+            lastPairedAt: Date(),
+            relayURL: relayURL
+        )
+        service.lastTrustedMacDeviceId = macDeviceID
+        service.relaySessionId = "stale-session"
+        service.relayUrl = relayURL
+        service.relayMacDeviceId = macDeviceID
+        service.relayMacIdentityPublicKey = macPublicKey
+
+        service.recoverTrustedReconnectCandidate()
+
+        XCTAssertNil(service.normalizedRelaySessionId)
+        XCTAssertEqual(service.normalizedRelayURL, relayURL)
+        XCTAssertEqual(service.normalizedRelayMacDeviceId, macDeviceID)
+        XCTAssertEqual(service.normalizedRelayMacIdentityPublicKey, macPublicKey)
+        XCTAssertFalse(service.hasSavedRelaySession)
+        XCTAssertTrue(service.hasTrustedMacReconnectCandidate)
+        XCTAssertEqual(service.secureConnectionState, .liveSessionUnresolved)
+        XCTAssertFalse(service.canWakePreferredMacDisplay)
+        XCTAssertEqual(
+            service.lastErrorMessage,
+            "Secure reconnect could not be restored from the saved session. Try reconnecting again."
+        )
     }
 
     func testForegroundReconnectKeepsRetryIntentArmedAfterRetryableFailures() async {

--- a/CodexMobile/CodexMobileTests/DesktopHandoffServiceTests.swift
+++ b/CodexMobile/CodexMobileTests/DesktopHandoffServiceTests.swift
@@ -32,8 +32,18 @@ final class DesktopHandoffServiceTests: XCTestCase {
 
     func testWakeDisplayUsesSavedSessionWhenDisconnected() async throws {
         let service = makeService()
-        service.relayUrl = "ws://macbook-pro-di-emanuele.local:8080/ws"
+        let macDeviceID = "mac-\(UUID().uuidString)"
+        let relayURL = "ws://macbook-pro-di-emanuele.local:8080/ws"
+        service.trustedMacRegistry.records[macDeviceID] = CodexTrustedMacRecord(
+            macDeviceId: macDeviceID,
+            macIdentityPublicKey: Data(repeating: 19, count: 32).base64EncodedString(),
+            lastPairedAt: Date(),
+            relayURL: relayURL
+        )
+        service.lastTrustedMacDeviceId = macDeviceID
+        service.relayUrl = relayURL
         service.relaySessionId = "session-123"
+        service.relayMacDeviceId = macDeviceID
 
         var capturedURL: String?
         var capturedMethods: [String] = []

--- a/phodex-bridge/bin/remodex.js
+++ b/phodex-bridge/bin/remodex.js
@@ -58,6 +58,7 @@ async function main({
 
   if (command === "up") {
     if (platform === "darwin") {
+      consoleImpl.log("[remodex] Starting bridge and pairing QR...");
       const result = await deps.startMacOSBridgeService({
         waitForPairing: true,
       });

--- a/phodex-bridge/test/remodex-cli.test.js
+++ b/phodex-bridge/test/remodex-cli.test.js
@@ -61,6 +61,46 @@ test("remodex restart reuses the macOS service start flow", async () => {
   ]);
 });
 
+test("remodex up shows a startup indicator while waiting for the pairing QR", async () => {
+  const calls = [];
+  const messages = [];
+
+  await main({
+    argv: ["node", "remodex", "up"],
+    platform: "darwin",
+    consoleImpl: {
+      log(message) {
+        messages.push(message);
+      },
+      error(message) {
+        messages.push(message);
+      },
+    },
+    exitImpl(code) {
+      throw new Error(`unexpected exit ${code}`);
+    },
+    deps: {
+      async startMacOSBridgeService(options) {
+        calls.push(["start-service", options]);
+        return {
+          pairingSession: { pairingPayload: { sessionId: "session-up" } },
+        };
+      },
+      printMacOSBridgePairingQr(options) {
+        calls.push(["print-qr", options]);
+      },
+    },
+  });
+
+  assert.deepEqual(messages, [
+    "[remodex] Starting bridge and pairing QR...",
+  ]);
+  assert.deepEqual(calls, [
+    ["start-service", { waitForPairing: true }],
+    ["print-qr", { pairingSession: { pairingPayload: { sessionId: "session-up" } } }],
+  ]);
+});
+
 test("remodex status --json exposes daemon metadata for companion apps", async () => {
   const writes = [];
   const originalWrite = process.stdout.write;


### PR DESCRIPTION
## Summary

This PR fixes trusted reconnect recovery when a Mac bridge relay session goes stale, especially for long-running/headless Mac setups where the bridge can restart while the Mac itself remains trusted.

Previously, repeated secure reconnect failures could clear too much relay state and push the iPhone toward a fresh QR scan even though the trusted Mac identity was still valid. The UI could also offer `Wake Screen` when the app only remembered a trusted Mac, not an actual live saved-session route that could carry the wake request.

## What Changed

- Preserve trusted Mac identity and relay base metadata when only the per-launch relay session is stale.
- Keep reconnect in `liveSessionUnresolved` instead of forcing QR unless trust is actually broken.
- Harden trusted-session resolve URL handling for proxied/self-hosted relays by trying proxy-relative and root resolve routes.
- Generate a fresh trusted-resolve nonce/signature for each candidate route.
- Limit `Wake Screen` to cases where a concrete saved trusted live-session route exists.
- Improve unsupported-relay copy so users are told trusted reconnect is unavailable rather than being told to immediately re-pair.
- Keep context-window usage unknown after request failures so transient errors do not display as real `0 used` data.
- Keep explicit zero only for valid missing/unreported context usage, and restore the UI distinction between unknown and zero.
- Add focused tests around reconnect URL fallback, stale-session preservation, wake eligibility, context usage failure handling, and CLI startup copy.

## Validation

- Ran `git diff --check` successfully.
- Attempted `node --test phodex-bridge/test/remodex-cli.test.js`, but this worktree is missing the `ws` dependency, so the test runner could not load the bridge module.
- Did not run Xcode tests, following the repo guardrail to avoid Xcode test runs unless explicitly requested.

## Notes

This does not try to perfectly diagnose whether the Mac is powered off, asleep, bridge-crashed, or blocked by a proxy. It makes the recovery behavior correct: if the Mac is still trusted, the app should try to resolve/reconnect instead of prematurely demanding a new QR code.
