### PR TITLE
Add local pet companion overlay and bridge support

### DIFF
--- a/CodexMobile/CodexMobile/CodexMobileApp.swift
+++ b/CodexMobile/CodexMobile/CodexMobileApp.swift
@@ -12,6 +12,8 @@ struct CodexMobileApp: App {
     @Environment(\.scenePhase) private var scenePhase
     @UIApplicationDelegateAdaptor(CodexMobileAppDelegate.self) private var appDelegate
     @State private var codexService: CodexService
+    @State private var petCompanionStore: PetCompanionStore
+    @State private var petCompanionStatusStore: PetCompanionStatusStore
     @State private var subscriptionService: SubscriptionService
 
     init() {
@@ -19,6 +21,8 @@ struct CodexMobileApp: App {
         let service = CodexService()
         service.configureNotifications()
         _codexService = State(initialValue: service)
+        _petCompanionStore = State(initialValue: PetCompanionStore())
+        _petCompanionStatusStore = State(initialValue: PetCompanionStatusStore())
         _subscriptionService = State(initialValue: SubscriptionService())
     }
 
@@ -26,6 +30,8 @@ struct CodexMobileApp: App {
         WindowGroup {
             ContentView()
                 .environment(codexService)
+                .environment(petCompanionStore)
+                .environment(petCompanionStatusStore)
                 .environment(subscriptionService)
                 .task {
                     await subscriptionService.bootstrap()

--- a/CodexMobile/CodexMobile/ContentView.swift
+++ b/CodexMobile/CodexMobile/ContentView.swift
@@ -361,6 +361,14 @@ struct ContentView: View {
                     mainNavigationLayer
                         .frame(width: proxy.size.width, alignment: .leading)
 
+                    PetCompanionStatusSyncView()
+
+                    PetCompanionOverlay(
+                        isInteractionEnabled: !sidebarVisible,
+                        bottomExclusionHeight: 16
+                    )
+                    .frame(width: proxy.size.width, height: proxy.size.height)
+
                     if sidebarVisible {
                         (colorScheme == .dark ? Color.white : Color.black)
                             .opacity(contentDimOpacity(for: currentSidebarWidth))

--- a/CodexMobile/CodexMobile/Models/PetCompanionModels.swift
+++ b/CodexMobile/CodexMobile/Models/PetCompanionModels.swift
@@ -1,0 +1,173 @@
+// FILE: PetCompanionModels.swift
+// Purpose: Models Codex-compatible companion pets and their sprite atlas layout.
+// Layer: Model
+// Exports: PetCompanion, PetCompanionPhase, PetCompanionPosition, PetCompanionLayout
+// Depends on: Foundation, CoreGraphics
+
+import CoreGraphics
+import Foundation
+
+struct PetCompanion: Identifiable, Equatable, Sendable {
+    let id: String
+    let folderName: String
+    let displayName: String
+    let description: String?
+    let spritesheetDataURL: String?
+    let spritesheetMimeType: String?
+    let spritesheetByteLength: Int?
+}
+
+struct PetCompanionStatusSnapshot: Equatable, Sendable {
+    let phase: PetCompanionPhase
+    var title: String?
+    var detail: String?
+
+    static let idle = PetCompanionStatusSnapshot(phase: .idle)
+
+    var showsLabel: Bool {
+        title != nil || detail != nil
+    }
+}
+
+enum PetCompanionPhase: String, CaseIterable, Sendable {
+    case idle
+    case runningRight = "running-right"
+    case runningLeft = "running-left"
+    case waving
+    case jumping
+    case failed
+    case waiting
+    case running
+    case review
+
+    static let cellSize = CGSize(width: 192, height: 208)
+    static let atlasColumns = 8
+
+    var rowIndex: Int {
+        switch self {
+        case .idle: 0
+        case .runningRight: 1
+        case .runningLeft: 2
+        case .waving: 3
+        case .jumping: 4
+        case .failed: 5
+        case .waiting: 6
+        case .running: 7
+        case .review: 8
+        }
+    }
+
+    var frameCount: Int {
+        switch self {
+        case .idle: 6
+        case .runningRight, .runningLeft, .failed: 8
+        case .waving: 4
+        case .jumping: 5
+        case .waiting, .running, .review: 6
+        }
+    }
+
+    var frameDurationsMilliseconds: [UInt64] {
+        switch self {
+        case .idle:
+            [280, 110, 110, 140, 140, 320]
+        case .runningRight, .runningLeft:
+            [120, 120, 120, 120, 120, 120, 120, 220]
+        case .waving:
+            [140, 140, 140, 280]
+        case .jumping:
+            [140, 140, 140, 140, 280]
+        case .failed:
+            [140, 140, 140, 140, 140, 140, 140, 240]
+        case .waiting:
+            [150, 150, 150, 150, 150, 260]
+        case .running:
+            [120, 120, 120, 120, 120, 220]
+        case .review:
+            [150, 150, 150, 150, 150, 280]
+        }
+    }
+
+    var slowFrameDurationsMilliseconds: [UInt64] {
+        frameDurationsMilliseconds.map { $0 * 6 }
+    }
+}
+
+struct PetCompanionPosition: Codable, Equatable, Sendable {
+    var normalizedX: Double
+    var normalizedY: Double
+
+    static let `default` = PetCompanionPosition(normalizedX: 0.82, normalizedY: 0.72)
+}
+
+enum PetCompanionLayout {
+    static func point(
+        for position: PetCompanionPosition,
+        in containerSize: CGSize,
+        petSize: CGSize,
+        leftExclusionWidth: CGFloat,
+        bottomExclusionHeight: CGFloat
+    ) -> CGPoint {
+        let rawPoint = CGPoint(
+            x: containerSize.width * CGFloat(position.normalizedX),
+            y: containerSize.height * CGFloat(position.normalizedY)
+        )
+
+        return clampedPoint(
+            rawPoint,
+            in: containerSize,
+            petSize: petSize,
+            leftExclusionWidth: leftExclusionWidth,
+            bottomExclusionHeight: bottomExclusionHeight
+        )
+    }
+
+    static func normalizedPosition(
+        for point: CGPoint,
+        in containerSize: CGSize,
+        petSize: CGSize,
+        leftExclusionWidth: CGFloat,
+        bottomExclusionHeight: CGFloat
+    ) -> PetCompanionPosition {
+        let clamped = clampedPoint(
+            point,
+            in: containerSize,
+            petSize: petSize,
+            leftExclusionWidth: leftExclusionWidth,
+            bottomExclusionHeight: bottomExclusionHeight
+        )
+
+        guard containerSize.width > 0, containerSize.height > 0 else {
+            return .default
+        }
+
+        return PetCompanionPosition(
+            normalizedX: Double(clamped.x / containerSize.width),
+            normalizedY: Double(clamped.y / containerSize.height)
+        )
+    }
+
+    static func clampedPoint(
+        _ point: CGPoint,
+        in containerSize: CGSize,
+        petSize: CGSize,
+        leftExclusionWidth: CGFloat,
+        bottomExclusionHeight: CGFloat
+    ) -> CGPoint {
+        guard containerSize.width > 0, containerSize.height > 0 else {
+            return .zero
+        }
+
+        let horizontalMargin = max(12, petSize.width / 2)
+        let verticalMargin = max(12, petSize.height / 2)
+        let minX = min(containerSize.width - horizontalMargin, leftExclusionWidth + horizontalMargin)
+        let maxX = max(minX, containerSize.width - horizontalMargin)
+        let minY = verticalMargin
+        let maxY = max(minY, containerSize.height - bottomExclusionHeight - verticalMargin)
+
+        return CGPoint(
+            x: min(max(point.x, minX), maxX),
+            y: min(max(point.y, minY), maxY)
+        )
+    }
+}

--- a/CodexMobile/CodexMobile/Services/CodexService+Pets.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Pets.swift
@@ -1,0 +1,272 @@
+// FILE: CodexService+Pets.swift
+// Purpose: Loads Codex-compatible local pet packages through the paired bridge.
+// Layer: Service
+// Exports: CodexService pet APIs, PetCompanionStatusSignature
+// Depends on: CodexService, JSONValue, PetCompanion
+
+import Foundation
+
+struct PetCompanionStatusSignature: Equatable, Sendable {
+    let isConnected: Bool
+    let activeThreadId: String?
+    let pendingApprovals: [String]
+    let runningThreadIDs: [String]
+    let protectedRunningThreadIDs: [String]
+    let activeTurnThreadIDs: [String]
+    let failedThreadIDs: [String]
+    let readyThreadIDs: [String]
+    let completionBanner: String?
+
+    var hasRunningWork: Bool {
+        !runningThreadIDs.isEmpty || !protectedRunningThreadIDs.isEmpty || !activeTurnThreadIDs.isEmpty
+    }
+}
+
+extension CodexService {
+    func listPets(includeData: Bool = false) async throws -> [PetCompanion] {
+        let response = try await sendRequest(
+            method: "pet/list",
+            params: .object([
+                "includeData": .bool(includeData),
+                "metadataOnly": .bool(!includeData)
+            ])
+        )
+
+        if let error = response.error {
+            throw CodexServiceError.rpcError(error)
+        }
+
+        guard let result = response.result?.objectValue else {
+            throw CodexServiceError.invalidResponse("The bridge returned an invalid pet list.")
+        }
+
+        let rawPets = result["avatars"]?.arrayValue ?? result["pets"]?.arrayValue ?? []
+        return rawPets.compactMap { value in
+            petCompanion(from: value, requiresSpritesheetData: includeData)
+        }
+    }
+
+    func readPet(id: String) async throws -> PetCompanion {
+        do {
+            return try await readPetDirect(id: id)
+        } catch {
+            guard isUnsupportedPetReadError(error),
+                  let fallbackPet = try await listPets(includeData: true).first(where: { $0.id == id }) else {
+                throw error
+            }
+
+            return fallbackPet
+        }
+    }
+
+    private func readPetDirect(id: String) async throws -> PetCompanion {
+        let response = try await sendRequest(method: "pet/read", params: .object(["id": .string(id)]))
+        if let error = response.error {
+            throw CodexServiceError.rpcError(error)
+        }
+
+        guard let result = response.result,
+              let pet = petCompanion(from: result, requiresSpritesheetData: true) else {
+            throw CodexServiceError.invalidResponse("The bridge returned an invalid pet.")
+        }
+
+        return pet
+    }
+
+    private func isUnsupportedPetReadError(_ error: Error) -> Bool {
+        guard case CodexServiceError.rpcError(let rpcError) = error else {
+            return false
+        }
+
+        let message = rpcError.message.lowercased()
+        return message.contains("unknown variant")
+            || message.contains("unknown method")
+            || message.contains("pet/read")
+    }
+
+    // Captures only pet-relevant observable state so the overlay does not subscribe to chat timelines.
+    func petCompanionStatusSignature() -> PetCompanionStatusSignature {
+        PetCompanionStatusSignature(
+            isConnected: isConnected,
+            activeThreadId: activeThreadId,
+            pendingApprovals: pendingApprovals.map { "\($0.id):\($0.threadId ?? "")" }.sorted(),
+            runningThreadIDs: runningThreadIDs.sorted(),
+            protectedRunningThreadIDs: protectedRunningFallbackThreadIDs.sorted(),
+            activeTurnThreadIDs: activeTurnIdByThread.keys.sorted(),
+            failedThreadIDs: failedThreadIDs.sorted(),
+            readyThreadIDs: readyThreadIDs.sorted(),
+            completionBanner: threadCompletionBanner.map { "\($0.id.uuidString):\($0.threadId):\($0.title)" }
+        )
+    }
+
+    func petCompanionStatusSnapshot() -> PetCompanionStatusSnapshot {
+        if let approval = preferredPetApprovalRequest() {
+            return PetCompanionStatusSnapshot(
+                phase: .waiting,
+                title: "Approval needed",
+                detail: approval.threadId.map {
+                    petProgressPrompt(for: $0, fallback: petThreadTitle(for: $0), prefersActivity: true)
+                } ?? "Waiting for you"
+            )
+        }
+
+        let runningThreadIDs = petRunningThreadIDs()
+        if let threadId = preferredPetThreadID(from: runningThreadIDs) {
+            return PetCompanionStatusSnapshot(
+                phase: .running,
+                title: runningThreadIDs.count > 1 ? "Working \(runningThreadIDs.count) chats" : "Working",
+                detail: petProgressPrompt(for: threadId, fallback: petThreadTitle(for: threadId), prefersActivity: true)
+            )
+        }
+
+        if let threadId = preferredPetThreadID(from: failedThreadIDs) {
+            return PetCompanionStatusSnapshot(
+                phase: .failed,
+                title: "Needs a look",
+                detail: petProgressPrompt(for: threadId, fallback: petThreadTitle(for: threadId))
+            )
+        }
+
+        if let banner = threadCompletionBanner {
+            return PetCompanionStatusSnapshot(phase: .review, title: "Done", detail: banner.title)
+        }
+
+        if let threadId = preferredPetThreadID(from: readyThreadIDs) {
+            return PetCompanionStatusSnapshot(
+                phase: .review,
+                title: "Done",
+                detail: petProgressPrompt(for: threadId, fallback: petThreadTitle(for: threadId))
+            )
+        }
+
+        return .idle
+    }
+
+    func petProgressPrompt(for threadId: String, fallback: String, prefersActivity: Bool = false) -> String {
+        let recentMessages = (messagesByThread[threadId] ?? []).suffix(12).reversed()
+        for message in recentMessages {
+            guard message.role != .user else {
+                continue
+            }
+            if prefersActivity, message.kind == .chat, !message.isStreaming {
+                continue
+            }
+
+            if let prompt = petPrompt(from: message) {
+                return prompt
+            }
+        }
+
+        if !prefersActivity,
+           let cached = latestAssistantOutputByThread[threadId],
+           let prompt = sanitizedPetPrompt(cached) {
+            return prompt
+        }
+
+        return fallback
+    }
+
+    private func petCompanion(from value: JSONValue, requiresSpritesheetData: Bool) -> PetCompanion? {
+        guard let object = value.objectValue else {
+            return nil
+        }
+
+        guard let id = object["id"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !id.isEmpty,
+              let displayName = object["displayName"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !displayName.isEmpty else {
+            return nil
+        }
+
+        let dataURL = object["spritesheetDataUrl"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if requiresSpritesheetData && (dataURL?.isEmpty ?? true) {
+            return nil
+        }
+
+        return PetCompanion(
+            id: id,
+            folderName: object["folderName"]?.stringValue ?? id,
+            displayName: displayName,
+            description: object["description"]?.stringValue,
+            spritesheetDataURL: dataURL,
+            spritesheetMimeType: object["spritesheetMimeType"]?.stringValue,
+            spritesheetByteLength: object["spritesheetByteLength"]?.intValue
+        )
+    }
+
+    private func petPrompt(from message: CodexMessage) -> String? {
+        switch message.kind {
+        case .commandExecution:
+            return message.isStreaming ? "Running command" : "Ran command"
+        case .fileChange:
+            return message.isStreaming ? "Editing files" : "Edited files"
+        case .toolActivity:
+            if let prompt = sanitizedPetPrompt(message.text) {
+                return prompt
+            }
+            return message.isStreaming ? "Using a tool" : "Used a tool"
+        case .thinking:
+            return sanitizedPetPrompt(message.text) ?? "Thinking"
+        case .userInputPrompt:
+            return "Waiting for you"
+        case .plan:
+            return sanitizedPetPrompt(message.text) ?? "Planning"
+        case .subagentAction:
+            return sanitizedPetPrompt(message.text) ?? "Working with an agent"
+        case .chat:
+            return sanitizedPetPrompt(message.text)
+        }
+    }
+
+    private func sanitizedPetPrompt(_ rawText: String) -> String? {
+        let trimmed = rawText
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "`", with: "")
+            .replacingOccurrences(of: "*", with: "")
+            .replacingOccurrences(of: "#", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+
+        if trimmed.count <= 52 {
+            return trimmed
+        }
+
+        let endIndex = trimmed.index(trimmed.startIndex, offsetBy: 49)
+        return String(trimmed[..<endIndex]).trimmingCharacters(in: .whitespacesAndNewlines) + "..."
+    }
+
+    private func preferredPetApprovalRequest() -> CodexApprovalRequest? {
+        if let activeThreadId,
+           let activeApproval = pendingApprovals.first(where: { $0.threadId == activeThreadId }) {
+            return activeApproval
+        }
+        return pendingApprovals.first
+    }
+
+    private func petRunningThreadIDs() -> Set<String> {
+        runningThreadIDs
+            .union(protectedRunningFallbackThreadIDs)
+            .union(Set(activeTurnIdByThread.keys))
+    }
+
+    private func preferredPetThreadID(from candidates: Set<String>) -> String? {
+        guard !candidates.isEmpty else {
+            return nil
+        }
+        if let activeThreadId, candidates.contains(activeThreadId) {
+            return activeThreadId
+        }
+        return threads.first(where: { candidates.contains($0.id) })?.id
+            ?? candidates.sorted().first
+    }
+
+    private func petThreadTitle(for threadId: String) -> String {
+        let title = thread(for: threadId)?.displayTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let title, !title.isEmpty else {
+            return "Chat"
+        }
+        return title
+    }
+}

--- a/CodexMobile/CodexMobile/Services/PetCompanionStore.swift
+++ b/CodexMobile/CodexMobile/Services/PetCompanionStore.swift
@@ -1,0 +1,194 @@
+// FILE: PetCompanionStore.swift
+// Purpose: Persists and loads the optional Codex companion pet state.
+// Layer: Service
+// Exports: PetCompanionStore, PetCompanionStatusStore
+// Depends on: Foundation, Observation, PetCompanion
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class PetCompanionStore {
+    private enum DefaultsKey {
+        static let isEnabled = "codex.pet.isEnabled"
+        static let selectedID = "codex.pet.selectedID"
+        static let positionX = "codex.pet.positionX"
+        static let positionY = "codex.pet.positionY"
+    }
+
+    private let defaults: UserDefaults
+
+    var isEnabled: Bool {
+        didSet {
+            defaults.set(isEnabled, forKey: DefaultsKey.isEnabled)
+        }
+    }
+    var availablePets: [PetCompanion] = []
+    var renderedPet: PetCompanion?
+    var selectedPetID: String? {
+        didSet {
+            defaults.set(selectedPetID, forKey: DefaultsKey.selectedID)
+        }
+    }
+    var position: PetCompanionPosition {
+        didSet {
+            defaults.set(position.normalizedX, forKey: DefaultsKey.positionX)
+            defaults.set(position.normalizedY, forKey: DefaultsKey.positionY)
+        }
+    }
+    var isLoading = false
+    var errorMessage: String?
+    @ObservationIgnored private var selectedPetLoadID: String?
+    @ObservationIgnored private var selectedPetLoadTask: Task<PetCompanion, Error>?
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.isEnabled = defaults.bool(forKey: DefaultsKey.isEnabled)
+        self.selectedPetID = defaults.string(forKey: DefaultsKey.selectedID)
+
+        if defaults.object(forKey: DefaultsKey.positionX) != nil,
+           defaults.object(forKey: DefaultsKey.positionY) != nil {
+            self.position = PetCompanionPosition(
+                normalizedX: defaults.double(forKey: DefaultsKey.positionX),
+                normalizedY: defaults.double(forKey: DefaultsKey.positionY)
+            )
+        } else {
+            self.position = .default
+        }
+    }
+
+    var selectedPet: PetCompanion? {
+        if let selectedPetID,
+           let selected = availablePets.first(where: { $0.id == selectedPetID }) {
+            return selected
+        }
+
+        return availablePets.first
+    }
+
+    func setEnabled(_ isEnabled: Bool) {
+        self.isEnabled = isEnabled
+    }
+
+    func selectPet(id: String?) {
+        guard selectedPetID != id else {
+            return
+        }
+        selectedPetID = id
+        renderedPet = nil
+        selectedPetLoadTask?.cancel()
+        selectedPetLoadTask = nil
+        selectedPetLoadID = nil
+    }
+
+    func updatePosition(_ position: PetCompanionPosition) {
+        self.position = position
+    }
+
+    func loadPetsIfNeeded(codex: CodexService) async {
+        guard availablePets.isEmpty else {
+            return
+        }
+        await refreshPets(codex: codex)
+    }
+
+    // Loads metadata first; the selected sprite atlas is fetched separately to keep memory low.
+    func refreshPets(codex: CodexService) async {
+        guard codex.isConnected else {
+            errorMessage = "Connect to your Mac to load local pets."
+            return
+        }
+        guard !isLoading else {
+            return
+        }
+
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let pets = try await codex.listPets(includeData: false)
+            availablePets = pets
+            errorMessage = nil
+            if let selectedPetID,
+               pets.contains(where: { $0.id == selectedPetID }) {
+                await loadSelectedPet(codex: codex)
+                return
+            }
+            selectedPetID = pets.first?.id
+            renderedPet = nil
+            await loadSelectedPet(codex: codex)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // Keeps only the currently displayed pet hydrated with spritesheet data.
+    func loadSelectedPet(codex: CodexService) async {
+        guard codex.isConnected else {
+            return
+        }
+        guard let selectedPet = selectedPet else {
+            renderedPet = nil
+            return
+        }
+        if renderedPet?.id == selectedPet.id,
+           renderedPet?.spritesheetDataURL?.isEmpty == false {
+            return
+        }
+
+        let requestedPetID = selectedPet.id
+        let loadTask: Task<PetCompanion, Error>
+        if selectedPetLoadID == requestedPetID, let existingTask = selectedPetLoadTask {
+            loadTask = existingTask
+        } else {
+            selectedPetLoadTask?.cancel()
+            loadTask = Task { @MainActor in
+                try await codex.readPet(id: requestedPetID)
+            }
+            selectedPetLoadID = requestedPetID
+            selectedPetLoadTask = loadTask
+        }
+
+        defer {
+            if selectedPetLoadID == requestedPetID {
+                selectedPetLoadID = nil
+                selectedPetLoadTask = nil
+            }
+        }
+
+        do {
+            let loadedPet = try await loadTask.value
+            guard selectedPetID == nil || selectedPetID == requestedPetID else {
+                return
+            }
+            renderedPet = loadedPet
+            errorMessage = nil
+        } catch is CancellationError {
+            return
+        } catch {
+            guard selectedPetID == nil || selectedPetID == requestedPetID else {
+                return
+            }
+            renderedPet = nil
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+@MainActor
+@Observable
+final class PetCompanionStatusStore {
+    var snapshot = PetCompanionStatusSnapshot.idle
+
+    func update(_ snapshot: PetCompanionStatusSnapshot) {
+        guard self.snapshot != snapshot else {
+            return
+        }
+        self.snapshot = snapshot
+    }
+
+    func reset() {
+        update(.idle)
+    }
+}

--- a/CodexMobile/CodexMobile/Views/Pet/PetCompanionOverlay.swift
+++ b/CodexMobile/CodexMobile/Views/Pet/PetCompanionOverlay.swift
@@ -1,0 +1,412 @@
+// FILE: PetCompanionOverlay.swift
+// Purpose: Draws and animates a draggable Codex companion pet above the app shell.
+// Layer: View
+// Exports: PetCompanionOverlay, PetCompanionStatusSyncView
+// Depends on: SwiftUI, UIKit, PetCompanionStore, CodexService
+
+import SwiftUI
+import UIKit
+
+struct PetCompanionOverlay: View {
+    @Environment(CodexService.self) private var codex
+    @Environment(PetCompanionStore.self) private var petStore
+    @Environment(PetCompanionStatusStore.self) private var petStatusStore
+
+    let isInteractionEnabled: Bool
+    let bottomExclusionHeight: CGFloat
+
+    @State private var dragStartPoint: CGPoint?
+    @State private var dragPoint: CGPoint?
+    @State private var isDragging = false
+    @State private var dragPhase: PetCompanionPhase = .runningRight
+    @State private var transientPhase: PetCompanionPhase?
+    @State private var transientPhaseTask: Task<Void, Never>?
+
+    private let spriteSize = CGSize(width: 92, height: 100)
+    private let companionSize = CGSize(width: 176, height: 150)
+    private let sidebarGestureExclusionWidth: CGFloat = 0
+
+    var body: some View {
+        GeometryReader { proxy in
+            if petStore.isEnabled, let pet = petStore.renderedPet {
+                let containerSize = proxy.size
+                let resolvedPoint = resolvedPetPoint(in: containerSize)
+                let status = currentStatus
+                let phase = status.phase
+
+                petBody(pet: pet, status: status)
+                    .frame(width: companionSize.width, height: companionSize.height)
+                    .position(resolvedPoint)
+                    .gesture(dragGesture(containerSize: containerSize, currentPoint: resolvedPoint))
+                    .simultaneousGesture(tapGesture)
+                    .allowsHitTesting(isInteractionEnabled)
+                    .animation(.spring(response: 0.28, dampingFraction: 0.78), value: resolvedPoint)
+                    .animation(.easeInOut(duration: 0.18), value: phase)
+            }
+        }
+        .task(id: codex.isConnected) {
+            guard codex.isConnected, petStore.isEnabled else {
+                return
+            }
+            await petStore.loadPetsIfNeeded(codex: codex)
+            await petStore.loadSelectedPet(codex: codex)
+        }
+        .task(id: petStore.selectedPetID) {
+            guard codex.isConnected, petStore.isEnabled else {
+                return
+            }
+            await petStore.loadSelectedPet(codex: codex)
+        }
+        .onChange(of: petStore.isEnabled) { _, isEnabled in
+            guard isEnabled else {
+                transientPhaseTask?.cancel()
+                transientPhaseTask = nil
+                return
+            }
+            Task {
+                await petStore.loadPetsIfNeeded(codex: codex)
+                await petStore.loadSelectedPet(codex: codex)
+            }
+        }
+    }
+
+    private var currentStatus: PetCompanionStatusSnapshot {
+        if isDragging {
+            return PetCompanionStatusSnapshot(phase: dragPhase)
+        }
+        if let transientPhase {
+            return PetCompanionStatusSnapshot(phase: transientPhase)
+        }
+        return petStatusStore.snapshot
+    }
+
+    @ViewBuilder
+    private func petBody(pet: PetCompanion, status: PetCompanionStatusSnapshot) -> some View {
+        VStack(spacing: 4) {
+            PetSpriteView(pet: pet, phase: status.phase)
+                .frame(width: spriteSize.width, height: spriteSize.height)
+                .shadow(color: .black.opacity(0.18), radius: 10, y: 5)
+
+            if status.showsLabel {
+                VStack(spacing: 1) {
+                    Text(status.title ?? "")
+                        .font(AppFont.caption(weight: .semibold))
+                        .foregroundStyle(.primary)
+                    if let detail = status.detail, !detail.isEmpty {
+                        Text(detail)
+                            .font(AppFont.caption())
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .frame(maxWidth: 168)
+                    .background(.ultraThinMaterial, in: Capsule())
+                    .overlay(
+                        Capsule()
+                            .stroke(.white.opacity(0.16), lineWidth: 1)
+                )
+            }
+        }
+        .frame(width: companionSize.width)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(pet.displayName) companion pet")
+    }
+
+    private func resolvedPetPoint(in containerSize: CGSize) -> CGPoint {
+        if let dragPoint {
+            return PetCompanionLayout.clampedPoint(
+                dragPoint,
+                in: containerSize,
+                petSize: companionSize,
+                leftExclusionWidth: sidebarGestureExclusionWidth,
+                bottomExclusionHeight: bottomExclusionHeight
+            )
+        }
+
+        return PetCompanionLayout.point(
+            for: petStore.position,
+            in: containerSize,
+            petSize: companionSize,
+            leftExclusionWidth: sidebarGestureExclusionWidth,
+            bottomExclusionHeight: bottomExclusionHeight
+        )
+    }
+
+    private func dragGesture(containerSize: CGSize, currentPoint: CGPoint) -> some Gesture {
+        DragGesture(minimumDistance: 4)
+            .onChanged { value in
+                let startPoint = dragStartPoint ?? currentPoint
+                dragStartPoint = startPoint
+                isDragging = true
+                if abs(value.translation.width) >= 4 {
+                    dragPhase = value.translation.width >= 0 ? .runningRight : .runningLeft
+                }
+                dragPoint = PetCompanionLayout.clampedPoint(
+                    CGPoint(
+                        x: startPoint.x + value.translation.width,
+                        y: startPoint.y + value.translation.height
+                    ),
+                    in: containerSize,
+                    petSize: companionSize,
+                    leftExclusionWidth: sidebarGestureExclusionWidth,
+                    bottomExclusionHeight: bottomExclusionHeight
+                )
+            }
+            .onEnded { _ in
+                if let dragPoint {
+                    let nextPosition = PetCompanionLayout.normalizedPosition(
+                        for: dragPoint,
+                        in: containerSize,
+                        petSize: companionSize,
+                        leftExclusionWidth: sidebarGestureExclusionWidth,
+                        bottomExclusionHeight: bottomExclusionHeight
+                    )
+                    petStore.updatePosition(nextPosition)
+                }
+                dragStartPoint = nil
+                dragPoint = nil
+                isDragging = false
+            }
+    }
+
+    private var tapGesture: some Gesture {
+        TapGesture()
+            .onEnded {
+                HapticFeedback.shared.triggerImpactFeedback(style: .light)
+                playTransientPhase(.jumping, durationNanoseconds: 850_000_000)
+            }
+    }
+
+    private func playTransientPhase(_ phase: PetCompanionPhase, durationNanoseconds: UInt64) {
+        transientPhaseTask?.cancel()
+        transientPhase = phase
+        transientPhaseTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: durationNanoseconds)
+            if !Task.isCancelled {
+                transientPhase = nil
+            }
+        }
+    }
+
+}
+
+struct PetCompanionStatusSyncView: View {
+    @Environment(CodexService.self) private var codex
+    @Environment(PetCompanionStore.self) private var petStore
+    @Environment(PetCompanionStatusStore.self) private var petStatusStore
+
+    var body: some View {
+        Group {
+            if petStore.isEnabled {
+                let signature = codex.petCompanionStatusSignature()
+
+                syncSurface
+                    .task(id: signature) {
+                        await refreshStatusLoop(for: signature)
+                    }
+            } else {
+                syncSurface
+                    .task {
+                        petStatusStore.reset()
+                    }
+            }
+        }
+        .onChange(of: petStore.isEnabled) { _, isEnabled in
+            if isEnabled {
+                petStatusStore.update(codex.petCompanionStatusSnapshot())
+            } else {
+                petStatusStore.reset()
+            }
+        }
+    }
+
+    private var syncSurface: some View {
+        Color.clear
+            .frame(width: 0, height: 0)
+            .allowsHitTesting(false)
+    }
+
+    private func refreshStatusLoop(for signature: PetCompanionStatusSignature) async {
+        guard petStore.isEnabled, signature.isConnected else {
+            petStatusStore.reset()
+            return
+        }
+
+        petStatusStore.update(codex.petCompanionStatusSnapshot())
+        guard signature.hasRunningWork else {
+            return
+        }
+
+        while !Task.isCancelled {
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            guard !Task.isCancelled, petStore.isEnabled else {
+                return
+            }
+            petStatusStore.update(codex.petCompanionStatusSnapshot())
+        }
+    }
+}
+
+private struct PetSpriteView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    let pet: PetCompanion
+    let phase: PetCompanionPhase
+
+    @State private var atlas: PetSpriteAtlas?
+    @State private var displayedPhase: PetCompanionPhase = .idle
+    @State private var frameIndex = 0
+
+    var body: some View {
+        Group {
+            if let frame = currentFrame {
+                Image(uiImage: frame)
+                    .interpolation(.none)
+                    .resizable()
+                    .scaledToFit()
+            } else {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+        .task(id: pet.spritesheetDataURL ?? pet.id) {
+            let nextAtlas = PetSpriteDecoder.decodeAtlas(from: pet.spritesheetDataURL)
+            nextAtlas?.prewarmSequence(for: phase)
+            atlas = nextAtlas
+        }
+        .task(id: "\(phase.rawValue)-\(reduceMotion)") {
+            atlas?.prewarmSequence(for: phase)
+            await runAnimationLoop()
+        }
+        .onChange(of: phase) { _, _ in
+            displayedPhase = phase
+            frameIndex = 0
+        }
+    }
+
+    private var currentFrame: UIImage? {
+        atlas?.cachedFrame(for: displayedPhase, index: frameIndex)
+            ?? atlas?.cachedFrame(for: .idle, index: 0)
+    }
+
+    private func runAnimationLoop() async {
+        displayedPhase = phase
+        frameIndex = 0
+        if reduceMotion {
+            return
+        }
+
+        if phase != .idle {
+            for _ in 0..<3 {
+                await playPhaseOnce(phase, durations: phase.frameDurationsMilliseconds)
+                guard !Task.isCancelled else {
+                    return
+                }
+            }
+            displayedPhase = .idle
+            frameIndex = 0
+        }
+
+        while !Task.isCancelled {
+            await playPhaseOnce(.idle, durations: PetCompanionPhase.idle.slowFrameDurationsMilliseconds)
+        }
+    }
+
+    private func playPhaseOnce(_ phase: PetCompanionPhase, durations: [UInt64]) async {
+        displayedPhase = phase
+        for index in 0..<phase.frameCount {
+            frameIndex = index
+            let delay = durations[index % durations.count]
+            try? await Task.sleep(nanoseconds: delay * 1_000_000)
+            guard !Task.isCancelled else {
+                return
+            }
+        }
+    }
+}
+
+private enum PetSpriteDecoder {
+    static func decodeAtlas(from dataURL: String?) -> PetSpriteAtlas? {
+        guard let image = image(from: dataURL),
+              let cgImage = image.cgImage else {
+            return nil
+        }
+
+        return PetSpriteAtlas(cgImage: cgImage, scale: image.scale, orientation: image.imageOrientation)
+    }
+
+    private static func image(from dataURL: String?) -> UIImage? {
+        guard let dataURL else {
+            return nil
+        }
+        guard let commaIndex = dataURL.firstIndex(of: ",") else {
+            return nil
+        }
+
+        let base64 = dataURL[dataURL.index(after: commaIndex)...]
+        guard let data = Data(base64Encoded: String(base64)) else {
+            return nil
+        }
+        return UIImage(data: data)
+    }
+}
+
+private final class PetSpriteAtlas {
+    private let cgImage: CGImage
+    private let scale: CGFloat
+    private let orientation: UIImage.Orientation
+    private var frameCache: [String: UIImage] = [:]
+
+    init(cgImage: CGImage, scale: CGFloat, orientation: UIImage.Orientation) {
+        self.cgImage = cgImage
+        self.scale = scale
+        self.orientation = orientation
+    }
+
+    // Prepares only the frames the current animation can show; body rendering stays a pure lookup.
+    func prewarmSequence(for phase: PetCompanionPhase) {
+        prewarm(phase)
+        if phase != .idle {
+            prewarm(.idle)
+        }
+    }
+
+    func cachedFrame(for phase: PetCompanionPhase, index: Int) -> UIImage? {
+        let normalizedIndex = index % max(phase.frameCount, 1)
+        return frameCache[cacheKey(for: phase, index: normalizedIndex)]
+    }
+
+    private func prewarm(_ phase: PetCompanionPhase) {
+        for index in 0..<phase.frameCount {
+            let key = cacheKey(for: phase, index: index)
+            guard frameCache[key] == nil,
+                  let frame = makeFrame(for: phase, index: index) else {
+                continue
+            }
+            frameCache[key] = frame
+        }
+    }
+
+    private func makeFrame(for phase: PetCompanionPhase, index: Int) -> UIImage? {
+        let normalizedIndex = index % max(phase.frameCount, 1)
+        let cropRect = CGRect(
+            x: CGFloat(normalizedIndex) * PetCompanionPhase.cellSize.width,
+            y: CGFloat(phase.rowIndex) * PetCompanionPhase.cellSize.height,
+            width: PetCompanionPhase.cellSize.width,
+            height: PetCompanionPhase.cellSize.height
+        )
+        guard let cropped = cgImage.cropping(to: cropRect) else {
+            return nil
+        }
+
+        return UIImage(cgImage: cropped, scale: scale, orientation: orientation)
+    }
+
+    private func cacheKey(for phase: PetCompanionPhase, index: Int) -> String {
+        "\(phase.rawValue):\(index)"
+    }
+}

--- a/CodexMobile/CodexMobile/Views/SettingsView.swift
+++ b/CodexMobile/CodexMobile/Views/SettingsView.swift
@@ -551,7 +551,103 @@ private struct SettingsAppearanceCard: View {
                     .font(AppFont.caption())
                     .foregroundStyle(.secondary)
             }
+
+            Divider()
+
+            SettingsPetCompanionSection(settingsAccentColor: settingsAccentColor)
         }
+    }
+}
+
+private struct SettingsPetCompanionSection: View {
+    @Environment(CodexService.self) private var codex
+    @Environment(PetCompanionStore.self) private var petStore
+
+    let settingsAccentColor: Color
+
+    var body: some View {
+        Group {
+            Toggle("Companion Pet", isOn: petEnabledBinding)
+                .tint(settingsAccentColor)
+
+            if petStore.isEnabled {
+                if petStore.availablePets.isEmpty {
+                    Text(petStore.isLoading
+                         ? "Loading local Codex pets from your Mac..."
+                         : "No local Codex pets found in ~/.codex/pets.")
+                        .font(AppFont.caption())
+                        .foregroundStyle(.secondary)
+                } else {
+                    HStack {
+                        Text("Pet")
+                        Spacer()
+                        Picker("Pet", selection: selectedPetBinding) {
+                            ForEach(petStore.availablePets) { pet in
+                                Text(pet.displayName).tag(pet.id)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .labelsHidden()
+                        .tint(settingsAccentColor)
+                    }
+
+                    if let description = petStore.selectedPet?.description,
+                       !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        Text(description)
+                            .font(AppFont.caption())
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if let errorMessage = petStore.errorMessage {
+                    Text(errorMessage)
+                        .font(AppFont.caption())
+                        .foregroundStyle(.red)
+                }
+
+                SettingsButton("Refresh Pets", isLoading: petStore.isLoading) {
+                    HapticFeedback.shared.triggerImpactFeedback(style: .light)
+                    Task {
+                        await petStore.refreshPets(codex: codex)
+                    }
+                }
+            }
+        }
+        .task(id: codex.isConnected) {
+            guard codex.isConnected, petStore.isEnabled else {
+                return
+            }
+            await petStore.loadPetsIfNeeded(codex: codex)
+            await petStore.loadSelectedPet(codex: codex)
+        }
+    }
+
+    private var petEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { petStore.isEnabled },
+            set: { isEnabled in
+                petStore.setEnabled(isEnabled)
+                guard isEnabled else {
+                    return
+                }
+                Task {
+                    await petStore.loadPetsIfNeeded(codex: codex)
+                    await petStore.loadSelectedPet(codex: codex)
+                }
+            }
+        )
+    }
+
+    private var selectedPetBinding: Binding<String> {
+        Binding(
+            get: { petStore.selectedPet?.id ?? "" },
+            set: { selectedID in
+                petStore.selectPet(id: selectedID.isEmpty ? nil : selectedID)
+                Task {
+                    await petStore.loadSelectedPet(codex: codex)
+                }
+            }
+        )
     }
 }
 

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -24,6 +24,7 @@ const { handleGitRequest } = require("./git-handler");
 const { handleThreadContextRequest } = require("./thread-context-handler");
 const { handleWorkspaceRequest } = require("./workspace-handler");
 const { handleProjectRequest } = require("./project-handler");
+const { handlePetRequest } = require("./pet-handler");
 const { createNotificationsHandler } = require("./notifications-handler");
 const { createVoiceHandler, resolveVoiceAuth } = require("./voice-handler");
 const {
@@ -518,6 +519,9 @@ function startBridge({
       return;
     }
     if (handleProjectRequest(rawMessage, sendApplicationResponse)) {
+      return;
+    }
+    if (handlePetRequest(rawMessage, sendApplicationResponse)) {
       return;
     }
     if (notificationsHandler.handleNotificationsRequest(rawMessage, sendApplicationResponse)) {

--- a/phodex-bridge/src/pet-handler.js
+++ b/phodex-bridge/src/pet-handler.js
@@ -10,6 +10,7 @@ const { resolveCodexHome } = require("./codex-home");
 
 const ATLAS_WIDTH = 1536;
 const ATLAS_HEIGHT = 1872;
+const MAX_SPRITESHEET_BYTES = 16 * 1024 * 1024;
 const IMAGE_MIME_TYPES_BY_EXTENSION = new Map([
   [".png", "image/png"],
   [".webp", "image/webp"],
@@ -260,6 +261,9 @@ async function readValidatedSpritesheet(spritesheetPath, { includeData }) {
     return readValidatedSpritesheetMetadata(spritesheetPath, mimeType);
   }
 
+  const stat = await readSpritesheetStat(spritesheetPath);
+  assertSpritesheetByteLength(stat.size);
+
   let data;
   try {
     data = await fs.promises.readFile(spritesheetPath);
@@ -287,6 +291,7 @@ async function readValidatedSpritesheetMetadata(spritesheetPath, mimeType) {
   try {
     file = await fs.promises.open(spritesheetPath, "r");
     const stat = await file.stat();
+    assertSpritesheetByteLength(stat.size);
     const dimensions = await readImageDimensionsFromFile(file, mimeType, stat.size);
     if (!dimensions || dimensions.width !== ATLAS_WIDTH || dimensions.height !== ATLAS_HEIGHT) {
       throw petError("pet_spritesheet_dimensions_invalid", "Pet spritesheets must be exactly 1536x1872 pixels.");
@@ -307,6 +312,24 @@ async function readValidatedSpritesheetMetadata(spritesheetPath, mimeType) {
     throw petError("pet_spritesheet_unreadable", "Could not read the pet spritesheet file.");
   } finally {
     await file?.close();
+  }
+}
+
+// Rejects oversized local packages before base64 expansion can bloat relay payloads.
+async function readSpritesheetStat(spritesheetPath) {
+  try {
+    return await fs.promises.stat(spritesheetPath);
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      throw petError("pet_spritesheet_missing", "The pet spritesheet file does not exist.");
+    }
+    throw petError("pet_spritesheet_unreadable", "Could not read the pet spritesheet file.");
+  }
+}
+
+function assertSpritesheetByteLength(byteLength) {
+  if (byteLength > MAX_SPRITESHEET_BYTES) {
+    throw petError("pet_spritesheet_too_large", "Pet spritesheets must be 16 MB or smaller.");
   }
 }
 

--- a/phodex-bridge/src/pet-handler.js
+++ b/phodex-bridge/src/pet-handler.js
@@ -1,0 +1,514 @@
+// FILE: pet-handler.js
+// Purpose: Lists Codex-compatible local pet packages for the mobile companion overlay.
+// Layer: Bridge handler
+// Exports: handlePetRequest, handlePetMethod
+// Depends on: fs, path, ./codex-home
+
+const fs = require("fs");
+const path = require("path");
+const { resolveCodexHome } = require("./codex-home");
+
+const ATLAS_WIDTH = 1536;
+const ATLAS_HEIGHT = 1872;
+const IMAGE_MIME_TYPES_BY_EXTENSION = new Map([
+  [".png", "image/png"],
+  [".webp", "image/webp"],
+]);
+
+function handlePetRequest(rawMessage, sendResponse) {
+  let parsed;
+  try {
+    parsed = JSON.parse(rawMessage);
+  } catch {
+    return false;
+  }
+
+  const method = typeof parsed?.method === "string" ? parsed.method.trim() : "";
+  if (!isPetMethod(method)) {
+    return false;
+  }
+
+  const id = parsed.id;
+  const params = parsed.params || {};
+  handlePetMethod(method, params)
+    .then((result) => {
+      sendResponse(JSON.stringify({ id, result }));
+    })
+    .catch((err) => {
+      const errorCode = err.errorCode || "pet_error";
+      const message = err.userMessage || err.message || "Unable to load Codex pets.";
+      sendResponse(
+        JSON.stringify({
+          id,
+          error: {
+            code: -32000,
+            message,
+            data: { errorCode },
+          },
+        })
+      );
+    });
+
+  return true;
+}
+
+async function handlePetMethod(method, params = {}) {
+  if (!isPetMethod(method)) {
+    throw petError("pet_method_unknown", "Unknown Codex pet method.");
+  }
+
+  if (method === "pet/read" || method === "custom-avatar/read") {
+    return readPet(params);
+  }
+
+  const codexHome = resolveCodexHome();
+  const includeData = params.includeData !== false && params.metadataOnly !== true;
+  const results = [];
+  const errors = [];
+
+  for (const directory of petDirectories(codexHome)) {
+    const discovered = await loadPetDirectory(directory, { includeData });
+    results.push(...discovered.avatars);
+    errors.push(...discovered.errors);
+  }
+
+  const avatars = mergeCustomAvatars(results);
+  return {
+    avatarDirectory: path.join(codexHome, "pets"),
+    petDirectory: path.join(codexHome, "pets"),
+    avatars,
+    pets: avatars,
+    errors,
+  };
+}
+
+// Reads a single selected pet so mobile does not have to embed every atlas in pet/list.
+async function readPet(params = {}) {
+  const codexHome = resolveCodexHome();
+  const folderName = petFolderNameFromID(params.id || params.folderName);
+  let lastError = null;
+
+  for (const directory of petDirectories(codexHome)) {
+    try {
+      const avatar = await loadCustomAvatar(directory, folderName, { includeData: true });
+      if (avatar) {
+        return avatar;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+  throw petError("pet_not_found", "The selected Codex pet could not be found.");
+}
+
+function isPetMethod(method) {
+  return method === "pet/list"
+    || method === "custom-avatars"
+    || method === "pet/read"
+    || method === "custom-avatar/read";
+}
+
+// Mirrors Codex desktop's pets-first custom avatar lookup while keeping legacy avatars usable.
+function petDirectories(codexHome) {
+  return [
+    {
+      root: path.join(codexHome, "pets"),
+      manifestName: "pet.json",
+      kind: "pet",
+    },
+    {
+      root: path.join(codexHome, "avatars"),
+      manifestName: "avatar.json",
+      kind: "avatar",
+    },
+  ];
+}
+
+// Accept only a local package id/folder name; the spritesheet path is validated separately.
+function petFolderNameFromID(rawID) {
+  if (typeof rawID !== "string") {
+    throw petError("pet_id_invalid", "A pet id is required.");
+  }
+
+  const folderName = rawID.startsWith("custom:") ? rawID.slice("custom:".length) : rawID;
+  if (
+    !folderName
+    || folderName === "."
+    || folderName === ".."
+    || path.isAbsolute(folderName)
+    || folderName.includes("/")
+    || folderName.includes("\\")
+  ) {
+    throw petError("pet_id_invalid", "The selected pet id is invalid.");
+  }
+
+  return folderName;
+}
+
+async function loadPetDirectory(directory, { includeData }) {
+  const avatars = [];
+  const errors = [];
+  let entries = [];
+
+  try {
+    entries = await fs.promises.readdir(directory.root, { withFileTypes: true });
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      return { avatars, errors };
+    }
+    throw petError("pet_directory_unreadable", "Could not read local Codex pet folders.");
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    try {
+      const avatar = await loadCustomAvatar(directory, entry.name, { includeData });
+      if (avatar) {
+        avatars.push(avatar);
+      }
+    } catch (error) {
+      errors.push({
+        folderName: entry.name,
+        kind: directory.kind,
+        message: error.userMessage || error.message || "Invalid pet package.",
+        errorCode: error.errorCode || "invalid_pet",
+      });
+    }
+  }
+
+  return { avatars, errors };
+}
+
+async function loadCustomAvatar(directory, folderName, { includeData }) {
+  const petRoot = path.join(directory.root, folderName);
+  const manifestPath = path.join(petRoot, directory.manifestName);
+  const manifest = await readManifest(manifestPath);
+  if (!manifest) {
+    return null;
+  }
+
+  const spritesheetPath = resolveSpritesheetPath(
+    petRoot,
+    typeof manifest.spritesheetPath === "string" ? manifest.spritesheetPath : "spritesheet.webp"
+  );
+  const image = await readValidatedSpritesheet(spritesheetPath, { includeData });
+  const displayName = firstNonEmptyString([manifest.displayName, manifest.name, displayFromSlug(folderName)]);
+  const description = firstNonEmptyString([manifest.description]) || "A custom Codex pet.";
+
+  return {
+    id: `custom:${folderName}`,
+    folderName,
+    kind: directory.kind,
+    displayName,
+    description,
+    spritesheetPath,
+    spritesheetMimeType: image.mimeType,
+    spritesheetByteLength: image.byteLength,
+    spritesheetDataUrl: image.dataUrl,
+  };
+}
+
+async function readManifest(manifestPath) {
+  let contents;
+  try {
+    contents = await fs.promises.readFile(manifestPath, "utf8");
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      return null;
+    }
+    throw petError("pet_manifest_unreadable", "Could not read the pet manifest.");
+  }
+
+  try {
+    const manifest = JSON.parse(contents);
+    return manifest && typeof manifest === "object" ? manifest : {};
+  } catch {
+    throw petError("pet_manifest_invalid", "The pet manifest is not valid JSON.");
+  }
+}
+
+function resolveSpritesheetPath(petRoot, rawSpritesheetPath) {
+  const trimmedPath = rawSpritesheetPath.trim() || "spritesheet.webp";
+  if (path.isAbsolute(trimmedPath)) {
+    throw petError("pet_spritesheet_path_invalid", "Pet spritesheet paths must be relative.");
+  }
+
+  const candidate = path.resolve(petRoot, trimmedPath);
+  const relative = path.relative(petRoot, candidate);
+  if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw petError("pet_spritesheet_path_invalid", "Pet spritesheet paths cannot escape the pet folder.");
+  }
+
+  return candidate;
+}
+
+async function readValidatedSpritesheet(spritesheetPath, { includeData }) {
+  const extension = path.extname(spritesheetPath).toLowerCase();
+  const mimeType = IMAGE_MIME_TYPES_BY_EXTENSION.get(extension);
+  if (!mimeType) {
+    throw petError("pet_spritesheet_type_invalid", "Pet spritesheets must be PNG or WebP files.");
+  }
+
+  if (!includeData) {
+    return readValidatedSpritesheetMetadata(spritesheetPath, mimeType);
+  }
+
+  let data;
+  try {
+    data = await fs.promises.readFile(spritesheetPath);
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      throw petError("pet_spritesheet_missing", "The pet spritesheet file does not exist.");
+    }
+    throw petError("pet_spritesheet_unreadable", "Could not read the pet spritesheet file.");
+  }
+
+  const dimensions = imageDimensions(data, mimeType);
+  if (!dimensions || dimensions.width !== ATLAS_WIDTH || dimensions.height !== ATLAS_HEIGHT) {
+    throw petError("pet_spritesheet_dimensions_invalid", "Pet spritesheets must be exactly 1536x1872 pixels.");
+  }
+
+  return {
+    mimeType,
+    byteLength: data.byteLength,
+    dataUrl: includeData ? `data:${mimeType};base64,${data.toString("base64")}` : undefined,
+  };
+}
+
+async function readValidatedSpritesheetMetadata(spritesheetPath, mimeType) {
+  let file;
+  try {
+    file = await fs.promises.open(spritesheetPath, "r");
+    const stat = await file.stat();
+    const dimensions = await readImageDimensionsFromFile(file, mimeType, stat.size);
+    if (!dimensions || dimensions.width !== ATLAS_WIDTH || dimensions.height !== ATLAS_HEIGHT) {
+      throw petError("pet_spritesheet_dimensions_invalid", "Pet spritesheets must be exactly 1536x1872 pixels.");
+    }
+
+    return {
+      mimeType,
+      byteLength: stat.size,
+      dataUrl: undefined,
+    };
+  } catch (error) {
+    if (error && error.errorCode) {
+      throw error;
+    }
+    if (error && error.code === "ENOENT") {
+      throw petError("pet_spritesheet_missing", "The pet spritesheet file does not exist.");
+    }
+    throw petError("pet_spritesheet_unreadable", "Could not read the pet spritesheet file.");
+  } finally {
+    await file?.close();
+  }
+}
+
+async function readImageDimensionsFromFile(file, mimeType, fileSize) {
+  if (mimeType === "image/png") {
+    return pngDimensions(await readFileSlice(file, 0, 24));
+  }
+  if (mimeType === "image/webp") {
+    return readWebPDimensionsFromFile(file, fileSize);
+  }
+  return null;
+}
+
+async function readWebPDimensionsFromFile(file, fileSize) {
+  const riffHeader = await readFileSlice(file, 0, 12);
+  if (
+    riffHeader.length < 12
+    || riffHeader.toString("ascii", 0, 4) !== "RIFF"
+    || riffHeader.toString("ascii", 8, 12) !== "WEBP"
+  ) {
+    return null;
+  }
+
+  let offset = 12;
+  while (offset + 8 <= fileSize) {
+    const chunkHeader = await readFileSlice(file, offset, 8);
+    if (chunkHeader.length < 8) {
+      return null;
+    }
+
+    const chunkType = chunkHeader.toString("ascii", 0, 4);
+    const chunkSize = chunkHeader.readUInt32LE(4);
+    const payloadOffset = offset + 8;
+    if (payloadOffset + chunkSize > fileSize) {
+      return null;
+    }
+
+    const dimensionsPayloadLength = webpDimensionsPayloadLength(chunkType);
+    if (dimensionsPayloadLength > 0) {
+      const payload = await readFileSlice(file, payloadOffset, Math.min(chunkSize, dimensionsPayloadLength));
+      const chunkBuffer = Buffer.concat([chunkHeader, payload]);
+      const dimensions = webpChunkDimensions(chunkBuffer, chunkType, 8, chunkSize);
+      if (dimensions) {
+        return dimensions;
+      }
+    }
+
+    offset = payloadOffset + chunkSize + (chunkSize % 2);
+  }
+
+  return null;
+}
+
+function webpDimensionsPayloadLength(chunkType) {
+  if (chunkType === "VP8X") {
+    return 10;
+  }
+  if (chunkType === "VP8L") {
+    return 5;
+  }
+  if (chunkType === "VP8 ") {
+    return 10;
+  }
+  return 0;
+}
+
+async function readFileSlice(file, offset, length) {
+  const buffer = Buffer.alloc(length);
+  const { bytesRead } = await file.read(buffer, 0, length, offset);
+  return buffer.subarray(0, bytesRead);
+}
+
+function imageDimensions(data, mimeType) {
+  if (mimeType === "image/png") {
+    return pngDimensions(data);
+  }
+  if (mimeType === "image/webp") {
+    return webpDimensions(data);
+  }
+  return null;
+}
+
+function pngDimensions(data) {
+  if (data.length < 24 || data.readUInt32BE(0) !== 0x89504e47 || data.readUInt32BE(4) !== 0x0d0a1a0a) {
+    return null;
+  }
+  return {
+    width: data.readUInt32BE(16),
+    height: data.readUInt32BE(20),
+  };
+}
+
+function webpDimensions(data) {
+  if (
+    data.length < 30
+    || data.toString("ascii", 0, 4) !== "RIFF"
+    || data.toString("ascii", 8, 12) !== "WEBP"
+  ) {
+    return null;
+  }
+
+  let offset = 12;
+  while (offset + 8 <= data.length) {
+    const chunkType = data.toString("ascii", offset, offset + 4);
+    const chunkSize = data.readUInt32LE(offset + 4);
+    const payloadOffset = offset + 8;
+    if (payloadOffset + chunkSize > data.length) {
+      return null;
+    }
+
+    const dimensions = webpChunkDimensions(data, chunkType, payloadOffset, chunkSize);
+    if (dimensions) {
+      return dimensions;
+    }
+
+    offset = payloadOffset + chunkSize + (chunkSize % 2);
+  }
+
+  return null;
+}
+
+function webpChunkDimensions(data, chunkType, payloadOffset, chunkSize) {
+  if (chunkType === "VP8X" && chunkSize >= 10) {
+    return {
+      width: readUInt24LE(data, payloadOffset + 4) + 1,
+      height: readUInt24LE(data, payloadOffset + 7) + 1,
+    };
+  }
+
+  if (chunkType === "VP8L" && chunkSize >= 5 && data[payloadOffset] === 0x2f) {
+    const bits = data.readUInt32LE(payloadOffset + 1);
+    return {
+      width: (bits & 0x3fff) + 1,
+      height: ((bits >> 14) & 0x3fff) + 1,
+    };
+  }
+
+  if (chunkType === "VP8 " && chunkSize >= 10) {
+    const startCodeOffset = payloadOffset + 3;
+    if (
+      data[startCodeOffset] !== 0x9d
+      || data[startCodeOffset + 1] !== 0x01
+      || data[startCodeOffset + 2] !== 0x2a
+    ) {
+      return null;
+    }
+
+    return {
+      width: data.readUInt16LE(payloadOffset + 6) & 0x3fff,
+      height: data.readUInt16LE(payloadOffset + 8) & 0x3fff,
+    };
+  }
+
+  return null;
+}
+
+function readUInt24LE(data, offset) {
+  return data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16);
+}
+
+// Keeps ~/.codex/pets entries authoritative when legacy ~/.codex/avatars has the same folder.
+function mergeCustomAvatars(avatars) {
+  const byID = new Map();
+  for (const avatar of avatars) {
+    const existing = byID.get(avatar.id);
+    if (!existing || avatar.kind === "pet") {
+      byID.set(avatar.id, avatar);
+    }
+  }
+  return Array.from(byID.values()).sort((left, right) => left.displayName.localeCompare(right.displayName));
+}
+
+function firstNonEmptyString(candidates) {
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") {
+      continue;
+    }
+    const trimmed = candidate.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return null;
+}
+
+function displayFromSlug(slug) {
+  return slug
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((word) => word.slice(0, 1).toUpperCase() + word.slice(1))
+    .join(" ") || slug;
+}
+
+function petError(errorCode, userMessage) {
+  const error = new Error(userMessage);
+  error.errorCode = errorCode;
+  error.userMessage = userMessage;
+  return error;
+}
+
+module.exports = {
+  handlePetMethod,
+  handlePetRequest,
+  imageDimensions,
+};

--- a/phodex-bridge/test/pet-handler.test.js
+++ b/phodex-bridge/test/pet-handler.test.js
@@ -84,6 +84,17 @@ test("pet/read rejects unsafe pet ids", async () => {
   );
 });
 
+test("pet/read rejects valid-dimension spritesheets that are too large", async () => {
+  const home = makeTempCodexHome();
+  process.env.CODEX_HOME = home;
+  writePetPackage(home, "too-large", { displayName: "Too Large" }, 16 * 1024 * 1024 + 1);
+
+  await assert.rejects(
+    () => handlePetMethod("pet/read", { id: "custom:too-large" }),
+    { errorCode: "pet_spritesheet_too_large" }
+  );
+});
+
 test("pet/read falls back to a legacy avatar when the matching pet is invalid", async () => {
   const home = makeTempCodexHome();
   process.env.CODEX_HOME = home;
@@ -122,7 +133,7 @@ function makeTempCodexHome() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "remodex-pets-"));
 }
 
-function writePetPackage(home, slug, manifest) {
+function writePetPackage(home, slug, manifest, spritesheetByteLength) {
   const root = path.join(home, "pets", slug);
   fs.mkdirSync(root, { recursive: true });
   fs.writeFileSync(
@@ -135,7 +146,7 @@ function writePetPackage(home, slug, manifest) {
       ...manifest,
     })
   );
-  fs.writeFileSync(path.join(root, "spritesheet.png"), fakePngHeader(1536, 1872));
+  fs.writeFileSync(path.join(root, "spritesheet.png"), fakePngData(1536, 1872, spritesheetByteLength));
 }
 
 function writeAvatarPackage(home, slug, manifest) {
@@ -151,11 +162,11 @@ function writeAvatarPackage(home, slug, manifest) {
       ...manifest,
     })
   );
-  fs.writeFileSync(path.join(root, "spritesheet.png"), fakePngHeader(1536, 1872));
+  fs.writeFileSync(path.join(root, "spritesheet.png"), fakePngData(1536, 1872));
 }
 
-function fakePngHeader(width, height) {
-  const data = Buffer.alloc(33);
+function fakePngData(width, height, byteLength = 33) {
+  const data = Buffer.alloc(byteLength);
   data.writeUInt32BE(0x89504e47, 0);
   data.writeUInt32BE(0x0d0a1a0a, 4);
   data.writeUInt32BE(13, 8);

--- a/phodex-bridge/test/pet-handler.test.js
+++ b/phodex-bridge/test/pet-handler.test.js
@@ -1,0 +1,168 @@
+// FILE: pet-handler.test.js
+// Purpose: Verifies local Codex pet package discovery and safety validation.
+// Layer: Test
+// Exports: node:test cases
+// Depends on: node:test, fs, os, path, ../src/pet-handler
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { handlePetMethod } = require("../src/pet-handler");
+
+test("pet/list returns valid custom Codex pets as data URLs", async () => {
+  const home = makeTempCodexHome();
+  process.env.CODEX_HOME = home;
+  writePetPackage(home, "icarus", {
+    displayName: "Icarus",
+    description: "A winged local pet.",
+  });
+
+  const result = await handlePetMethod("pet/list", {});
+
+  assert.equal(result.avatars.length, 1);
+  assert.equal(result.avatars[0].id, "custom:icarus");
+  assert.equal(result.avatars[0].displayName, "Icarus");
+  assert.match(result.avatars[0].spritesheetDataUrl, /^data:image\/png;base64,/);
+  assert.equal(result.errors.length, 0);
+});
+
+test("pet/list reports invalid packages without failing the whole list", async () => {
+  const home = makeTempCodexHome();
+  process.env.CODEX_HOME = home;
+  writePetPackage(home, "good-one", { displayName: "Good One" });
+
+  const badRoot = path.join(home, "pets", "bad-one");
+  fs.mkdirSync(badRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(badRoot, "pet.json"),
+    JSON.stringify({ displayName: "Bad One", spritesheetPath: "../escape.webp" })
+  );
+
+  const result = await handlePetMethod("pet/list", {});
+
+  assert.equal(result.avatars.length, 1);
+  assert.equal(result.avatars[0].id, "custom:good-one");
+  assert.equal(result.errors.length, 1);
+  assert.equal(result.errors[0].errorCode, "pet_spritesheet_path_invalid");
+});
+
+test("pet/list can return metadata without embedding spritesheet data", async () => {
+  const home = makeTempCodexHome();
+  process.env.CODEX_HOME = home;
+  writePetPackage(home, "metadata-only", { displayName: "Metadata Only" });
+
+  const result = await handlePetMethod("pet/list", { metadataOnly: true });
+
+  assert.equal(result.avatars.length, 1);
+  assert.equal(result.avatars[0].id, "custom:metadata-only");
+  assert.equal(result.avatars[0].spritesheetDataUrl, undefined);
+  assert.equal(result.avatars[0].spritesheetMimeType, "image/png");
+});
+
+test("pet/read returns spritesheet data for one selected pet", async () => {
+  const home = makeTempCodexHome();
+  process.env.CODEX_HOME = home;
+  writePetPackage(home, "selected-one", { displayName: "Selected One" });
+  writePetPackage(home, "other-one", { displayName: "Other One" });
+
+  const result = await handlePetMethod("pet/read", { id: "custom:selected-one" });
+
+  assert.equal(result.id, "custom:selected-one");
+  assert.equal(result.displayName, "Selected One");
+  assert.match(result.spritesheetDataUrl, /^data:image\/png;base64,/);
+});
+
+test("pet/read rejects unsafe pet ids", async () => {
+  const home = makeTempCodexHome();
+  process.env.CODEX_HOME = home;
+
+  await assert.rejects(
+    () => handlePetMethod("pet/read", { id: "custom:../escape" }),
+    { errorCode: "pet_id_invalid" }
+  );
+});
+
+test("pet/read falls back to a legacy avatar when the matching pet is invalid", async () => {
+  const home = makeTempCodexHome();
+  process.env.CODEX_HOME = home;
+
+  const badRoot = path.join(home, "pets", "same-name");
+  fs.mkdirSync(badRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(badRoot, "pet.json"),
+    JSON.stringify({ displayName: "Broken Pet", spritesheetPath: "../escape.webp" })
+  );
+  writeAvatarPackage(home, "same-name", { displayName: "Legacy Avatar" });
+
+  const result = await handlePetMethod("pet/read", { id: "custom:same-name" });
+
+  assert.equal(result.id, "custom:same-name");
+  assert.equal(result.kind, "avatar");
+  assert.equal(result.displayName, "Legacy Avatar");
+  assert.match(result.spritesheetDataUrl, /^data:image\/png;base64,/);
+});
+
+test("pet/list prefers pets over legacy avatars with the same folder name", async () => {
+  const home = makeTempCodexHome();
+  process.env.CODEX_HOME = home;
+  writePetPackage(home, "same-name", { displayName: "Modern Pet" });
+  writeAvatarPackage(home, "same-name", { displayName: "Legacy Avatar" });
+
+  const result = await handlePetMethod("pet/list", { metadataOnly: true });
+
+  assert.equal(result.avatars.length, 1);
+  assert.equal(result.avatars[0].id, "custom:same-name");
+  assert.equal(result.avatars[0].displayName, "Modern Pet");
+  assert.equal(result.avatars[0].kind, "pet");
+});
+
+function makeTempCodexHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "remodex-pets-"));
+}
+
+function writePetPackage(home, slug, manifest) {
+  const root = path.join(home, "pets", slug);
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "pet.json"),
+    JSON.stringify({
+      id: slug,
+      displayName: slug,
+      description: "A test pet.",
+      spritesheetPath: "spritesheet.png",
+      ...manifest,
+    })
+  );
+  fs.writeFileSync(path.join(root, "spritesheet.png"), fakePngHeader(1536, 1872));
+}
+
+function writeAvatarPackage(home, slug, manifest) {
+  const root = path.join(home, "avatars", slug);
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "avatar.json"),
+    JSON.stringify({
+      id: slug,
+      displayName: slug,
+      description: "A test avatar.",
+      spritesheetPath: "spritesheet.png",
+      ...manifest,
+    })
+  );
+  fs.writeFileSync(path.join(root, "spritesheet.png"), fakePngHeader(1536, 1872));
+}
+
+function fakePngHeader(width, height) {
+  const data = Buffer.alloc(33);
+  data.writeUInt32BE(0x89504e47, 0);
+  data.writeUInt32BE(0x0d0a1a0a, 4);
+  data.writeUInt32BE(13, 8);
+  data.write("IHDR", 12, "ascii");
+  data.writeUInt32BE(width, 16);
+  data.writeUInt32BE(height, 20);
+  data[24] = 8;
+  data[25] = 6;
+  return data;
+}


### PR DESCRIPTION
## Summary
- Added a new local pet companion system in the mobile app, including persisted selection/position state, status tracking, and a draggable overlay UI.
- Wired the overlay into the main app shell and settings so users can enable the pet, choose an available companion, and keep it positioned locally.
- Extended the bridge with pet list/read handlers and status synthesis so the mobile overlay can reflect active work, approvals, failures, and completion states.
- Added bridge-side tests covering the pet handler behavior.

## Testing
- Not run (not requested).
- Bridge logic covered by `phodex-bridge/test/pet-handler.test.js`.
- Mobile UI/state integration not run in simulator or Xcode tests.