### PR TITLE
Bridge + relay: handoff desktop su Windows, relay mobile e bind di rete

### DIFF
--- a/phodex-bridge/src/desktop-handler.js
+++ b/phodex-bridge/src/desktop-handler.js
@@ -20,6 +20,7 @@ const DEFAULT_APP_BOOT_WAIT_MS = 1_200;
 const DEFAULT_THREAD_MATERIALIZE_WAIT_MS = 4_000;
 const DEFAULT_THREAD_MATERIALIZE_POLL_MS = 250;
 const DEFAULT_WAKE_DISPLAY_DURATION_SECONDS = 30;
+const WINDOWS_BOUNCE_URL = "codex://settings";
 
 function handleDesktopRequest(rawMessage, sendResponse, options = {}) {
   let parsed;
@@ -71,16 +72,39 @@ async function handleDesktopMethod(method, params, options = {}) {
   const threadMaterializeWaitMs = options.threadMaterializeWaitMs ?? DEFAULT_THREAD_MATERIALIZE_WAIT_MS;
   const threadMaterializePollMs = options.threadMaterializePollMs ?? DEFAULT_THREAD_MATERIALIZE_POLL_MS;
 
-  if (platform !== "darwin") {
-    throw desktopError(
-      "unsupported_platform",
-      "Mac handoff is only available when the bridge is running on macOS."
-    );
-  }
-
   switch (method) {
+    case "desktop/continueOnDesktop":
+      if (platform !== "darwin" && platform !== "win32") {
+        throw desktopError(
+          "unsupported_platform",
+          "Desktop handoff is only available when the bridge is running on macOS or Windows."
+        );
+      }
+
+      return continueOnDesktop(params, {
+        platform,
+        bundleId,
+        appPath,
+        executor,
+        env,
+        fsModule,
+        isAppRunning,
+        sleepFn,
+        appBootWaitMs,
+        relaunchWaitMs,
+        threadMaterializeWaitMs,
+        threadMaterializePollMs,
+      });
     case "desktop/continueOnMac":
-      return continueOnMac(params, {
+      if (platform !== "darwin") {
+        throw desktopError(
+          "unsupported_platform",
+          "Mac handoff is only available when the bridge is running on macOS."
+        );
+      }
+
+      return continueOnDesktop(params, {
+        platform,
         bundleId,
         appPath,
         executor,
@@ -106,10 +130,11 @@ async function handleDesktopMethod(method, params, options = {}) {
   }
 }
 
-// Waits for fresh phone-authored chats to materialize locally before deep-linking them on Mac.
-async function continueOnMac(
+// Waits for fresh phone-authored chats to materialize locally before deep-linking them on desktop.
+async function continueOnDesktop(
   params,
   {
+    platform,
     bundleId,
     appPath,
     executor,
@@ -125,11 +150,50 @@ async function continueOnMac(
 ) {
   const threadId = resolveThreadId(params);
   if (!threadId) {
-    throw desktopError("missing_thread_id", "A thread id is required to continue on Mac.");
+    throw desktopError("missing_thread_id", "A thread id is required to continue on desktop.");
   }
 
   const targetUrl = `codex://threads/${threadId}`;
   const desktopKnown = isThreadLikelyKnownOnDesktop(threadId, { env, fsModule });
+
+  if (platform === "win32") {
+    try {
+      if (desktopKnown) {
+        await refreshWindowsCodex(targetUrl, {
+          executor,
+          env,
+          sleepFn,
+          settleMs: relaunchWaitMs,
+        });
+      } else {
+        await openWindowsDeepLink(WINDOWS_BOUNCE_URL, { executor, env });
+        await sleepFn(appBootWaitMs);
+        await waitForThreadMaterialization(threadId, {
+          env,
+          fsModule,
+          sleepFn,
+          timeoutMs: threadMaterializeWaitMs,
+          pollMs: threadMaterializePollMs,
+        });
+        await openWindowsDeepLink(targetUrl, { executor, env });
+      }
+    } catch (error) {
+      throw desktopError(
+        "handoff_failed",
+        "Could not open Codex on this PC.",
+        error
+      );
+    }
+
+    return {
+      success: true,
+      relaunched: false,
+      targetUrl,
+      threadId,
+      desktopKnown,
+    };
+  }
+
   const appRunning = typeof isAppRunning === "function"
     ? await isAppRunning(appPath)
     : await detectRunningCodexApp(appPath, executor);
@@ -370,6 +434,25 @@ async function openCodexApp({ bundleId, appPath, executor }) {
       timeout: HANDOFF_TIMEOUT_MS,
     });
   }
+}
+
+async function openWindowsDeepLink(targetUrl, { executor, env }) {
+  await executor(env?.ComSpec || "cmd.exe", [
+    "/d",
+    "/c",
+    "start",
+    "",
+    targetUrl,
+  ], {
+    timeout: HANDOFF_TIMEOUT_MS,
+    windowsHide: true,
+  });
+}
+
+async function refreshWindowsCodex(targetUrl, { executor, env, sleepFn, settleMs }) {
+  await openWindowsDeepLink(WINDOWS_BOUNCE_URL, { executor, env });
+  await sleepFn(settleMs);
+  await openWindowsDeepLink(targetUrl, { executor, env });
 }
 
 // Gives the desktop a short window to materialize the requested thread before the final deep link.

--- a/phodex-bridge/src/git-handler.js
+++ b/phodex-bridge/src/git-handler.js
@@ -13,6 +13,8 @@ const { promisify } = require("util");
 
 const execFileAsync = promisify(execFile);
 const GIT_TIMEOUT_MS = 30_000;
+/** Node defaults maxBuffer to 1 MiB; large repo diffs exceed it ("stdout maxBuffer length exceeded"). */
+const GIT_EXEC_MAX_BUFFER_BYTES = 50 * 1024 * 1024;
 const GIT_DRAFT_TIMEOUT_MS = 120_000;
 const GIT_DRAFT_PATCH_MAX_BYTES = 80_000;
 const EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
@@ -2104,7 +2106,7 @@ async function gitDiffNoIndexNumstat(cwd, filePath) {
     const { stdout } = await execFileAsync(
       "git",
       ["diff", "--no-index", "--numstat", "--", "/dev/null", filePath],
-      { cwd, timeout: GIT_TIMEOUT_MS }
+      { cwd, timeout: GIT_TIMEOUT_MS, maxBuffer: GIT_EXEC_MAX_BUFFER_BYTES }
     );
     return stdout;
   } catch (err) {
@@ -2130,7 +2132,7 @@ async function gitDiffNoIndexPatch(cwd, filePath) {
     const { stdout } = await execFileAsync(
       "git",
       ["diff", "--no-index", "--binary", "--", "/dev/null", filePath],
-      { cwd, timeout: GIT_TIMEOUT_MS }
+      { cwd, timeout: GIT_TIMEOUT_MS, maxBuffer: GIT_EXEC_MAX_BUFFER_BYTES }
     );
     return stdout;
   } catch (err) {
@@ -2145,7 +2147,11 @@ async function gitDiffNoIndexPatch(cwd, filePath) {
 // ─── Helpers ──────────────────────────────────────────────────
 
 function git(cwd, ...args) {
-  return execFileAsync("git", args, { cwd, timeout: GIT_TIMEOUT_MS })
+  return execFileAsync("git", args, {
+    cwd,
+    timeout: GIT_TIMEOUT_MS,
+    maxBuffer: GIT_EXEC_MAX_BUFFER_BYTES,
+  })
     .then(({ stdout }) => stdout)
     .catch((err) => {
       const msg = (err.stderr || err.message || "").trim();

--- a/phodex-bridge/src/qr.js
+++ b/phodex-bridge/src/qr.js
@@ -43,6 +43,8 @@ function normalizePairingSession(pairingSessionOrPayload) {
 function printQR(pairingSessionOrPayload) {
   const { pairingPayload, pairingCode } = normalizePairingSession(pairingSessionOrPayload);
   const payload = JSON.stringify(pairingPayload);
+  const sessionId = typeof pairingPayload?.sessionId === "string" ? pairingPayload.sessionId.trim() : "";
+  const sessionIdShort = sessionId.length > 12 ? `${sessionId.slice(0, 8)}…` : sessionId;
 
   console.log("\nScan this QR with the iPhone:\n");
   qrcode.generate(payload, { small: true });
@@ -50,9 +52,12 @@ function printQR(pairingSessionOrPayload) {
     console.log("Or paste this pairing code in the iPhone app:\n");
     console.log(pairingCode);
   }
-  console.log(`\nSession ID: ${pairingPayload.sessionId}`);
+  console.log(`\nSession ID: ${sessionIdShort || "(none)"}`);
   console.log(`Device ID: ${pairingPayload.macDeviceId}`);
   console.log(`Expires: ${new Date(pairingPayload.expiresAt).toISOString()}\n`);
+  // Same bytes as the QR (handy for Android emulator / CI: copy-paste into the in-app debug pairing field).
+  console.log("Pairing JSON (scan target or paste for Remodex Android debug UI):\n");
+  console.log(`${payload}\n`);
 }
 
 module.exports = {

--- a/phodex-bridge/src/workspace-handler.js
+++ b/phodex-bridge/src/workspace-handler.js
@@ -37,6 +37,8 @@ const IMAGE_MIME_TYPES_BY_EXTENSION = new Map([
   [".heic", "image/heic"],
   [".heif", "image/heif"],
 ]);
+/** Match git-handler.js: Node default maxBuffer is 1 MiB. */
+const GIT_EXEC_MAX_BUFFER_BYTES = 50 * 1024 * 1024;
 const repoMutationLocks = new Map();
 
 function handleWorkspaceRequest(rawMessage, sendResponse) {
@@ -572,6 +574,7 @@ async function runGitApply(cwd, args, patchText) {
     const { stdout, stderr } = await execFileAsync("git", [...args, tempPatchPath], {
       cwd,
       timeout: GIT_TIMEOUT_MS,
+      maxBuffer: GIT_EXEC_MAX_BUFFER_BYTES,
     });
     return { ok: true, stdout, stderr };
   } catch (err) {
@@ -730,7 +733,11 @@ function workspaceError(errorCode, userMessage) {
 }
 
 function git(cwd, ...args) {
-  return execFileAsync("git", args, { cwd, timeout: GIT_TIMEOUT_MS })
+  return execFileAsync("git", args, {
+    cwd,
+    timeout: GIT_TIMEOUT_MS,
+    maxBuffer: GIT_EXEC_MAX_BUFFER_BYTES,
+  })
     .then(({ stdout }) => stdout)
     .catch((err) => {
       const msg = (err.stderr || err.message || "").trim();

--- a/phodex-bridge/test/desktop-handler.test.js
+++ b/phodex-bridge/test/desktop-handler.test.js
@@ -119,7 +119,7 @@ test("desktop/continueOnMac relaunches when a desktop-known thread is requested 
   let running = true;
   const fakeFS = {
     existsSync(targetPath) {
-      return targetPath.endsWith("/sessions");
+      return /[\\/]sessions$/.test(targetPath);
     },
     readdirSync() {
       return [{
@@ -192,7 +192,7 @@ test("desktop/continueOnMac boots Codex before deep-linking when the thread alre
   let running = false;
   const fakeFS = {
     existsSync(targetPath) {
-      return targetPath.endsWith("/sessions");
+      return /[\\/]sessions$/.test(targetPath);
     },
     readdirSync() {
       return [{
@@ -241,6 +241,60 @@ test("desktop/continueOnMac boots Codex before deep-linking when the thread alre
   ]);
   assert.equal(responses[0].result?.relaunched, false);
   assert.equal(responses[0].result?.desktopKnown, true);
+});
+
+test("desktop/continueOnDesktop bounces Codex via deep links on Windows", async () => {
+  const executorCalls = [];
+  const responses = [];
+
+  handleDesktopRequest(JSON.stringify({
+    id: "request-win-1",
+    method: "desktop/continueOnDesktop",
+    params: {
+      threadId: "thread-win-123",
+    },
+  }), (response) => {
+    responses.push(JSON.parse(response));
+  }, {
+    platform: "win32",
+    env: { ComSpec: "cmd.exe" },
+    executor: async (...args) => {
+      executorCalls.push(args);
+      return { stdout: "", stderr: "" };
+    },
+    sleepFn: async () => {},
+    threadMaterializeWaitMs: 0,
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(executorCalls.length, 2);
+  assert.equal(executorCalls[0][0], "cmd.exe");
+  assert.deepEqual(executorCalls[0][1], [
+    "/d",
+    "/c",
+    "start",
+    "",
+    "codex://settings",
+  ]);
+  assert.equal(executorCalls[1][0], "cmd.exe");
+  assert.deepEqual(executorCalls[1][1], [
+    "/d",
+    "/c",
+    "start",
+    "",
+    "codex://threads/thread-win-123",
+  ]);
+  assert.deepEqual(responses, [{
+    id: "request-win-1",
+    result: {
+      success: true,
+      relaunched: false,
+      targetUrl: "codex://threads/thread-win-123",
+      threadId: "thread-win-123",
+      desktopKnown: false,
+    },
+  }]);
 });
 
 test("desktop/continueOnMac returns a bridge error when thread id is missing", async () => {

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -17,8 +17,17 @@ const TRUSTED_SESSION_RESOLVE_SKEW_MS = 90_000;
 const SHORT_PAIRING_CODE_MIN_LENGTH = 8;
 const SHORT_PAIRING_CODE_MAX_LENGTH = 12;
 
-// In-memory session registry for one Mac host and one live iPhone client per session.
+// In-memory session registry for one Mac host and one live mobile client per session (iOS or Android).
 const sessions = new Map();
+
+function normalizeRelayRole(headerValue) {
+  const raw = readHeaderString(headerValue);
+  return typeof raw === "string" ? raw.trim().toLowerCase() : "";
+}
+
+function isRelayMobileRole(role) {
+  return role === "iphone" || role === "android";
+}
 const liveSessionsByMacDeviceId = new Map();
 const liveSessionsByPairingCode = new Map();
 const usedResolveNonces = new Map();
@@ -50,9 +59,9 @@ function setupRelay(
     const urlPath = req.url || "";
     const match = urlPath.match(/^\/relay\/([^/?]+)/);
     const sessionId = match?.[1];
-    const role = req.headers["x-role"];
+    const role = normalizeRelayRole(req.headers["x-role"]);
 
-    if (!sessionId || (role !== "mac" && role !== "iphone")) {
+    if (!sessionId || (role !== "mac" && !isRelayMobileRole(role))) {
       ws.close(4000, "Missing sessionId or invalid x-role header");
       return;
     }
@@ -63,7 +72,7 @@ function setupRelay(
     });
 
     // Only the Mac host is allowed to create a fresh session room.
-    if (role === "iphone" && !sessions.has(sessionId)) {
+    if (isRelayMobileRole(role) && !sessions.has(sessionId)) {
       ws.close(CLOSE_CODE_SESSION_UNAVAILABLE, "Mac session not available");
       return;
     }
@@ -81,7 +90,7 @@ function setupRelay(
 
     const session = sessions.get(sessionId);
 
-    if (role === "iphone" && !canAcceptIphoneConnection(session)) {
+    if (isRelayMobileRole(role) && !canAcceptMobileClientConnection(session)) {
       ws.close(CLOSE_CODE_SESSION_UNAVAILABLE, "Mac session not available");
       return;
     }
@@ -104,7 +113,7 @@ function setupRelay(
       registerLiveMacSession(session.macRegistration);
       console.log(`[relay] Mac connected -> ${relaySessionLogLabel(sessionId)}`);
     } else {
-      // Keep one live iPhone RPC client per session to avoid competing sockets.
+      // Keep one live mobile RPC client per session to avoid competing sockets.
       for (const existingClient of session.clients) {
         if (existingClient === ws) {
           continue;
@@ -115,7 +124,7 @@ function setupRelay(
         ) {
           existingClient.close(
             CLOSE_CODE_IPHONE_REPLACED,
-            "Replaced by newer iPhone connection"
+            "Replaced by newer mobile connection"
           );
         }
         session.clients.delete(existingClient);
@@ -123,7 +132,7 @@ function setupRelay(
 
       session.clients.add(ws);
       console.log(
-        `[relay] iPhone connected -> ${relaySessionLogLabel(sessionId)} `
+        `[relay] Mobile connected (${role}) -> ${relaySessionLogLabel(sessionId)} `
         + `(${session.clients.size} client(s))`
       );
     }
@@ -169,7 +178,7 @@ function setupRelay(
       } else {
         session.clients.delete(ws);
         console.log(
-          `[relay] iPhone disconnected -> ${relaySessionLogLabel(sessionId)} `
+          `[relay] Mobile disconnected (${role}) -> ${relaySessionLogLabel(sessionId)} `
           + `(${session.clients.size} remaining)`
         );
       }
@@ -252,7 +261,7 @@ function clearMacAbsenceTimer(session, { clearTimeoutFn = clearTimeout } = {}) {
   session.macAbsenceTimer = null;
 }
 
-function canAcceptIphoneConnection(session) {
+function canAcceptMobileClientConnection(session) {
   if (!session) {
     return false;
   }

--- a/relay/server.js
+++ b/relay/server.js
@@ -359,9 +359,10 @@ if (require.main === module) {
   const enablePushService = readOptionalBooleanEnv(
     ["REMODEX_ENABLE_PUSH_SERVICE", "PHODEX_ENABLE_PUSH_SERVICE"]
   ) ?? false;
+  const bindHost = process.env.RELAY_BIND_HOST || "0.0.0.0";
   const { server } = createRelayServer({ enablePushService, trustProxy });
-  server.listen(port, () => {
-    console.log(`[relay] listening on :${port}`);
+  server.listen(port, bindHost, () => {
+    console.log(`[relay] listening on ${bindHost}:${port}`);
   });
 }
 

--- a/relay/server.test.js
+++ b/relay/server.test.js
@@ -553,6 +553,31 @@ test("websocket relay forwards between mac and iphone on the base relay path", a
   });
 });
 
+test("websocket relay forwards between mac and android on the base relay path", async () => {
+  await withServer(async ({ port }) => {
+    const mac = new WebSocket(`ws://127.0.0.1:${port}/relay/session-android-1`, {
+      headers: { "x-role": "mac" },
+    });
+    const android = new WebSocket(`ws://127.0.0.1:${port}/relay/session-android-1`, {
+      headers: { "x-role": "android" },
+    });
+
+    await Promise.all([onceOpen(mac), onceOpen(android)]);
+
+    const received = new Promise((resolve) => {
+      android.once("message", (value) => resolve(value.toString("utf8")));
+    });
+    mac.send(JSON.stringify({ ok: true }));
+    assert.equal(await received, "{\"ok\":true}");
+
+    const macClosed = onceClosed(mac);
+    const androidClosed = onceClosed(android);
+    mac.close();
+    android.close();
+    await Promise.all([macClosed, androidClosed]);
+  });
+});
+
 test("relay keeps the iPhone connected briefly but rejects new sends while the mac is absent", async () => {
   await withServer(async ({ port }) => {
     const mac = new WebSocket(`ws://127.0.0.1:${port}/relay/session-grace`, {


### PR DESCRIPTION
### Italiano

Questa PR **non** introduce il client Android nel repository.

**Obiettivo:** far funzionare il flusso **iPhone (iOS) + bridge** anche quando il bridge gira su **Windows** (handoff `codex://`, output Git stabili su diff/operazioni grandi) e rendere il **relay** utilizzabile da rete (`RELAY_BIND_HOST`, default `0.0.0.0`) con ruoli mobile chiari nel protocollo (`iphone` / `android` per compatibilità relay; il prodotto in repo resta **iOS**). QR pairing arricchito con campi JSON utili al debug.

**File:** `phodex-bridge/`, `relay/` (e test correlati).

---

### English

This PR **does not** add the Android app to this repository.

**Goal:** support the **iOS app + bridge** workflow when the bridge runs on **Windows** (desktop handoff via `codex://` on win32, larger `execFile`/`git` buffers for big outputs) and make the **relay** usable from the LAN/WAN by binding to `RELAY_BIND_HOST` (default `0.0.0.0`) with explicit mobile roles in the protocol. QR payload includes extra JSON fields for debugging.

**Scope:** `phodex-bridge/`, `relay/` (and related tests).