### PR TITLE
Add desktop IPC action follower to bridge

### DIFF
--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -40,6 +40,10 @@ const {
 } = require("./secure-device-state");
 const { createBridgeSecureTransport } = require("./secure-transport");
 const { createRolloutLiveMirrorController } = require("./rollout-live-mirror");
+const {
+  createDesktopIpcActionFollower,
+  seedConversationStateFromThreadRead,
+} = require("./desktop-ipc-action-follower");
 const { version: bridgePackageVersion = "" } = require("../package.json");
 const {
   MINIMUM_SUPPORTED_IOS_APP_VERSION,
@@ -173,6 +177,13 @@ function startBridge({
   const rolloutLiveMirror = !config.codexEndpoint
     ? createRolloutLiveMirrorController({
       sendApplicationResponse,
+    })
+    : null;
+  const desktopIpcActionFollower = !config.codexEndpoint
+    ? createDesktopIpcActionFollower({
+      sendApplicationResponse,
+      readConversationState: readDesktopConversationState,
+      socketPath: config.desktopIpcSocketPath || undefined,
     })
     : null;
   let contextUsageWatcher = null;
@@ -410,6 +421,7 @@ function startBridge({
       }
       stopContextUsageWatcher();
       rolloutLiveMirror?.stopAll();
+      desktopIpcActionFollower?.stopAll();
       desktopRefresher.handleTransportReset();
       scheduleRelayReconnect(code);
     });
@@ -464,6 +476,7 @@ function startBridge({
     clearReconnectTimer();
     stopContextUsageWatcher();
     rolloutLiveMirror?.stopAll();
+    desktopIpcActionFollower?.stopAll();
     desktopRefresher.handleTransportReset();
     failBridgeManagedCodexRequests(new Error("Codex transport closed before the bridge request completed."));
     forwardedRequestMethodsById.clear();
@@ -526,6 +539,9 @@ function startBridge({
     }
     desktopRefresher.handleInbound(rawMessage);
     rolloutLiveMirror?.observeInbound(rawMessage);
+    if (desktopIpcActionFollower?.observeInbound(rawMessage)) {
+      return;
+    }
     rememberForwardedRequestMethod(rawMessage);
     rememberThreadFromMessage("phone", rawMessage);
     codex.send(rawMessage);
@@ -556,6 +572,15 @@ function startBridge({
         title: name,
       },
     }));
+  }
+
+  // Seeds the desktop IPC follower when it receives patches before a full snapshot.
+  async function readDesktopConversationState(threadId) {
+    const result = await sendCodexRequest("thread/read", {
+      threadId,
+      includeTurns: true,
+    });
+    return seedConversationStateFromThreadRead(result);
   }
 
   // ─── Bridge-owned auth snapshot ─────────────────────────────

--- a/phodex-bridge/src/codex-desktop-refresher.js
+++ b/phodex-bridge/src/codex-desktop-refresher.js
@@ -581,6 +581,7 @@ function readBridgeConfig({
       ? (persistedKeepMacAwakeEnabled == null ? false : persistedKeepMacAwakeEnabled)
       : explicitKeepMacAwakeEnabled,
     codexEndpoint,
+    desktopIpcSocketPath: readFirstDefinedEnv(["REMODEX_DESKTOP_IPC_SOCKET"], "", env),
     refreshCommand,
     codexBundleId: readFirstDefinedEnv(["REMODEX_CODEX_BUNDLE_ID"], DEFAULT_BUNDLE_ID, env),
     codexAppPath: DEFAULT_APP_PATH,

--- a/phodex-bridge/src/desktop-ipc-action-follower.js
+++ b/phodex-bridge/src/desktop-ipc-action-follower.js
@@ -1,0 +1,646 @@
+// FILE: desktop-ipc-action-follower.js
+// Purpose: Mirrors live Codex Desktop IPC pending actions to the phone and routes replies back to the desktop runtime.
+// Layer: CLI helper
+// Exports: createDesktopIpcActionFollower, projectPendingDesktopActions
+// Depends on: net, os, path
+
+const net = require("net");
+const os = require("os");
+const path = require("path");
+
+const FRAME_HEADER_BYTES = 4;
+const MAX_FRAME_BYTES = 256 * 1024 * 1024;
+const REQUEST_TIMEOUT_MS = 10_000;
+const DESKTOP_RESUME_METHODS = new Set(["thread/read", "thread/resume"]);
+const ACTION_METHODS = new Set([
+  "item/commandExecution/requestApproval",
+  "item/fileChange/requestApproval",
+  "item/tool/requestUserInput",
+]);
+const REPLY_METHOD_BY_ACTION_METHOD = new Map([
+  ["item/commandExecution/requestApproval", "thread-follower-command-approval-decision"],
+  ["item/fileChange/requestApproval", "thread-follower-file-approval-decision"],
+  ["item/tool/requestUserInput", "thread-follower-submit-user-input"],
+]);
+const METHOD_VERSION_BY_NAME = new Map([
+  ["initialize", 1],
+  ["thread-follower-command-approval-decision", 1],
+  ["thread-follower-file-approval-decision", 1],
+  ["thread-follower-submit-user-input", 1],
+]);
+const APPROVAL_DECISIONS = new Set(["accept", "acceptForSession", "decline", "cancel"]);
+
+// Opens the Desktop IPC bus on demand and exposes Mac-owned pending actions as normal app-server requests.
+function createDesktopIpcActionFollower({
+  sendApplicationResponse,
+  readConversationState = null,
+  logPrefix = "[remodex]",
+  socketPath = resolveDefaultIpcSocketPath(),
+  netModule = net,
+  now = () => Date.now(),
+  requestTimeoutMs = REQUEST_TIMEOUT_MS,
+} = {}) {
+  const ipc = createDesktopIpcClient({
+    socketPath,
+    netModule,
+    now,
+    requestTimeoutMs,
+    logPrefix,
+    onEnvelope,
+    onDisconnect,
+  });
+  const rawStatesByThreadId = new Map();
+  const pendingRoutesByRequestId = new Map();
+  const activeThreadIds = new Set();
+  const recoveringThreadIds = new Set();
+  const queuedChangesByThreadId = new Map();
+
+  function observeInbound(rawMessage) {
+    const message = safeParseJSON(rawMessage);
+    const responseRoute = desktopRouteForResponse(message);
+    if (responseRoute) {
+      submitDesktopActionResponse(responseRoute, message);
+      return true;
+    }
+
+    const method = readString(message?.method);
+    if (!DESKTOP_RESUME_METHODS.has(method)) {
+      return false;
+    }
+
+    const threadId = readThreadId(message?.params);
+    if (!threadId) {
+      return false;
+    }
+
+    activeThreadIds.add(threadId);
+    ipc.ensureConnected();
+    recoverThreadBaseline(threadId);
+    return false;
+  }
+
+  function stopAll() {
+    rawStatesByThreadId.clear();
+    pendingRoutesByRequestId.clear();
+    activeThreadIds.clear();
+    recoveringThreadIds.clear();
+    queuedChangesByThreadId.clear();
+    ipc.close();
+  }
+
+  // Desktop broadcasts carry the live conversation state Litter projects from.
+  function onEnvelope(envelope) {
+    if (envelope?.type !== "broadcast" || envelope.method !== "thread-stream-state-changed") {
+      return;
+    }
+
+    const params = envelope.params || {};
+    const threadId = readString(params.conversationId) || readString(params.conversation_id);
+    if (!threadId || !activeThreadIds.has(threadId)) {
+      return;
+    }
+
+    if (recoveringThreadIds.has(threadId)) {
+      queueThreadChange(threadId, params.change);
+      return;
+    }
+
+    const previousState = rawStatesByThreadId.get(threadId) || null;
+    const nextState = applyConversationStateChange(previousState, params.change);
+    if (!nextState) {
+      if (isPatchChange(params.change)) {
+        queueThreadChange(threadId, params.change);
+        recoverThreadBaseline(threadId);
+      }
+      return;
+    }
+
+    rawStatesByThreadId.set(threadId, nextState);
+    syncProjectedActions(threadId, projectPendingDesktopActions(threadId, nextState));
+  }
+
+  function onDisconnect() {
+    rawStatesByThreadId.clear();
+    pendingRoutesByRequestId.clear();
+    recoveringThreadIds.clear();
+    queuedChangesByThreadId.clear();
+  }
+
+  function syncProjectedActions(threadId, actions) {
+    const nextRequestIds = new Set(actions.map((action) => action.id));
+    for (const [requestId, route] of Array.from(pendingRoutesByRequestId.entries())) {
+      if (route.threadId !== threadId || nextRequestIds.has(requestId)) {
+        continue;
+      }
+
+      pendingRoutesByRequestId.delete(requestId);
+      sendApplicationResponse(JSON.stringify({
+        method: "serverRequest/resolved",
+        params: {
+          threadId,
+          requestId,
+        },
+      }));
+    }
+
+    for (const action of actions) {
+      if (pendingRoutesByRequestId.has(action.id)) {
+        continue;
+      }
+
+      pendingRoutesByRequestId.set(action.id, {
+        requestId: action.id,
+        method: action.method,
+        threadId,
+      });
+      sendApplicationResponse(JSON.stringify({
+        id: action.id,
+        method: action.method,
+        params: action.params,
+      }));
+    }
+  }
+
+  function desktopRouteForResponse(message) {
+    if (!message || typeof message !== "object" || message.method) {
+      return null;
+    }
+
+    const requestId = requestIdKey(message.id);
+    return requestId ? pendingRoutesByRequestId.get(requestId) || null : null;
+  }
+
+  function submitDesktopActionResponse(route, responseMessage) {
+    const payload = desktopFollowerPayloadForResponse(route, responseMessage);
+    if (!payload) {
+      sendApplicationResponse(JSON.stringify({
+        id: responseMessage?.id ?? route.requestId,
+        error: {
+          code: -32602,
+          message: "Invalid desktop action response.",
+        },
+      }));
+      return;
+    }
+
+    ipc.sendRequest(payload.method, payload.params)
+      .then(() => {
+        pendingRoutesByRequestId.delete(route.requestId);
+        sendApplicationResponse(JSON.stringify({
+          method: "serverRequest/resolved",
+          params: {
+            threadId: route.threadId,
+            requestId: route.requestId,
+          },
+        }));
+      })
+      .catch((error) => {
+        console.warn(`${logPrefix} desktop action reply failed for ${route.threadId}: ${error.message}`);
+        sendApplicationResponse(JSON.stringify({
+          id: responseMessage.id,
+          error: {
+            code: -32000,
+            message: "Could not send this action to Codex on the Mac.",
+          },
+        }));
+      });
+  }
+
+  function queueThreadChange(threadId, change) {
+    if (!change || typeof change !== "object") {
+      return;
+    }
+
+    const queuedChanges = queuedChangesByThreadId.get(threadId) || [];
+    queuedChanges.push(change);
+    queuedChangesByThreadId.set(threadId, queuedChanges);
+  }
+
+  function recoverThreadBaseline(threadId) {
+    if (typeof readConversationState !== "function"
+      || recoveringThreadIds.has(threadId)
+      || rawStatesByThreadId.has(threadId)) {
+      return;
+    }
+
+    recoveringThreadIds.add(threadId);
+    Promise.resolve()
+      .then(() => readConversationState(threadId))
+      .then((baselineState) => {
+        if (!baselineState || typeof baselineState !== "object") {
+          return;
+        }
+
+        let nextState = cloneJSON(baselineState);
+        const queuedChanges = queuedChangesByThreadId.get(threadId) || [];
+        queuedChangesByThreadId.delete(threadId);
+        for (const change of queuedChanges) {
+          nextState = applyConversationStateChange(nextState, change) || nextState;
+        }
+
+        rawStatesByThreadId.set(threadId, nextState);
+        syncProjectedActions(threadId, projectPendingDesktopActions(threadId, nextState));
+      })
+      .catch((error) => {
+        console.warn(`${logPrefix} desktop IPC baseline recovery failed for ${threadId}: ${error.message}`);
+      })
+      .finally(() => {
+        recoveringThreadIds.delete(threadId);
+      });
+  }
+
+  return {
+    observeInbound,
+    stopAll,
+  };
+}
+
+// Minimal IPC client for Litter's length-prefixed Codex desktop bus.
+function createDesktopIpcClient({
+  socketPath,
+  netModule,
+  now,
+  requestTimeoutMs,
+  logPrefix,
+  onEnvelope,
+  onDisconnect,
+}) {
+  let socket = null;
+  let clientId = "";
+  let isConnecting = false;
+  let readBuffer = Buffer.alloc(0);
+  const pendingRequests = new Map();
+
+  function ensureConnected() {
+    if (socket || isConnecting) {
+      return;
+    }
+
+    isConnecting = true;
+    const nextSocket = netModule.createConnection(socketPath);
+    socket = nextSocket;
+
+    nextSocket.on("connect", () => {
+      isConnecting = false;
+      sendRequest("initialize", { clientType: "remodex-bridge" })
+        .then((result) => {
+          clientId = readString(result?.clientId) || clientId;
+        })
+        .catch((error) => {
+          console.warn(`${logPrefix} desktop IPC initialize failed: ${error.message}`);
+          close();
+        });
+    });
+    nextSocket.on("data", handleData);
+    nextSocket.on("close", handleClose);
+    nextSocket.on("error", (error) => {
+      if (error?.code !== "ENOENT" && error?.code !== "ECONNREFUSED") {
+        console.warn(`${logPrefix} desktop IPC connection failed: ${error.message}`);
+      }
+    });
+  }
+
+  function sendRequest(method, params) {
+    ensureConnected();
+    if (!socket || socket.destroyed) {
+      return Promise.reject(new Error("Desktop IPC is not connected."));
+    }
+
+    const requestId = `remodex-${now().toString(36)}-${Math.random().toString(16).slice(2)}`;
+    const envelope = {
+      type: "request",
+      requestId,
+      sourceClientId: method === "initialize" ? "initializing-client" : clientId || "remodex-bridge",
+      version: METHOD_VERSION_BY_NAME.get(method) || 1,
+      method,
+      params: params || {},
+    };
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pendingRequests.delete(requestId);
+        reject(new Error(`Desktop IPC request timed out: ${method}`));
+      }, requestTimeoutMs);
+      timeout.unref?.();
+
+      pendingRequests.set(requestId, {
+        method,
+        resolve,
+        reject,
+        timeout,
+      });
+      writeFrame(socket, JSON.stringify(envelope), (error) => {
+        if (!error) {
+          return;
+        }
+
+        clearTimeout(timeout);
+        pendingRequests.delete(requestId);
+        reject(error);
+      });
+    });
+  }
+
+  function handleData(chunk) {
+    readBuffer = Buffer.concat([readBuffer, chunk]);
+    while (readBuffer.length >= FRAME_HEADER_BYTES) {
+      const frameLength = readBuffer.readUInt32LE(0);
+      if (frameLength > MAX_FRAME_BYTES) {
+        close();
+        return;
+      }
+      if (readBuffer.length < FRAME_HEADER_BYTES + frameLength) {
+        return;
+      }
+
+      const payload = readBuffer.slice(FRAME_HEADER_BYTES, FRAME_HEADER_BYTES + frameLength).toString("utf8");
+      readBuffer = readBuffer.slice(FRAME_HEADER_BYTES + frameLength);
+      const envelope = safeParseJSON(payload);
+      if (envelope) {
+        dispatchEnvelope(envelope);
+      }
+    }
+  }
+
+  function dispatchEnvelope(envelope) {
+    if (envelope.type === "client-discovery-request") {
+      writeEnvelope({
+        type: "client-discovery-response",
+        requestId: envelope.requestId,
+        response: {
+          canHandle: false,
+        },
+      });
+      return;
+    }
+
+    if (envelope.type === "response") {
+      const requestId = requestIdKey(envelope.requestId);
+      const waiter = requestId ? pendingRequests.get(requestId) : null;
+      if (!waiter) {
+        return;
+      }
+
+      pendingRequests.delete(requestId);
+      clearTimeout(waiter.timeout);
+      if (envelope.resultType === "error") {
+        waiter.reject(new Error(envelope.error || `Desktop IPC request failed: ${waiter.method}`));
+        return;
+      }
+
+      waiter.resolve(envelope.result ?? null);
+      return;
+    }
+
+    onEnvelope(envelope);
+  }
+
+  function handleClose() {
+    socket = null;
+    clientId = "";
+    isConnecting = false;
+    readBuffer = Buffer.alloc(0);
+    for (const waiter of pendingRequests.values()) {
+      clearTimeout(waiter.timeout);
+      waiter.reject(new Error("Desktop IPC connection closed."));
+    }
+    pendingRequests.clear();
+    onDisconnect();
+  }
+
+  function close() {
+    if (!socket) {
+      return;
+    }
+
+    const nextSocket = socket;
+    socket = null;
+    nextSocket.destroy();
+  }
+
+  function writeEnvelope(envelope, callback = () => {}) {
+    if (!socket || socket.destroyed) {
+      callback(new Error("Desktop IPC is not connected."));
+      return;
+    }
+
+    writeFrame(socket, JSON.stringify(envelope), callback);
+  }
+
+  return {
+    ensureConnected,
+    sendRequest,
+    close,
+  };
+}
+
+function desktopFollowerPayloadForResponse(route, responseMessage) {
+  const method = REPLY_METHOD_BY_ACTION_METHOD.get(route.method);
+  if (!method || responseMessage?.error) {
+    return null;
+  }
+
+  if (route.method === "item/tool/requestUserInput") {
+    const answers = responseMessage?.result?.answers;
+    if (!answers || typeof answers !== "object" || Array.isArray(answers)) {
+      return null;
+    }
+
+    return {
+      method,
+      params: {
+        conversationId: route.threadId,
+        requestId: route.requestId,
+        response: {
+          answers,
+        },
+      },
+    };
+  }
+
+  const decision = readString(responseMessage?.result?.decision);
+  if (!APPROVAL_DECISIONS.has(decision)) {
+    return null;
+  }
+
+  return {
+    method,
+    params: {
+      conversationId: route.threadId,
+      requestId: route.requestId,
+      decision,
+    },
+  };
+}
+
+function projectPendingDesktopActions(threadId, conversationState) {
+  const requests = Array.isArray(conversationState?.requests) ? conversationState.requests : [];
+  return requests
+    .filter((request) => request && request.completed !== true)
+    .filter((request) => ACTION_METHODS.has(readString(request.method)))
+    .map((request) => projectPendingDesktopAction(threadId, request))
+    .filter(Boolean);
+}
+
+function projectPendingDesktopAction(threadId, request) {
+  const requestId = requestIdKey(request.id);
+  const method = readString(request.method);
+  const params = request.params && typeof request.params === "object" && !Array.isArray(request.params)
+    ? request.params
+    : {};
+  if (!requestId || !method) {
+    return null;
+  }
+
+  if (method === "item/tool/requestUserInput") {
+    const questions = Array.isArray(params.questions) ? params.questions : [];
+    if (questions.length === 0) {
+      return null;
+    }
+  }
+
+  return {
+    id: requestId,
+    method,
+    params: {
+      ...params,
+      threadId: readString(params.threadId) || readString(params.thread_id) || threadId,
+    },
+  };
+}
+
+function applyConversationStateChange(previousState, change) {
+  if (!change || typeof change !== "object") {
+    return null;
+  }
+
+  if (change.type === "snapshot" || change.type === "Snapshot") {
+    return cloneJSON(change.conversationState || change.conversation_state || {});
+  }
+
+  if (change.type !== "patches" && change.type !== "Patches") {
+    return previousState || null;
+  }
+
+  const patches = Array.isArray(change.patches) ? change.patches : [];
+  if (!previousState || patches.length === 0) {
+    return previousState || null;
+  }
+
+  const nextState = cloneJSON(previousState);
+  for (const patch of patches) {
+    applyImmerPatch(nextState, patch);
+  }
+  return nextState;
+}
+
+function isPatchChange(change) {
+  return change?.type === "patches" || change?.type === "Patches";
+}
+
+function seedConversationStateFromThreadRead(response) {
+  const conversationState = response?.conversationState || response?.conversation_state;
+  if (conversationState && typeof conversationState === "object" && !Array.isArray(conversationState)) {
+    return cloneJSON(conversationState);
+  }
+
+  const thread = response?.thread && typeof response.thread === "object" && !Array.isArray(response.thread)
+    ? response.thread
+    : {};
+  return {
+    turns: Array.isArray(thread.turns) ? cloneJSON(thread.turns) : [],
+    requests: Array.isArray(thread.requests) ? cloneJSON(thread.requests) : [],
+  };
+}
+
+function applyImmerPatch(target, patch) {
+  const patchPath = Array.isArray(patch?.path) ? patch.path : [];
+  const op = readString(patch?.op).toLowerCase();
+  if (!op || patchPath.length === 0) {
+    return;
+  }
+
+  let parent = target;
+  for (let index = 0; index < patchPath.length - 1; index += 1) {
+    parent = parent?.[patchPath[index]];
+    if (parent == null) {
+      return;
+    }
+  }
+
+  const key = patchPath[patchPath.length - 1];
+  if (op === "remove") {
+    if (Array.isArray(parent) && Number.isInteger(key)) {
+      parent.splice(key, 1);
+    } else if (parent && typeof parent === "object") {
+      delete parent[key];
+    }
+    return;
+  }
+
+  if (op === "add" || op === "replace") {
+    if (Array.isArray(parent) && Number.isInteger(key)) {
+      if (op === "add") {
+        parent.splice(key, 0, patch.value);
+      } else {
+        parent[key] = patch.value;
+      }
+    } else if (parent && typeof parent === "object") {
+      parent[key] = patch.value;
+    }
+  }
+}
+
+function writeFrame(socket, payload, callback) {
+  const body = Buffer.from(payload, "utf8");
+  const header = Buffer.alloc(FRAME_HEADER_BYTES);
+  header.writeUInt32LE(body.length, 0);
+  socket.write(Buffer.concat([header, body]), callback);
+}
+
+function resolveDefaultIpcSocketPath() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : 0;
+  return path.join(os.tmpdir(), "codex-ipc", `ipc-${uid}.sock`);
+}
+
+function readThreadId(params) {
+  return readString(params?.threadId)
+    || readString(params?.thread_id)
+    || readString(params?.conversationId)
+    || readString(params?.conversation_id);
+}
+
+function requestIdKey(value) {
+  if (typeof value === "string" && value) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return "";
+}
+
+function readString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function cloneJSON(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function safeParseJSON(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+module.exports = {
+  applyConversationStateChange,
+  createDesktopIpcActionFollower,
+  desktopFollowerPayloadForResponse,
+  projectPendingDesktopActions,
+  resolveDefaultIpcSocketPath,
+  seedConversationStateFromThreadRead,
+};

--- a/phodex-bridge/src/desktop-ipc-action-follower.js
+++ b/phodex-bridge/src/desktop-ipc-action-follower.js
@@ -15,11 +15,13 @@ const DESKTOP_RESUME_METHODS = new Set(["thread/read", "thread/resume"]);
 const ACTION_METHODS = new Set([
   "item/commandExecution/requestApproval",
   "item/fileChange/requestApproval",
+  "item/fileRead/requestApproval",
   "item/tool/requestUserInput",
 ]);
 const REPLY_METHOD_BY_ACTION_METHOD = new Map([
   ["item/commandExecution/requestApproval", "thread-follower-command-approval-decision"],
   ["item/fileChange/requestApproval", "thread-follower-file-approval-decision"],
+  ["item/fileRead/requestApproval", "thread-follower-file-approval-decision"],
   ["item/tool/requestUserInput", "thread-follower-submit-user-input"],
 ]);
 const METHOD_VERSION_BY_NAME = new Map([

--- a/phodex-bridge/test/bridge-desktop-ipc-integration.test.js
+++ b/phodex-bridge/test/bridge-desktop-ipc-integration.test.js
@@ -1,0 +1,321 @@
+// FILE: bridge-desktop-ipc-integration.test.js
+// Purpose: Verifies the bridge wires phone-origin replies to Codex Desktop IPC actions.
+// Layer: Integration test
+// Exports: node:test suite
+// Depends on: node:test, ws, net, ../src/bridge with mocked runtime transports
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const Module = require("node:module");
+const net = require("node:net");
+const os = require("node:os");
+const path = require("node:path");
+const { setTimeout: wait } = require("node:timers/promises");
+const WebSocket = require("ws");
+
+test("bridge forwards desktop IPC actions to the phone and routes replies back to Codex Desktop", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-bridge-ipc-"));
+  const ipcSocketPath = path.join(tempDir, "ipc.sock");
+  const relayServer = new WebSocket.Server({ port: 0 });
+  const relayMessages = [];
+  const ipcFrames = [];
+  let relaySocket = null;
+  let ipcServerSocket = null;
+  let fakeCodex = null;
+
+  await new Promise((resolve) => relayServer.once("listening", resolve));
+  relayServer.on("connection", (socket) => {
+    relaySocket = socket;
+    socket.on("message", (data) => {
+      const parsed = safeParseJSON(data.toString("utf8"));
+      if (parsed) {
+        relayMessages.push(parsed);
+      }
+    });
+  });
+
+  const ipcServer = net.createServer((socket) => {
+    ipcServerSocket = socket;
+    attachFrameReader(socket, (frame) => {
+      ipcFrames.push(frame);
+      if (frame.method === "initialize") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: "initialize",
+          handledByClientId: "desktop",
+          result: { clientId: "desktop-test" },
+        });
+      }
+      if (frame.method === "thread-follower-submit-user-input") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: frame.method,
+          handledByClientId: "desktop",
+          result: { ok: true },
+        });
+      }
+    });
+  });
+  await new Promise((resolve) => ipcServer.listen(ipcSocketPath, resolve));
+
+  const { startBridge } = loadBridgeWithTestDoubles({
+    createCodexTransportImpl() {
+      fakeCodex = createFakeCodexTransport();
+      return fakeCodex;
+    },
+  });
+
+  t.after(() => {
+    fakeCodex?.emitClose();
+    relaySocket?.close();
+    relayServer.close();
+    ipcServer.close();
+    ipcServerSocket?.destroy();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  startBridge({
+    printPairingQr: false,
+    config: {
+      relayUrl: `ws://127.0.0.1:${relayServer.address().port}`,
+      pushServiceUrl: "",
+      pushPreviewMaxChars: 160,
+      refreshEnabled: false,
+      refreshDebounceMs: 1,
+      keepMacAwakeEnabled: false,
+      codexEndpoint: "",
+      refreshCommand: "",
+      codexBundleId: "",
+      codexAppPath: "",
+      desktopIpcSocketPath: ipcSocketPath,
+    },
+  });
+
+  await waitFor(() => relaySocket && relaySocket.readyState === WebSocket.OPEN);
+  relaySocket.send(JSON.stringify({
+    id: "resume-from-phone",
+    method: "thread/resume",
+    params: { threadId: "thread-ipc" },
+  }));
+
+  await waitFor(() => ipcServerSocket);
+  writeFrame(ipcServerSocket, {
+    type: "broadcast",
+    method: "thread-stream-state-changed",
+    sourceClientId: "desktop",
+    version: 1,
+    params: {
+      conversationId: "thread-ipc",
+      change: {
+        type: "snapshot",
+        conversationState: {
+          requests: [{
+            id: "req-ipc",
+            method: "item/tool/requestUserInput",
+            params: {
+              threadId: "thread-ipc",
+              turnId: "turn-ipc",
+              itemId: "item-ipc",
+              questions: [{ id: "q1", question: "Continue?" }],
+            },
+          }],
+        },
+      },
+    },
+  });
+
+  const actionMessage = await waitForMessage(relayMessages, (message) => message.id === "req-ipc");
+  assert.equal(actionMessage.method, "item/tool/requestUserInput");
+
+  relaySocket.send(JSON.stringify({
+    id: "req-ipc",
+    result: {
+      answers: {
+        q1: { answers: ["Yes"] },
+      },
+    },
+  }));
+
+  const ipcReply = await waitForMessage(
+    ipcFrames,
+    (frame) => frame.method === "thread-follower-submit-user-input"
+  );
+  assert.deepEqual(ipcReply.params, {
+    conversationId: "thread-ipc",
+    requestId: "req-ipc",
+    response: {
+      answers: {
+        q1: { answers: ["Yes"] },
+      },
+    },
+  });
+  assert.equal(fakeCodex.sent.some((message) => message.id === "req-ipc"), false);
+
+  const resolvedMessage = await waitForMessage(
+    relayMessages,
+    (message) => message.method === "serverRequest/resolved"
+      && message.params?.requestId === "req-ipc"
+  );
+  assert.equal(resolvedMessage.params.threadId, "thread-ipc");
+});
+
+// Loads bridge.js with plaintext test transports while leaving the production module untouched.
+function loadBridgeWithTestDoubles({ createCodexTransportImpl }) {
+  const bridgePath = require.resolve("../src/bridge");
+  const originalLoad = Module._load;
+  delete require.cache[bridgePath];
+  Module._load = function loadWithBridgeDoubles(request, parent, isMain) {
+    if (parent?.filename === bridgePath && request === "./codex-transport") {
+      return { createCodexTransport: createCodexTransportImpl };
+    }
+    if (parent?.filename === bridgePath && request === "./secure-transport") {
+      return { createBridgeSecureTransport: createPlaintextSecureTransport };
+    }
+    if (parent?.filename === bridgePath && request === "./secure-device-state") {
+      return createSecureDeviceStateDouble();
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    return require("../src/bridge");
+  } finally {
+    Module._load = originalLoad;
+    delete require.cache[bridgePath];
+  }
+}
+
+// Uses plaintext relay messages so this test can focus on bridge routing, not encryption.
+function createPlaintextSecureTransport() {
+  return {
+    createPairingPayload() {
+      return { v: 1, expiresAt: Date.now() + 60_000 };
+    },
+    bindLiveSendWireMessage() {},
+    handleIncomingWireMessage(message, { onApplicationMessage }) {
+      onApplicationMessage(message);
+      return true;
+    },
+    queueOutboundApplicationMessage(message, sendWireMessage) {
+      sendWireMessage(message);
+    },
+  };
+}
+
+function createSecureDeviceStateDouble() {
+  return {
+    loadOrCreateBridgeDeviceState() {
+      return {
+        macDeviceId: "mac-test",
+        macIdentityPublicKey: "mac-key-test",
+        trustedPhones: {},
+      };
+    },
+    rememberLastSeenPhoneAppVersion(deviceState) {
+      return deviceState;
+    },
+    resolveBridgeRelaySession(deviceState) {
+      return {
+        sessionId: "session-test",
+        deviceState,
+      };
+    },
+  };
+}
+
+function createFakeCodexTransport() {
+  const listeners = {};
+  const sent = [];
+  return {
+    sent,
+    describe() {
+      return "fake codex app-server";
+    },
+    send(message) {
+      const parsed = JSON.parse(message);
+      sent.push(parsed);
+      if (parsed.method === "thread/read") {
+        listeners.message?.(JSON.stringify({
+          id: parsed.id,
+          result: {
+            conversationState: {
+              turns: [],
+              requests: [],
+            },
+          },
+        }));
+      }
+    },
+    onMessage(handler) {
+      listeners.message = handler;
+    },
+    onClose(handler) {
+      listeners.close = handler;
+    },
+    onError(handler) {
+      listeners.error = handler;
+    },
+    onStarted(handler) {
+      listeners.started = handler;
+      setImmediate(() => handler({ mode: "test" }));
+    },
+    shutdown() {
+      this.emitClose();
+    },
+    emitClose() {
+      listeners.close?.();
+    },
+  };
+}
+
+function attachFrameReader(socket, onFrame) {
+  let buffer = Buffer.alloc(0);
+  socket.on("data", (chunk) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    while (buffer.length >= 4) {
+      const frameLength = buffer.readUInt32LE(0);
+      if (buffer.length < 4 + frameLength) {
+        return;
+      }
+
+      const payload = buffer.slice(4, 4 + frameLength).toString("utf8");
+      buffer = buffer.slice(4 + frameLength);
+      onFrame(JSON.parse(payload));
+    }
+  });
+}
+
+function writeFrame(socket, payload) {
+  const body = Buffer.from(JSON.stringify(payload), "utf8");
+  const header = Buffer.alloc(4);
+  header.writeUInt32LE(body.length, 0);
+  socket.write(Buffer.concat([header, body]));
+}
+
+async function waitForMessage(messages, predicate, timeoutMs = 500) {
+  await waitFor(() => messages.find(predicate), timeoutMs);
+  return messages.find(predicate);
+}
+
+async function waitFor(predicate, timeoutMs = 500) {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await wait(5);
+  }
+}
+
+function safeParseJSON(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}

--- a/phodex-bridge/test/codex-desktop-refresher.test.js
+++ b/phodex-bridge/test/codex-desktop-refresher.test.js
@@ -87,6 +87,7 @@ test("readBridgeConfig keeps safe defaults and explicit overrides", () => {
     env: {
       REMODEX_CODEX_ENDPOINT: "ws://localhost:8080",
       REMODEX_REFRESH_ENABLED: "true",
+      REMODEX_DESKTOP_IPC_SOCKET: "/tmp/remodex-ipc.sock",
     },
     platform: "darwin",
     runtimeRoot: "/tmp/remodex-package",
@@ -121,6 +122,7 @@ test("readBridgeConfig keeps safe defaults and explicit overrides", () => {
   assert.equal(linuxConfig.refreshEnabled, false);
   assert.equal(linuxCommandConfig.refreshEnabled, false);
   assert.equal(explicitOnConfig.refreshEnabled, true);
+  assert.equal(explicitOnConfig.desktopIpcSocketPath, "/tmp/remodex-ipc.sock");
   assert.equal(explicitOffConfig.refreshEnabled, false);
   assert.equal(explicitOffConfig.keepMacAwakeEnabled, false);
 });

--- a/phodex-bridge/test/desktop-ipc-action-follower.test.js
+++ b/phodex-bridge/test/desktop-ipc-action-follower.test.js
@@ -1,0 +1,531 @@
+// FILE: desktop-ipc-action-follower.test.js
+// Purpose: Verifies Codex Desktop IPC pending actions are projected and routed without using rollout text.
+// Layer: Unit test
+// Exports: node:test suite
+// Depends on: node:test, node:assert/strict, ../src/desktop-ipc-action-follower
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const net = require("node:net");
+const os = require("node:os");
+const path = require("node:path");
+const { setTimeout: wait } = require("node:timers/promises");
+
+const {
+  applyConversationStateChange,
+  createDesktopIpcActionFollower,
+  desktopFollowerPayloadForResponse,
+  projectPendingDesktopActions,
+  seedConversationStateFromThreadRead,
+} = require("../src/desktop-ipc-action-follower");
+
+test("projects desktop pending user input as an app-server request shape", () => {
+  const actions = projectPendingDesktopActions("thread-1", {
+    requests: [{
+      id: "req-user-input",
+      method: "item/tool/requestUserInput",
+      completed: false,
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "item-1",
+        questions: [{
+          id: "q1",
+          header: "Mode",
+          question: "Choose one",
+          isOther: true,
+          options: [{ label: "Yes", description: "Continue" }],
+        }],
+      },
+    }],
+  });
+
+  assert.deepEqual(actions, [{
+    id: "req-user-input",
+    method: "item/tool/requestUserInput",
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "item-1",
+      questions: [{
+        id: "q1",
+        header: "Mode",
+        question: "Choose one",
+        isOther: true,
+        options: [{ label: "Yes", description: "Continue" }],
+      }],
+    },
+  }]);
+});
+
+test("projects command and file approvals while ignoring completed or unsupported requests", () => {
+  const actions = projectPendingDesktopActions("thread-2", {
+    requests: [
+      {
+        id: "req-command",
+        method: "item/commandExecution/requestApproval",
+        params: {
+          turnId: "turn-2",
+          itemId: "item-command",
+          command: "git status",
+          cwd: "/repo",
+          reason: "Need to inspect changes",
+        },
+      },
+      {
+        id: "req-file",
+        method: "item/fileChange/requestApproval",
+        params: {
+          threadId: "thread-2",
+          turnId: "turn-2",
+          itemId: "item-file",
+          grantRoot: "/repo",
+          reason: "Need to edit files",
+        },
+      },
+      {
+        id: "req-done",
+        method: "item/tool/requestUserInput",
+        completed: true,
+        params: {
+          questions: [{ id: "q", question: "Done?" }],
+        },
+      },
+      {
+        id: "req-permissions",
+        method: "item/permissions/requestApproval",
+        params: {},
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    actions.map((action) => [action.id, action.method, action.params.threadId]),
+    [
+      ["req-command", "item/commandExecution/requestApproval", "thread-2"],
+      ["req-file", "item/fileChange/requestApproval", "thread-2"],
+    ]
+  );
+  assert.equal(actions[0].params.command, "git status");
+  assert.equal(actions[1].params.grantRoot, "/repo");
+});
+
+test("builds desktop follower reply payloads from iOS responses", () => {
+  assert.deepEqual(
+    desktopFollowerPayloadForResponse({
+      requestId: "req-command",
+      method: "item/commandExecution/requestApproval",
+      threadId: "thread-1",
+    }, {
+      id: "req-command",
+      result: { decision: "acceptForSession" },
+    }),
+    {
+      method: "thread-follower-command-approval-decision",
+      params: {
+        conversationId: "thread-1",
+        requestId: "req-command",
+        decision: "acceptForSession",
+      },
+    }
+  );
+
+  assert.deepEqual(
+    desktopFollowerPayloadForResponse({
+      requestId: "req-user-input",
+      method: "item/tool/requestUserInput",
+      threadId: "thread-1",
+    }, {
+      id: "req-user-input",
+      result: {
+        answers: {
+          q1: { answers: ["Yes"] },
+        },
+      },
+    }),
+    {
+      method: "thread-follower-submit-user-input",
+      params: {
+        conversationId: "thread-1",
+        requestId: "req-user-input",
+        response: {
+          answers: {
+            q1: { answers: ["Yes"] },
+          },
+        },
+      },
+    }
+  );
+});
+
+test("rejects malformed or failed desktop action responses instead of defaulting to accept", () => {
+  assert.equal(
+    desktopFollowerPayloadForResponse({
+      requestId: "req-command",
+      method: "item/commandExecution/requestApproval",
+      threadId: "thread-1",
+    }, {
+      id: "req-command",
+      error: { code: -32603, message: "User cancelled" },
+    }),
+    null
+  );
+
+  assert.equal(
+    desktopFollowerPayloadForResponse({
+      requestId: "req-command",
+      method: "item/commandExecution/requestApproval",
+      threadId: "thread-1",
+    }, {
+      id: "req-command",
+      result: {},
+    }),
+    null
+  );
+
+  assert.equal(
+    desktopFollowerPayloadForResponse({
+      requestId: "req-user-input",
+      method: "item/tool/requestUserInput",
+      threadId: "thread-1",
+    }, {
+      id: "req-user-input",
+      result: {},
+    }),
+    null
+  );
+});
+
+test("applies desktop IPC snapshots and Immer-style request patches", () => {
+  const snapshot = applyConversationStateChange(null, {
+    type: "snapshot",
+    conversationState: {
+      requests: [{
+        id: "req-1",
+        method: "item/tool/requestUserInput",
+        params: {
+          questions: [{ id: "q1", question: "Continue?" }],
+        },
+      }],
+    },
+  });
+
+  const patched = applyConversationStateChange(snapshot, {
+    type: "patches",
+    patches: [{
+      op: "replace",
+      path: ["requests", 0, "completed"],
+      value: true,
+    }],
+  });
+
+  assert.equal(snapshot.requests[0].completed, undefined);
+  assert.equal(patched.requests[0].completed, true);
+  assert.deepEqual(projectPendingDesktopActions("thread-1", patched), []);
+});
+
+test("seeds conversation state from thread/read responses for IPC recovery", () => {
+  assert.deepEqual(
+    seedConversationStateFromThreadRead({
+      thread: {
+        turns: [{ id: "turn-1", items: [] }],
+      },
+    }),
+    {
+      turns: [{ id: "turn-1", items: [] }],
+      requests: [],
+    }
+  );
+
+  assert.deepEqual(
+    seedConversationStateFromThreadRead({
+      conversationState: {
+        requests: [{ id: "req-1" }],
+      },
+    }),
+    {
+      requests: [{ id: "req-1" }],
+    }
+  );
+});
+
+test("desktop IPC follower recovers a baseline before applying first patch-only action updates", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-ipc-recovery-"));
+  const socketPath = path.join(tempDir, "ipc.sock");
+  let serverSocket = null;
+
+  const server = net.createServer((socket) => {
+    serverSocket = socket;
+    attachFrameReader(socket, (frame) => {
+      if (frame.method === "initialize") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: "initialize",
+          handledByClientId: "desktop",
+          result: { clientId: "remodex-test" },
+        });
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  t.after(() => {
+    server.close();
+    serverSocket?.destroy();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const outbound = [];
+  const follower = createDesktopIpcActionFollower({
+    socketPath,
+    sendApplicationResponse(message) {
+      outbound.push(JSON.parse(message));
+    },
+    async readConversationState() {
+      await wait(30);
+      return { requests: [] };
+    },
+    requestTimeoutMs: 500,
+  });
+  t.after(() => follower.stopAll());
+
+  follower.observeInbound(JSON.stringify({
+    method: "thread/resume",
+    params: { threadId: "thread-patch" },
+  }));
+  await waitFor(() => serverSocket);
+  writeFrame(serverSocket, {
+    type: "broadcast",
+    method: "thread-stream-state-changed",
+    sourceClientId: "desktop",
+    version: 5,
+    params: {
+      conversationId: "thread-patch",
+      change: {
+        type: "patches",
+        patches: [{
+          op: "add",
+          path: ["requests", 0],
+          value: {
+            id: "req-patch",
+            method: "item/tool/requestUserInput",
+            params: {
+              threadId: "thread-patch",
+              turnId: "turn-patch",
+              itemId: "item-patch",
+              questions: [{ id: "q1", question: "Continue?" }],
+            },
+          },
+        }],
+      },
+    },
+  });
+  await wait(60);
+
+  assert.equal(outbound[0].id, "req-patch");
+  assert.equal(outbound[0].method, "item/tool/requestUserInput");
+});
+
+test("desktop IPC follower answers client discovery requests as a passive client", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-ipc-discovery-"));
+  const socketPath = path.join(tempDir, "ipc.sock");
+  const serverFrames = [];
+  let serverSocket = null;
+
+  const server = net.createServer((socket) => {
+    serverSocket = socket;
+    attachFrameReader(socket, (frame) => {
+      serverFrames.push(frame);
+      if (frame.method === "initialize") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: "initialize",
+          handledByClientId: "desktop",
+          result: { clientId: "remodex-test" },
+        });
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  t.after(() => {
+    server.close();
+    serverSocket?.destroy();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const follower = createDesktopIpcActionFollower({
+    socketPath,
+    sendApplicationResponse() {},
+    requestTimeoutMs: 500,
+  });
+  t.after(() => follower.stopAll());
+
+  follower.observeInbound(JSON.stringify({
+    method: "thread/resume",
+    params: { threadId: "thread-discovery" },
+  }));
+  await waitFor(() => serverSocket);
+  writeFrame(serverSocket, {
+    type: "client-discovery-request",
+    requestId: "discovery-1",
+    request: {
+      requestId: "inner-1",
+      sourceClientId: "desktop",
+      version: 1,
+      method: "thread-follower-start-turn",
+      params: {},
+    },
+  });
+  await wait(25);
+
+  const discoveryResponse = serverFrames.find((frame) => frame.type === "client-discovery-response");
+  assert.deepEqual(discoveryResponse, {
+    type: "client-discovery-response",
+    requestId: "discovery-1",
+    response: {
+      canHandle: false,
+    },
+  });
+});
+
+test("desktop IPC follower forwards pending actions and routes iOS replies back to the Mac", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-ipc-follower-"));
+  const socketPath = path.join(tempDir, "ipc.sock");
+  const serverFrames = [];
+  let serverSocket = null;
+
+  const server = net.createServer((socket) => {
+    serverSocket = socket;
+    attachFrameReader(socket, (frame) => {
+      serverFrames.push(frame);
+      if (frame.method === "initialize") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: "initialize",
+          handledByClientId: "desktop",
+          result: { clientId: "remodex-test" },
+        });
+      } else if (frame.method === "thread-follower-submit-user-input") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: frame.method,
+          handledByClientId: "desktop",
+          result: { ok: true },
+        });
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  t.after(() => {
+    server.close();
+    serverSocket?.destroy();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const outbound = [];
+  const follower = createDesktopIpcActionFollower({
+    socketPath,
+    sendApplicationResponse(message) {
+      outbound.push(JSON.parse(message));
+    },
+    requestTimeoutMs: 500,
+  });
+  t.after(() => follower.stopAll());
+
+  follower.observeInbound(JSON.stringify({
+    method: "thread/resume",
+    params: { threadId: "thread-live" },
+  }));
+  await waitFor(() => serverSocket);
+  writeFrame(serverSocket, {
+    type: "broadcast",
+    method: "thread-stream-state-changed",
+    sourceClientId: "desktop",
+    version: 5,
+    params: {
+      conversationId: "thread-live",
+      change: {
+        type: "snapshot",
+        conversationState: {
+          requests: [{
+            id: "req-live",
+            method: "item/tool/requestUserInput",
+            params: {
+              threadId: "thread-live",
+              turnId: "turn-live",
+              itemId: "item-live",
+              questions: [{ id: "q1", question: "Continue?" }],
+            },
+          }],
+        },
+      },
+    },
+  });
+  await wait(25);
+
+  assert.equal(outbound[0].id, "req-live");
+  assert.equal(outbound[0].method, "item/tool/requestUserInput");
+
+  follower.observeInbound(JSON.stringify({
+    id: "req-live",
+    result: {
+      answers: {
+        q1: { answers: ["Yes"] },
+      },
+    },
+  }));
+  await wait(25);
+
+  const replyFrame = serverFrames.find((frame) => frame.method === "thread-follower-submit-user-input");
+  assert.deepEqual(replyFrame.params, {
+    conversationId: "thread-live",
+    requestId: "req-live",
+    response: {
+      answers: {
+        q1: { answers: ["Yes"] },
+      },
+    },
+  });
+});
+
+function attachFrameReader(socket, onFrame) {
+  let buffer = Buffer.alloc(0);
+  socket.on("data", (chunk) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    while (buffer.length >= 4) {
+      const frameLength = buffer.readUInt32LE(0);
+      if (buffer.length < 4 + frameLength) {
+        return;
+      }
+
+      const payload = buffer.slice(4, 4 + frameLength).toString("utf8");
+      buffer = buffer.slice(4 + frameLength);
+      onFrame(JSON.parse(payload));
+    }
+  });
+}
+
+function writeFrame(socket, payload) {
+  const body = Buffer.from(JSON.stringify(payload), "utf8");
+  const header = Buffer.alloc(4);
+  header.writeUInt32LE(body.length, 0);
+  socket.write(Buffer.concat([header, body]));
+}
+
+async function waitFor(predicate, timeoutMs = 500) {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await wait(5);
+  }
+}

--- a/phodex-bridge/test/desktop-ipc-action-follower.test.js
+++ b/phodex-bridge/test/desktop-ipc-action-follower.test.js
@@ -85,6 +85,17 @@ test("projects command and file approvals while ignoring completed or unsupporte
         },
       },
       {
+        id: "req-file-read",
+        method: "item/fileRead/requestApproval",
+        params: {
+          threadId: "thread-2",
+          turnId: "turn-2",
+          itemId: "item-file-read",
+          path: "/repo/secrets.txt",
+          reason: "Need to inspect a file",
+        },
+      },
+      {
         id: "req-done",
         method: "item/tool/requestUserInput",
         completed: true,
@@ -105,10 +116,12 @@ test("projects command and file approvals while ignoring completed or unsupporte
     [
       ["req-command", "item/commandExecution/requestApproval", "thread-2"],
       ["req-file", "item/fileChange/requestApproval", "thread-2"],
+      ["req-file-read", "item/fileRead/requestApproval", "thread-2"],
     ]
   );
   assert.equal(actions[0].params.command, "git status");
   assert.equal(actions[1].params.grantRoot, "/repo");
+  assert.equal(actions[2].params.path, "/repo/secrets.txt");
 });
 
 test("builds desktop follower reply payloads from iOS responses", () => {
@@ -154,6 +167,25 @@ test("builds desktop follower reply payloads from iOS responses", () => {
             q1: { answers: ["Yes"] },
           },
         },
+      },
+    }
+  );
+
+  assert.deepEqual(
+    desktopFollowerPayloadForResponse({
+      requestId: "req-file-read",
+      method: "item/fileRead/requestApproval",
+      threadId: "thread-1",
+    }, {
+      id: "req-file-read",
+      result: { decision: "accept" },
+    }),
+    {
+      method: "thread-follower-file-approval-decision",
+      params: {
+        conversationId: "thread-1",
+        requestId: "req-file-read",
+        decision: "accept",
       },
     }
   );


### PR DESCRIPTION
## Summary
- Add a new desktop IPC action follower in `phodex-bridge` to observe and forward desktop-side actions through the bridge.
- Wire the follower into the bridge entrypoint and desktop refresher flow.
- Add bridge integration coverage plus focused follower tests for the new action pipeline.

## Testing
- `phodex-bridge/test/desktop-ipc-action-follower.test.js`
- `phodex-bridge/test/bridge-desktop-ipc-integration.test.js`
- `phodex-bridge/test/codex-desktop-refresher.test.js`