### PR TITLE
Supporta handoff desktop Windows e rafforza bridge e relay

### DIFF
--- a/CodexMobile/CodexMobile/Services/DesktopHandoffService.swift
+++ b/CodexMobile/CodexMobile/Services/DesktopHandoffService.swift
@@ -196,7 +196,7 @@ private extension DesktopHandoffError {
         case "missing_thread_id":
             return "This chat does not have a valid thread id yet."
         case "unsupported_platform":
-            return "Desktop app handoff works only when the bridge is running on macOS."
+            return "Desktop app handoff works only when the bridge is running on a supported desktop platform."
         case "handoff_failed":
             return fallback ?? "Could not relaunch Codex.app on this computer."
         case "wake_display_failed":

--- a/CodexMobile/CodexMobile/Services/DesktopHandoffService.swift
+++ b/CodexMobile/CodexMobile/Services/DesktopHandoffService.swift
@@ -40,6 +40,7 @@ final class DesktopHandoffService {
         self.savedPairConnector = savedPairConnector
     }
 
+    // Uses the platform-neutral desktop handoff RPC so the same iOS action works with macOS and Windows bridges.
     func continueOnDesktopApp(threadId: String) async throws {
         let trimmedThreadID = threadId.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedThreadID.isEmpty else {
@@ -54,7 +55,7 @@ final class DesktopHandoffService {
         ])
 
         do {
-            let response = try await codex.sendRequest(method: "desktop/continueOnMac", params: params)
+            let response = try await codex.sendRequest(method: "desktop/continueOnDesktop", params: params)
             guard let resultObject = response.result?.objectValue,
                   resultObject["success"]?.boolValue == true else {
                 throw DesktopHandoffError.invalidResponse

--- a/CodexMobile/CodexMobileTests/DesktopHandoffServiceTests.swift
+++ b/CodexMobile/CodexMobileTests/DesktopHandoffServiceTests.swift
@@ -110,6 +110,18 @@ final class DesktopHandoffServiceTests: XCTestCase {
         }
     }
 
+    func testUnsupportedPlatformMessageIsPlatformNeutral() {
+        let error = DesktopHandoffError.bridgeError(
+            code: "unsupported_platform",
+            message: "Unsupported platform"
+        )
+
+        XCTAssertEqual(
+            error.errorDescription,
+            "Desktop app handoff works only when the bridge is running on a supported desktop platform."
+        )
+    }
+
     private func makeService() -> CodexService {
         let suiteName = "DesktopHandoffServiceTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName) ?? .standard

--- a/CodexMobile/CodexMobileTests/DesktopHandoffServiceTests.swift
+++ b/CodexMobile/CodexMobileTests/DesktopHandoffServiceTests.swift
@@ -1,5 +1,5 @@
 // FILE: DesktopHandoffServiceTests.swift
-// Purpose: Verifies Mac handoff requests cover the new display-wake flow for connected and saved-pair paths.
+// Purpose: Verifies desktop handoff and display-wake requests use the bridge RPC contract.
 // Layer: Unit Test
 // Exports: DesktopHandoffServiceTests
 // Depends on: XCTest, CodexMobile
@@ -9,6 +9,27 @@ import XCTest
 
 @MainActor
 final class DesktopHandoffServiceTests: XCTestCase {
+    func testContinueOnDesktopUsesPlatformNeutralBridgeMethod() async throws {
+        let service = makeService()
+        var capturedMethod: String?
+        var capturedParams: JSONValue?
+        service.requestTransportOverride = { method, params in
+            capturedMethod = method
+            capturedParams = params
+            return RPCMessage(
+                id: .string(UUID().uuidString),
+                result: .object(["success": .bool(true)]),
+                includeJSONRPC: false
+            )
+        }
+
+        let handoff = DesktopHandoffService(codex: service)
+        try await handoff.continueOnDesktopApp(threadId: " thread-123 ")
+
+        XCTAssertEqual(capturedMethod, "desktop/continueOnDesktop")
+        XCTAssertEqual(capturedParams?.objectValue?["threadId"]?.stringValue, "thread-123")
+    }
+
     func testWakeDisplayUsesCurrentBridgeConnectionWhenAvailable() async throws {
         let service = makeService()
         service.isConnected = true

--- a/phodex-bridge/src/desktop-handler.js
+++ b/phodex-bridge/src/desktop-handler.js
@@ -20,6 +20,7 @@ const DEFAULT_APP_BOOT_WAIT_MS = 1_200;
 const DEFAULT_THREAD_MATERIALIZE_WAIT_MS = 4_000;
 const DEFAULT_THREAD_MATERIALIZE_POLL_MS = 250;
 const DEFAULT_WAKE_DISPLAY_DURATION_SECONDS = 30;
+const WINDOWS_BOUNCE_URL = "codex://settings";
 
 function handleDesktopRequest(rawMessage, sendResponse, options = {}) {
   let parsed;
@@ -71,16 +72,39 @@ async function handleDesktopMethod(method, params, options = {}) {
   const threadMaterializeWaitMs = options.threadMaterializeWaitMs ?? DEFAULT_THREAD_MATERIALIZE_WAIT_MS;
   const threadMaterializePollMs = options.threadMaterializePollMs ?? DEFAULT_THREAD_MATERIALIZE_POLL_MS;
 
-  if (platform !== "darwin") {
-    throw desktopError(
-      "unsupported_platform",
-      "Mac handoff is only available when the bridge is running on macOS."
-    );
-  }
-
   switch (method) {
+    case "desktop/continueOnDesktop":
+      if (platform !== "darwin" && platform !== "win32") {
+        throw desktopError(
+          "unsupported_platform",
+          "Desktop handoff is only available when the bridge is running on macOS or Windows."
+        );
+      }
+
+      return continueOnDesktop(params, {
+        platform,
+        bundleId,
+        appPath,
+        executor,
+        env,
+        fsModule,
+        isAppRunning,
+        sleepFn,
+        appBootWaitMs,
+        relaunchWaitMs,
+        threadMaterializeWaitMs,
+        threadMaterializePollMs,
+      });
     case "desktop/continueOnMac":
-      return continueOnMac(params, {
+      if (platform !== "darwin") {
+        throw desktopError(
+          "unsupported_platform",
+          "Mac handoff is only available when the bridge is running on macOS."
+        );
+      }
+
+      return continueOnDesktop(params, {
+        platform,
         bundleId,
         appPath,
         executor,
@@ -106,10 +130,11 @@ async function handleDesktopMethod(method, params, options = {}) {
   }
 }
 
-// Waits for fresh phone-authored chats to materialize locally before deep-linking them on Mac.
-async function continueOnMac(
+// Waits for fresh phone-authored chats to materialize locally before deep-linking them on desktop.
+async function continueOnDesktop(
   params,
   {
+    platform,
     bundleId,
     appPath,
     executor,
@@ -125,11 +150,50 @@ async function continueOnMac(
 ) {
   const threadId = resolveThreadId(params);
   if (!threadId) {
-    throw desktopError("missing_thread_id", "A thread id is required to continue on Mac.");
+    throw desktopError("missing_thread_id", "A thread id is required to continue on desktop.");
   }
 
   const targetUrl = `codex://threads/${threadId}`;
   const desktopKnown = isThreadLikelyKnownOnDesktop(threadId, { env, fsModule });
+
+  if (platform === "win32") {
+    try {
+      if (desktopKnown) {
+        await refreshWindowsCodex(targetUrl, {
+          executor,
+          env,
+          sleepFn,
+          settleMs: relaunchWaitMs,
+        });
+      } else {
+        await openWindowsDeepLink(WINDOWS_BOUNCE_URL, { executor, env });
+        await sleepFn(appBootWaitMs);
+        await waitForThreadMaterialization(threadId, {
+          env,
+          fsModule,
+          sleepFn,
+          timeoutMs: threadMaterializeWaitMs,
+          pollMs: threadMaterializePollMs,
+        });
+        await openWindowsDeepLink(targetUrl, { executor, env });
+      }
+    } catch (error) {
+      throw desktopError(
+        "handoff_failed",
+        "Could not open Codex on this PC.",
+        error
+      );
+    }
+
+    return {
+      success: true,
+      relaunched: false,
+      targetUrl,
+      threadId,
+      desktopKnown,
+    };
+  }
+
   const appRunning = typeof isAppRunning === "function"
     ? await isAppRunning(appPath)
     : await detectRunningCodexApp(appPath, executor);
@@ -370,6 +434,25 @@ async function openCodexApp({ bundleId, appPath, executor }) {
       timeout: HANDOFF_TIMEOUT_MS,
     });
   }
+}
+
+async function openWindowsDeepLink(targetUrl, { executor, env }) {
+  await executor(env?.ComSpec || "cmd.exe", [
+    "/d",
+    "/c",
+    "start",
+    "",
+    targetUrl,
+  ], {
+    timeout: HANDOFF_TIMEOUT_MS,
+    windowsHide: true,
+  });
+}
+
+async function refreshWindowsCodex(targetUrl, { executor, env, sleepFn, settleMs }) {
+  await openWindowsDeepLink(WINDOWS_BOUNCE_URL, { executor, env });
+  await sleepFn(settleMs);
+  await openWindowsDeepLink(targetUrl, { executor, env });
 }
 
 // Gives the desktop a short window to materialize the requested thread before the final deep link.

--- a/phodex-bridge/src/desktop-handler.js
+++ b/phodex-bridge/src/desktop-handler.js
@@ -21,6 +21,7 @@ const DEFAULT_THREAD_MATERIALIZE_WAIT_MS = 4_000;
 const DEFAULT_THREAD_MATERIALIZE_POLL_MS = 250;
 const DEFAULT_WAKE_DISPLAY_DURATION_SECONDS = 30;
 const WINDOWS_BOUNCE_URL = "codex://settings";
+const DESKTOP_THREAD_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$/;
 
 function handleDesktopRequest(rawMessage, sendResponse, options = {}) {
   let parsed;
@@ -151,6 +152,9 @@ async function continueOnDesktop(
   const threadId = resolveThreadId(params);
   if (!threadId) {
     throw desktopError("missing_thread_id", "A thread id is required to continue on desktop.");
+  }
+  if (!isValidDesktopThreadId(threadId)) {
+    throw desktopError("invalid_thread_id", "The requested desktop thread id is not valid.");
   }
 
   const targetUrl = `codex://threads/${threadId}`;
@@ -375,6 +379,11 @@ function resolveThreadId(params) {
   return "";
 }
 
+// Keeps desktop deep links to a single safe route segment before handing them to OS launchers.
+function isValidDesktopThreadId(threadId) {
+  return typeof threadId === "string" && DESKTOP_THREAD_ID_PATTERN.test(threadId);
+}
+
 function desktopError(errorCode, userMessage, cause = null) {
   const error = new Error(userMessage);
   error.errorCode = errorCode;
@@ -437,11 +446,8 @@ async function openCodexApp({ bundleId, appPath, executor }) {
 }
 
 async function openWindowsDeepLink(targetUrl, { executor, env }) {
-  await executor(env?.ComSpec || "cmd.exe", [
-    "/d",
-    "/c",
-    "start",
-    "",
+  await executor(env?.SystemRoot ? path.join(env.SystemRoot, "System32", "rundll32.exe") : "rundll32.exe", [
+    "url.dll,FileProtocolHandler",
     targetUrl,
   ], {
     timeout: HANDOFF_TIMEOUT_MS,

--- a/phodex-bridge/src/git-handler.js
+++ b/phodex-bridge/src/git-handler.js
@@ -13,6 +13,8 @@ const { promisify } = require("util");
 
 const execFileAsync = promisify(execFile);
 const GIT_TIMEOUT_MS = 30_000;
+/** Node defaults maxBuffer to 1 MiB; large repo diffs exceed it ("stdout maxBuffer length exceeded"). */
+const GIT_EXEC_MAX_BUFFER_BYTES = 50 * 1024 * 1024;
 const GIT_DRAFT_TIMEOUT_MS = 120_000;
 const GIT_DRAFT_PATCH_MAX_BYTES = 80_000;
 const EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
@@ -2104,7 +2106,7 @@ async function gitDiffNoIndexNumstat(cwd, filePath) {
     const { stdout } = await execFileAsync(
       "git",
       ["diff", "--no-index", "--numstat", "--", "/dev/null", filePath],
-      { cwd, timeout: GIT_TIMEOUT_MS }
+      { cwd, timeout: GIT_TIMEOUT_MS, maxBuffer: GIT_EXEC_MAX_BUFFER_BYTES }
     );
     return stdout;
   } catch (err) {
@@ -2130,7 +2132,7 @@ async function gitDiffNoIndexPatch(cwd, filePath) {
     const { stdout } = await execFileAsync(
       "git",
       ["diff", "--no-index", "--binary", "--", "/dev/null", filePath],
-      { cwd, timeout: GIT_TIMEOUT_MS }
+      { cwd, timeout: GIT_TIMEOUT_MS, maxBuffer: GIT_EXEC_MAX_BUFFER_BYTES }
     );
     return stdout;
   } catch (err) {
@@ -2145,7 +2147,11 @@ async function gitDiffNoIndexPatch(cwd, filePath) {
 // ─── Helpers ──────────────────────────────────────────────────
 
 function git(cwd, ...args) {
-  return execFileAsync("git", args, { cwd, timeout: GIT_TIMEOUT_MS })
+  return execFileAsync("git", args, {
+    cwd,
+    timeout: GIT_TIMEOUT_MS,
+    maxBuffer: GIT_EXEC_MAX_BUFFER_BYTES,
+  })
     .then(({ stdout }) => stdout)
     .catch((err) => {
       const msg = (err.stderr || err.message || "").trim();

--- a/phodex-bridge/src/qr.js
+++ b/phodex-bridge/src/qr.js
@@ -43,6 +43,8 @@ function normalizePairingSession(pairingSessionOrPayload) {
 function printQR(pairingSessionOrPayload) {
   const { pairingPayload, pairingCode } = normalizePairingSession(pairingSessionOrPayload);
   const payload = JSON.stringify(pairingPayload);
+  const sessionId = typeof pairingPayload?.sessionId === "string" ? pairingPayload.sessionId.trim() : "";
+  const sessionIdShort = sessionId.length > 12 ? `${sessionId.slice(0, 8)}…` : sessionId;
 
   console.log("\nScan this QR with the iPhone:\n");
   qrcode.generate(payload, { small: true });
@@ -50,9 +52,12 @@ function printQR(pairingSessionOrPayload) {
     console.log("Or paste this pairing code in the iPhone app:\n");
     console.log(pairingCode);
   }
-  console.log(`\nSession ID: ${pairingPayload.sessionId}`);
+  console.log(`\nSession ID: ${sessionIdShort || "(none)"}`);
   console.log(`Device ID: ${pairingPayload.macDeviceId}`);
   console.log(`Expires: ${new Date(pairingPayload.expiresAt).toISOString()}\n`);
+  // Same bytes as the QR (handy for Android emulator / CI: copy-paste into the in-app debug pairing field).
+  console.log("Pairing JSON (scan target or paste for Remodex Android debug UI):\n");
+  console.log(`${payload}\n`);
 }
 
 module.exports = {

--- a/phodex-bridge/src/qr.js
+++ b/phodex-bridge/src/qr.js
@@ -40,11 +40,12 @@ function normalizePairingSession(pairingSessionOrPayload) {
   };
 }
 
-function printQR(pairingSessionOrPayload) {
+function printQR(pairingSessionOrPayload, options = {}) {
   const { pairingPayload, pairingCode } = normalizePairingSession(pairingSessionOrPayload);
   const payload = JSON.stringify(pairingPayload);
   const sessionId = typeof pairingPayload?.sessionId === "string" ? pairingPayload.sessionId.trim() : "";
   const sessionIdShort = sessionId.length > 12 ? `${sessionId.slice(0, 8)}…` : sessionId;
+  const env = options.env || process.env;
 
   console.log("\nScan this QR with the iPhone:\n");
   qrcode.generate(payload, { small: true });
@@ -55,9 +56,21 @@ function printQR(pairingSessionOrPayload) {
   console.log(`\nSession ID: ${sessionIdShort || "(none)"}`);
   console.log(`Device ID: ${pairingPayload.macDeviceId}`);
   console.log(`Expires: ${new Date(pairingPayload.expiresAt).toISOString()}\n`);
-  // Same bytes as the QR (handy for Android emulator / CI: copy-paste into the in-app debug pairing field).
-  console.log("Pairing JSON (scan target or paste for Remodex Android debug UI):\n");
-  console.log(`${payload}\n`);
+
+  if (shouldPrintPairingJson({ env, explicitValue: options.printPairingJson })) {
+    // Opt-in only: this is the same bearer-like payload as the QR scan target.
+    console.log("Pairing JSON (debug only; same sensitive bytes as the QR):\n");
+    console.log(`${payload}\n`);
+  }
+}
+
+function shouldPrintPairingJson({ env = process.env, explicitValue } = {}) {
+  if (typeof explicitValue === "boolean") {
+    return explicitValue;
+  }
+
+  const rawValue = env?.REMODEX_PRINT_PAIRING_JSON || env?.PHODEX_PRINT_PAIRING_JSON || "";
+  return ["1", "true", "yes", "on"].includes(String(rawValue).trim().toLowerCase());
 }
 
 module.exports = {
@@ -65,4 +78,5 @@ module.exports = {
   SHORT_PAIRING_CODE_LENGTH,
   createShortPairingCode,
   printQR,
+  shouldPrintPairingJson,
 };

--- a/phodex-bridge/src/workspace-handler.js
+++ b/phodex-bridge/src/workspace-handler.js
@@ -37,6 +37,8 @@ const IMAGE_MIME_TYPES_BY_EXTENSION = new Map([
   [".heic", "image/heic"],
   [".heif", "image/heif"],
 ]);
+/** Match git-handler.js: Node default maxBuffer is 1 MiB. */
+const GIT_EXEC_MAX_BUFFER_BYTES = 50 * 1024 * 1024;
 const repoMutationLocks = new Map();
 
 function handleWorkspaceRequest(rawMessage, sendResponse) {
@@ -572,6 +574,7 @@ async function runGitApply(cwd, args, patchText) {
     const { stdout, stderr } = await execFileAsync("git", [...args, tempPatchPath], {
       cwd,
       timeout: GIT_TIMEOUT_MS,
+      maxBuffer: GIT_EXEC_MAX_BUFFER_BYTES,
     });
     return { ok: true, stdout, stderr };
   } catch (err) {
@@ -730,7 +733,11 @@ function workspaceError(errorCode, userMessage) {
 }
 
 function git(cwd, ...args) {
-  return execFileAsync("git", args, { cwd, timeout: GIT_TIMEOUT_MS })
+  return execFileAsync("git", args, {
+    cwd,
+    timeout: GIT_TIMEOUT_MS,
+    maxBuffer: GIT_EXEC_MAX_BUFFER_BYTES,
+  })
     .then(({ stdout }) => stdout)
     .catch((err) => {
       const msg = (err.stderr || err.message || "").trim();

--- a/phodex-bridge/test/desktop-handler.test.js
+++ b/phodex-bridge/test/desktop-handler.test.js
@@ -119,7 +119,7 @@ test("desktop/continueOnMac relaunches when a desktop-known thread is requested 
   let running = true;
   const fakeFS = {
     existsSync(targetPath) {
-      return targetPath.endsWith("/sessions");
+      return /[\\/]sessions$/.test(targetPath);
     },
     readdirSync() {
       return [{
@@ -192,7 +192,7 @@ test("desktop/continueOnMac boots Codex before deep-linking when the thread alre
   let running = false;
   const fakeFS = {
     existsSync(targetPath) {
-      return targetPath.endsWith("/sessions");
+      return /[\\/]sessions$/.test(targetPath);
     },
     readdirSync() {
       return [{
@@ -241,6 +241,60 @@ test("desktop/continueOnMac boots Codex before deep-linking when the thread alre
   ]);
   assert.equal(responses[0].result?.relaunched, false);
   assert.equal(responses[0].result?.desktopKnown, true);
+});
+
+test("desktop/continueOnDesktop bounces Codex via deep links on Windows", async () => {
+  const executorCalls = [];
+  const responses = [];
+
+  handleDesktopRequest(JSON.stringify({
+    id: "request-win-1",
+    method: "desktop/continueOnDesktop",
+    params: {
+      threadId: "thread-win-123",
+    },
+  }), (response) => {
+    responses.push(JSON.parse(response));
+  }, {
+    platform: "win32",
+    env: { ComSpec: "cmd.exe" },
+    executor: async (...args) => {
+      executorCalls.push(args);
+      return { stdout: "", stderr: "" };
+    },
+    sleepFn: async () => {},
+    threadMaterializeWaitMs: 0,
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(executorCalls.length, 2);
+  assert.equal(executorCalls[0][0], "cmd.exe");
+  assert.deepEqual(executorCalls[0][1], [
+    "/d",
+    "/c",
+    "start",
+    "",
+    "codex://settings",
+  ]);
+  assert.equal(executorCalls[1][0], "cmd.exe");
+  assert.deepEqual(executorCalls[1][1], [
+    "/d",
+    "/c",
+    "start",
+    "",
+    "codex://threads/thread-win-123",
+  ]);
+  assert.deepEqual(responses, [{
+    id: "request-win-1",
+    result: {
+      success: true,
+      relaunched: false,
+      targetUrl: "codex://threads/thread-win-123",
+      threadId: "thread-win-123",
+      desktopKnown: false,
+    },
+  }]);
 });
 
 test("desktop/continueOnMac returns a bridge error when thread id is missing", async () => {

--- a/phodex-bridge/test/desktop-handler.test.js
+++ b/phodex-bridge/test/desktop-handler.test.js
@@ -257,7 +257,7 @@ test("desktop/continueOnDesktop bounces Codex via deep links on Windows", async 
     responses.push(JSON.parse(response));
   }, {
     platform: "win32",
-    env: { ComSpec: "cmd.exe" },
+    env: { SystemRoot: "C:\\Windows" },
     executor: async (...args) => {
       executorCalls.push(args);
       return { stdout: "", stderr: "" };
@@ -269,20 +269,14 @@ test("desktop/continueOnDesktop bounces Codex via deep links on Windows", async 
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   assert.equal(executorCalls.length, 2);
-  assert.equal(executorCalls[0][0], "cmd.exe");
+  assert.equal(executorCalls[0][0], "C:\\Windows/System32/rundll32.exe");
   assert.deepEqual(executorCalls[0][1], [
-    "/d",
-    "/c",
-    "start",
-    "",
+    "url.dll,FileProtocolHandler",
     "codex://settings",
   ]);
-  assert.equal(executorCalls[1][0], "cmd.exe");
+  assert.equal(executorCalls[1][0], "C:\\Windows/System32/rundll32.exe");
   assert.deepEqual(executorCalls[1][1], [
-    "/d",
-    "/c",
-    "start",
-    "",
+    "url.dll,FileProtocolHandler",
     "codex://threads/thread-win-123",
   ]);
   assert.deepEqual(responses, [{
@@ -295,6 +289,34 @@ test("desktop/continueOnDesktop bounces Codex via deep links on Windows", async 
       desktopKnown: false,
     },
   }]);
+});
+
+test("desktop/continueOnDesktop rejects unsafe thread ids before opening Windows links", async () => {
+  const executorCalls = [];
+  const responses = [];
+
+  handleDesktopRequest(JSON.stringify({
+    id: "request-win-injection",
+    method: "desktop/continueOnDesktop",
+    params: {
+      threadId: "thread-win-123 & calc.exe",
+    },
+  }), (response) => {
+    responses.push(JSON.parse(response));
+  }, {
+    platform: "win32",
+    executor: async (...args) => {
+      executorCalls.push(args);
+      return { stdout: "", stderr: "" };
+    },
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(executorCalls.length, 0);
+  assert.equal(responses.length, 1);
+  assert.equal(responses[0].id, "request-win-injection");
+  assert.equal(responses[0].error?.data?.errorCode, "invalid_thread_id");
 });
 
 test("desktop/continueOnMac returns a bridge error when thread id is missing", async () => {

--- a/phodex-bridge/test/qr.test.js
+++ b/phodex-bridge/test/qr.test.js
@@ -1,5 +1,5 @@
 // FILE: qr.test.js
-// Purpose: Verifies the short terminal pairing code stays human-sized and URL-safe.
+// Purpose: Verifies terminal pairing output keeps codes usable without leaking full bearer-like IDs by default.
 // Layer: Unit Test
 // Exports: node:test suite
 // Depends on: node:test, node:assert/strict, ../src/qr
@@ -10,6 +10,8 @@ const {
   SHORT_PAIRING_CODE_ALPHABET,
   SHORT_PAIRING_CODE_LENGTH,
   createShortPairingCode,
+  printQR,
+  shouldPrintPairingJson,
 } = require("../src/qr");
 
 test("createShortPairingCode emits a short human-friendly token", () => {
@@ -22,3 +24,66 @@ test("createShortPairingCode emits a short human-friendly token", () => {
   assert.equal(code.length, SHORT_PAIRING_CODE_LENGTH);
   assert.match(code, new RegExp(`^[${SHORT_PAIRING_CODE_ALPHABET}]+$`));
 });
+
+test("printQR does not print the full pairing JSON unless debug output is enabled", () => {
+  const logs = captureConsoleLog(() => {
+    printQR({
+      pairingPayload: {
+        relay: "ws://127.0.0.1:9000/relay",
+        sessionId: "session-sensitive-long-value",
+        macDeviceId: "mac-123",
+        expiresAt: 1_900_000_000_000,
+      },
+      pairingCode: "ABCDEFGHJK",
+    }, {
+      env: {},
+    });
+  });
+
+  const output = logs.join("\n");
+  assert.match(output, /Session ID: session-/);
+  assert.doesNotMatch(output, /session-sensitive-long-value/);
+  assert.doesNotMatch(output, /Pairing JSON/);
+});
+
+test("printQR can print the pairing JSON for explicit debug workflows", () => {
+  const logs = captureConsoleLog(() => {
+    printQR({
+      relay: "ws://127.0.0.1:9000/relay",
+      sessionId: "session-debug",
+      macDeviceId: "mac-123",
+      expiresAt: 1_900_000_000_000,
+    }, {
+      printPairingJson: true,
+      env: {},
+    });
+  });
+
+  const output = logs.join("\n");
+  assert.match(output, /Pairing JSON \(debug only; same sensitive bytes as the QR\)/);
+  assert.match(output, /"sessionId":"session-debug"/);
+});
+
+test("shouldPrintPairingJson accepts explicit flags and debug env aliases", () => {
+  assert.equal(shouldPrintPairingJson({ explicitValue: true, env: {} }), true);
+  assert.equal(shouldPrintPairingJson({ explicitValue: false, env: { REMODEX_PRINT_PAIRING_JSON: "1" } }), false);
+  assert.equal(shouldPrintPairingJson({ env: { REMODEX_PRINT_PAIRING_JSON: "yes" } }), true);
+  assert.equal(shouldPrintPairingJson({ env: { PHODEX_PRINT_PAIRING_JSON: "on" } }), true);
+  assert.equal(shouldPrintPairingJson({ env: { REMODEX_PRINT_PAIRING_JSON: "0" } }), false);
+});
+
+function captureConsoleLog(callback) {
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => {
+    logs.push(args.join(" "));
+  };
+
+  try {
+    callback();
+  } finally {
+    console.log = originalLog;
+  }
+
+  return logs;
+}

--- a/relay/README.md
+++ b/relay/README.md
@@ -7,10 +7,10 @@ The point of keeping this code in the repo is transparency: anyone forking Remod
 ## What It Does
 
 - accepts WebSocket connections at `/relay/{sessionId}`
-- pairs one Mac host with one live iPhone client for a session
+- pairs one Mac host with one live mobile client for a session
 - keeps an in-memory index of the current live session for each trusted Mac
-- resolves the current live session for a previously trusted iPhone through an authenticated HTTP lookup
-- forwards secure control messages and encrypted payloads between Mac and iPhone
+- resolves the current live session for a previously trusted mobile client through an authenticated HTTP lookup
+- forwards secure control messages and encrypted payloads between Mac and the mobile client
 - exposes optional HTTP endpoints for push registration and run-completion alerts only when push is enabled explicitly
 - logs only connection metadata and payload sizes, not plaintext prompts or responses
 
@@ -27,9 +27,9 @@ Codex, git, and local file operations still run on the user's Mac.
 
 Remodex uses the relay as a transport hop, not as a trusted application server.
 
-- The pairing QR gives the iPhone the bridge identity public key plus short-lived session details.
-- After the first successful QR bootstrap, the relay can help the iPhone find the Mac's current live session again through a signed trusted-session resolve request.
-- The iPhone and bridge perform a signed handshake, derive shared AES-256-GCM keys with X25519 + HKDF-SHA256, and then encrypt application payloads end to end.
+- The pairing QR gives the mobile client the bridge identity public key plus short-lived session details.
+- After the first successful QR bootstrap, the relay can help the mobile client find the Mac's current live session again through a signed trusted-session resolve request.
+- The mobile client and bridge perform a signed handshake, derive shared AES-256-GCM keys with X25519 + HKDF-SHA256, and then encrypt application payloads end to end.
 - The relay can still observe connection metadata and the plaintext secure control messages needed to establish the encrypted session.
 - The relay does not receive plaintext Remodex application payloads after the secure session is active.
 
@@ -43,45 +43,45 @@ flowchart TD
     D --> E[Relay creates in-memory session room]
     D --> E2[Relay records macDeviceId plus trusted phone metadata for live-session resolve]
 
-    C --> F[iPhone scans QR]
-    F --> G[iPhone opens WebSocket to /relay/{sessionId}<br/>x-role: iphone]
+    C --> F[Mobile client scans QR]
+    F --> G[Mobile client opens WebSocket to /relay/{sessionId}<br/>x-role: iphone or android]
     G --> H{Mac session live?}
-    H -- No --> I[Relay closes iPhone socket<br/>4002 session unavailable]
-    H -- Yes --> J[Relay binds iPhone to that session]
+    H -- No --> I[Relay closes mobile socket<br/>4002 session unavailable]
+    H -- Yes --> J[Relay binds mobile client to that session]
 
     E --> K[Relay forwards secure control messages]
     J --> K
-    K --> L[Mac and iPhone exchange signed handshake]
+    K --> L[Mac and mobile client exchange signed handshake]
     L --> M[Both sides derive AES-256-GCM session keys]
 
-    M --> N[iPhone sends encrypted app messages]
+    M --> N[Mobile client sends encrypted app messages]
     M --> O[Mac sends encrypted Codex and bridge responses]
     N --> P[Relay forwards ciphertext to Mac]
-    O --> Q[Relay forwards ciphertext to iPhone]
+    O --> Q[Relay forwards ciphertext to mobile client]
 
     P --> R[Bridge decrypts and routes locally]
     R --> S[Codex app-server / git / workspace handlers]
     S --> O
 
-    Q --> T[iPhone decrypts and renders timeline]
+    Q --> T[Mobile client decrypts and renders timeline]
 
     D --> U[Relay stores per-session notification secret]
     U --> V[Push registration/completion endpoints only work while live Mac session exists]
 
     D --> W{Mac reconnects?}
     W -- Yes --> X[Relay replaces older Mac socket<br/>4001 to old connection]
-    G --> Y{iPhone reconnects?}
-    Y -- Yes --> Z[Relay replaces older iPhone socket<br/>4003 to old connection]
+    G --> Y{Mobile client reconnects?}
+    Y -- Yes --> Z[Relay replaces older mobile socket<br/>4003 to old connection]
 
     X --> E
     Z --> J
 
     D --> AA{Mac disconnects?}
-    AA -- Yes --> AB[Relay closes iPhone socket(s)<br/>4002 Mac disconnected]
+    AA -- Yes --> AB[Relay closes mobile socket(s)<br/>4002 Mac disconnected]
     AB --> AC[Empty session cleaned up after delay]
 
     T --> AD[Later app reopen]
-    AD --> AE[iPhone calls POST /v1/trusted/session/resolve]
+    AD --> AE[Mobile client calls POST /v1/trusted/session/resolve]
     AE --> AF[Relay verifies trusted-device signature, nonce, and freshness]
     AF --> AG[Relay returns current live sessionId for that Mac]
     AG --> G
@@ -90,11 +90,11 @@ flowchart TD
 ## Protocol Notes
 
 - WebSocket path: `/relay/{sessionId}`
-- required header: `x-role: mac` or `x-role: iphone`
+- required header: `x-role: mac`, `x-role: iphone`, or `x-role: android`
 - close code `4000`: invalid session or role
 - close code `4001`: previous Mac connection replaced
 - close code `4002`: session unavailable / Mac disconnected
-- close code `4003`: previous iPhone connection replaced
+- close code `4003`: previous mobile connection replaced
 
 Optional HTTP endpoints:
 
@@ -103,7 +103,7 @@ Optional HTTP endpoints:
 - `POST /v1/push/session/register-device`
 - `POST /v1/push/session/notify-completion`
 
-The trusted-session resolve endpoint is intended for phones that have already completed the first QR bootstrap. It returns the current live session only after signature, nonce, and freshness checks pass.
+The trusted-session resolve endpoint is intended for mobile clients that have already completed the first QR bootstrap. It returns the current live session only after signature, nonce, and freshness checks pass.
 
 Push is disabled by default. Enable it only when you are ready to wire APNs and the bridge-side `REMODEX_PUSH_SERVICE_URL`, for example with `REMODEX_ENABLE_PUSH_SERVICE=true`.
 

--- a/relay/relay.js
+++ b/relay/relay.js
@@ -17,8 +17,17 @@ const TRUSTED_SESSION_RESOLVE_SKEW_MS = 90_000;
 const SHORT_PAIRING_CODE_MIN_LENGTH = 8;
 const SHORT_PAIRING_CODE_MAX_LENGTH = 12;
 
-// In-memory session registry for one Mac host and one live iPhone client per session.
+// In-memory session registry for one Mac host and one live mobile client per session (iOS or Android).
 const sessions = new Map();
+
+function normalizeRelayRole(headerValue) {
+  const raw = readHeaderString(headerValue);
+  return typeof raw === "string" ? raw.trim().toLowerCase() : "";
+}
+
+function isRelayMobileRole(role) {
+  return role === "iphone" || role === "android";
+}
 const liveSessionsByMacDeviceId = new Map();
 const liveSessionsByPairingCode = new Map();
 const usedResolveNonces = new Map();
@@ -50,9 +59,9 @@ function setupRelay(
     const urlPath = req.url || "";
     const match = urlPath.match(/^\/relay\/([^/?]+)/);
     const sessionId = match?.[1];
-    const role = req.headers["x-role"];
+    const role = normalizeRelayRole(req.headers["x-role"]);
 
-    if (!sessionId || (role !== "mac" && role !== "iphone")) {
+    if (!sessionId || (role !== "mac" && !isRelayMobileRole(role))) {
       ws.close(4000, "Missing sessionId or invalid x-role header");
       return;
     }
@@ -63,7 +72,7 @@ function setupRelay(
     });
 
     // Only the Mac host is allowed to create a fresh session room.
-    if (role === "iphone" && !sessions.has(sessionId)) {
+    if (isRelayMobileRole(role) && !sessions.has(sessionId)) {
       ws.close(CLOSE_CODE_SESSION_UNAVAILABLE, "Mac session not available");
       return;
     }
@@ -81,7 +90,7 @@ function setupRelay(
 
     const session = sessions.get(sessionId);
 
-    if (role === "iphone" && !canAcceptIphoneConnection(session)) {
+    if (isRelayMobileRole(role) && !canAcceptMobileClientConnection(session)) {
       ws.close(CLOSE_CODE_SESSION_UNAVAILABLE, "Mac session not available");
       return;
     }
@@ -104,7 +113,7 @@ function setupRelay(
       registerLiveMacSession(session.macRegistration);
       console.log(`[relay] Mac connected -> ${relaySessionLogLabel(sessionId)}`);
     } else {
-      // Keep one live iPhone RPC client per session to avoid competing sockets.
+      // Keep one live mobile RPC client per session to avoid competing sockets.
       for (const existingClient of session.clients) {
         if (existingClient === ws) {
           continue;
@@ -115,7 +124,7 @@ function setupRelay(
         ) {
           existingClient.close(
             CLOSE_CODE_IPHONE_REPLACED,
-            "Replaced by newer iPhone connection"
+            "Replaced by newer mobile connection"
           );
         }
         session.clients.delete(existingClient);
@@ -123,7 +132,7 @@ function setupRelay(
 
       session.clients.add(ws);
       console.log(
-        `[relay] iPhone connected -> ${relaySessionLogLabel(sessionId)} `
+        `[relay] Mobile connected (${role}) -> ${relaySessionLogLabel(sessionId)} `
         + `(${session.clients.size} client(s))`
       );
     }
@@ -169,7 +178,7 @@ function setupRelay(
       } else {
         session.clients.delete(ws);
         console.log(
-          `[relay] iPhone disconnected -> ${relaySessionLogLabel(sessionId)} `
+          `[relay] Mobile disconnected (${role}) -> ${relaySessionLogLabel(sessionId)} `
           + `(${session.clients.size} remaining)`
         );
       }
@@ -252,7 +261,7 @@ function clearMacAbsenceTimer(session, { clearTimeoutFn = clearTimeout } = {}) {
   session.macAbsenceTimer = null;
 }
 
-function canAcceptIphoneConnection(session) {
+function canAcceptMobileClientConnection(session) {
   if (!session) {
     return false;
   }

--- a/relay/server.js
+++ b/relay/server.js
@@ -359,9 +359,10 @@ if (require.main === module) {
   const enablePushService = readOptionalBooleanEnv(
     ["REMODEX_ENABLE_PUSH_SERVICE", "PHODEX_ENABLE_PUSH_SERVICE"]
   ) ?? false;
+  const bindHost = process.env.RELAY_BIND_HOST || "0.0.0.0";
   const { server } = createRelayServer({ enablePushService, trustProxy });
-  server.listen(port, () => {
-    console.log(`[relay] listening on :${port}`);
+  server.listen(port, bindHost, () => {
+    console.log(`[relay] listening on ${bindHost}:${port}`);
   });
 }
 

--- a/relay/server.test.js
+++ b/relay/server.test.js
@@ -553,6 +553,31 @@ test("websocket relay forwards between mac and iphone on the base relay path", a
   });
 });
 
+test("websocket relay forwards between mac and android on the base relay path", async () => {
+  await withServer(async ({ port }) => {
+    const mac = new WebSocket(`ws://127.0.0.1:${port}/relay/session-android-1`, {
+      headers: { "x-role": "mac" },
+    });
+    const android = new WebSocket(`ws://127.0.0.1:${port}/relay/session-android-1`, {
+      headers: { "x-role": "android" },
+    });
+
+    await Promise.all([onceOpen(mac), onceOpen(android)]);
+
+    const received = new Promise((resolve) => {
+      android.once("message", (value) => resolve(value.toString("utf8")));
+    });
+    mac.send(JSON.stringify({ ok: true }));
+    assert.equal(await received, "{\"ok\":true}");
+
+    const macClosed = onceClosed(mac);
+    const androidClosed = onceClosed(android);
+    mac.close();
+    android.close();
+    await Promise.all([macClosed, androidClosed]);
+  });
+});
+
 test("relay keeps the iPhone connected briefly but rejects new sends while the mac is absent", async () => {
   await withServer(async ({ port }) => {
     const mac = new WebSocket(`ws://127.0.0.1:${port}/relay/session-grace`, {


### PR DESCRIPTION
## Summary
- Aggiunge il percorso iOS -> desktop tramite RPC neutrale, così l’handoff funziona anche con bridge Windows.
- Rende più sicura l’apertura dei thread su Windows validando gli ID e rimuovendo `cmd.exe` dal flusso di lancio.
- Riduce l’esposizione di dati sensibili nei log QR e allinea relay/docs ai nuovi ruoli supportati.
- Aggiorna i test per coprire i nuovi percorsi e le regressioni principali.

## Testing
- Aggiunti/aggiornati test unitari per handoff desktop, parsing QR e bridge relay.
- Verifica locale dei test Node per `phodex-bridge` e `relay`.
- Controllo diff e formattazione passati.