### PR TITLE
Add local relay URL override

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,18 @@ This launcher:
 3. Points the bridge at that relay
 4. Prints a QR code in your terminal for the initial trust bootstrap
 
+For a temporary public tunnel to that local relay, start the tunnel in one terminal:
+
+```sh
+cloudflared tunnel --url http://127.0.0.1:9000
+```
+
+Then pass the generated URL to the launcher in another terminal:
+
+```sh
+./run-local-remodex.sh --relay-url https://<random>.trycloudflare.com
+```
+
 If you only want the bridge process:
 
 ```sh
@@ -100,7 +112,7 @@ The app uses SwiftUI and the current project target is iOS 18.6. No CocoaPods or
 
 ### Environment variables
 
-For OSS/local development, prefer the launcher above. If you want to point the bridge at your own relay manually, export `REMODEX_RELAY` in your shell:
+For OSS/local development, prefer the launcher above. If you want to point the bridge process at your own relay manually without the launcher, export `REMODEX_RELAY` in your shell:
 
 ```sh
 # Connect to an existing Codex instance instead of spawning one
@@ -160,6 +172,6 @@ remodex/
 
 - The first QR pairing is possession-based: it contains the relay URL and a live session ID.
 - After that first handshake, the iPhone stores a trusted Mac record and can ask the relay for the Mac's current live session again.
-- Set `REMODEX_RELAY` to a relay you control when you are not using the local launcher. Use `wss://` when you want TLS in transit.
+- Set `REMODEX_RELAY` to a relay you control when you are not using the local launcher, or pass the relay URL to the launcher with `--relay-url`. Use `wss://` when you want TLS in transit.
 - Remodex uses an authenticated end-to-end encrypted transport after pairing completes. The relay code is public for inspection, but deployed relay details should stay in private config.
 - The built-in daemon / background service path is currently macOS-only. Linux and Windows can still run the bridge, but contributors should treat the daemon logic as platform-specific.

--- a/Docs/self-hosting.md
+++ b/Docs/self-hosting.md
@@ -13,7 +13,7 @@ The public source tree is local-first and self-host friendly:
 
 - there is no public production relay baked into the GitHub source
 - local pairing should work out of the box with `./run-local-remodex.sh`
-- internet-facing setups should pass their own relay URL explicitly with `REMODEX_RELAY`
+- internet-facing manual bridge setups should pass their own relay URL explicitly with `REMODEX_RELAY`; source-checkout launcher setups can pass it with `./run-local-remodex.sh --relay-url`
 - the first QR scan bootstraps trust, then later reconnects can reuse the same trusted Mac through that relay
 - the built-in background daemon for trusted reconnect is currently macOS-only
 
@@ -71,6 +71,22 @@ Pass a hostname or IP address that the phone can actually reach:
 ```sh
 ./run-local-remodex.sh --hostname 192.168.1.10
 ```
+
+If you are using a tunnel or reverse proxy in front of the local relay, pass the public URL instead of a LAN hostname.
+
+For example, with a temporary Cloudflare Tunnel, run this in one terminal:
+
+```sh
+cloudflared tunnel --url http://127.0.0.1:9000
+```
+
+Copy the generated `https://<random>.trycloudflare.com` URL, then start Remodex in another terminal:
+
+```sh
+./run-local-remodex.sh --relay-url https://<random>.trycloudflare.com
+```
+
+The launcher accepts `http://` or `https://` tunnel URLs, converts them to `ws://` or `wss://`, and appends `/relay` when the URL has no path.
 
 ### Health check
 
@@ -153,6 +169,12 @@ On the Mac that runs the bridge:
 
 ```sh
 REMODEX_RELAY="wss://relay.example.com/relay" remodex up
+```
+
+If you are running the source-checkout launcher behind a tunnel or reverse proxy that forwards to the local relay, pass that public URL directly to the launcher:
+
+```sh
+./run-local-remodex.sh --relay-url https://<random>.trycloudflare.com
 ```
 
 Or, if you are running from source:

--- a/README.md
+++ b/README.md
@@ -143,16 +143,31 @@ cd remodex
 ./run-local-remodex.sh
 ```
 
-That launcher starts a local relay, points the bridge at `ws://<your-host>:9000/relay`, and prints the pairing QR for the iPhone app.
+That launcher starts a local relay, points the bridge at `ws://<your-host>:9000/relay` by default, and prints the pairing QR for the iPhone app.
 
 For iPhone self-hosting, the recommended path is Tailscale or another stable private network. Plain LAN pairing over `ws://<lan-ip>` on the same Wi-Fi is still available for local testing, but it can be unreliable on some iOS devices even when the relay and Wi-Fi are healthy.
 
 Options:
 
 - `./run-local-remodex.sh --hostname <lan-hostname-or-ip>`
+- `./run-local-remodex.sh --relay-url https://<random>.trycloudflare.com`
 - `./run-local-remodex.sh --bind-host 127.0.0.1 --port 9100`
 
 If your iPhone is pairing over LAN, use a hostname or IP the phone can actually reach.
+
+For a temporary Cloudflare Tunnel, run this in one terminal:
+
+```sh
+cloudflared tunnel --url http://127.0.0.1:9000
+```
+
+Then pass the generated `https://<random>.trycloudflare.com` URL to the local launcher in another terminal:
+
+```sh
+./run-local-remodex.sh --relay-url https://<random>.trycloudflare.com
+```
+
+The launcher advertises that as `wss://<random>.trycloudflare.com/relay` in the pairing QR while keeping the relay process local.
 
 ## Custom Relay Endpoint
 

--- a/run-local-remodex.sh
+++ b/run-local-remodex.sh
@@ -16,6 +16,7 @@ RELAY_SERVER_MODULE="${RELAY_DIR}/server.js"
 RELAY_BIND_HOST="${RELAY_BIND_HOST:-0.0.0.0}"
 RELAY_PORT="${RELAY_PORT:-9000}"
 RELAY_HOSTNAME="${RELAY_HOSTNAME:-}"
+RELAY_URL="${RELAY_URL:-}"
 RELAY_BRIDGE_HOST=""
 RELAY_PID=""
 BRIDGE_PID=""
@@ -35,6 +36,7 @@ Usage: ./run-local-remodex.sh [options]
 
 Options:
   --hostname HOSTNAME   Hostname or IP the iPhone should use to reach the relay
+  --relay-url URL       Full relay URL to advertise, for tunnels or reverse proxies
   --bind-host HOST      Interface/address the local relay should listen on
   --port PORT           Relay port to listen on
   --help                Show this help text
@@ -43,6 +45,7 @@ Defaults:
   --bind-host           0.0.0.0
   --port                9000
   --hostname            macOS LocalHostName.local, then hostname, then localhost
+  --relay-url           auto-built as ws://<hostname>:<port>/relay
 EOF
 }
 
@@ -58,6 +61,11 @@ parse_args() {
       --hostname)
         require_value "--hostname" "$#"
         RELAY_HOSTNAME="$2"
+        shift 2
+        ;;
+      --relay-url)
+        require_value "--relay-url" "$#"
+        RELAY_URL="$2"
         shift 2
         ;;
       --bind-host)
@@ -157,6 +165,69 @@ ensure_prerequisites() {
   require_command npm
   require_command curl
   ensure_node_version
+}
+
+validate_hostname_argument() {
+  local hostname="$1"
+  [[ -n "${hostname}" ]] || die "Hostname cannot be empty."
+
+  # Expect just a host/IP value. A URL cannot be converted into a valid
+  # ws:// relay endpoint by this local-only helper.
+  if [[ "${hostname}" == *"://"* ]] || [[ "${hostname}" == */* ]]; then
+    die "Invalid --hostname '${hostname}'. Pass only a LAN hostname or IP address (for example: --hostname 192.168.1.101)."
+  fi
+}
+
+normalize_relay_url() {
+  local raw_url="$1"
+
+  node -e '
+const rawUrl = process.argv[1];
+
+try {
+  const url = new URL(rawUrl);
+  if (url.username || url.password) {
+    throw new Error("credentials are not supported in relay URLs");
+  }
+  if (url.search || url.hash) {
+    throw new Error("query strings and fragments are not supported in relay URLs");
+  }
+
+  switch (url.protocol) {
+    case "ws:":
+    case "wss:":
+      break;
+    case "http:":
+      url.protocol = "ws:";
+      break;
+    case "https:":
+      url.protocol = "wss:";
+      break;
+    default:
+      throw new Error("expected ws://, wss://, http://, or https://");
+  }
+
+  if (url.pathname === "" || url.pathname === "/") {
+    url.pathname = "/relay";
+  }
+
+  console.log(url.toString());
+} catch (error) {
+  console.error((error && error.message) || "invalid URL");
+  process.exit(1);
+}
+' "${raw_url}"
+}
+
+configure_relay_url() {
+  if [[ -n "${RELAY_URL}" ]]; then
+    RELAY_URL="$(normalize_relay_url "${RELAY_URL}")" || die "Invalid --relay-url '${RELAY_URL}'. Pass ws(s)://.../relay, or paste an http(s) tunnel URL."
+    return
+  fi
+
+  validate_hostname_argument "${RELAY_HOSTNAME}"
+  ensure_hostname_belongs_to_this_mac
+  RELAY_URL="ws://${RELAY_HOSTNAME}:${RELAY_PORT}/relay"
 }
 
 # Validates the advertised host before boot so the QR cannot point at another machine by mistake.
@@ -289,7 +360,7 @@ print_summary() {
   Relay port      : ${RELAY_PORT}
   Relay hostname  : ${RELAY_HOSTNAME}
   Bridge host     : ${RELAY_BRIDGE_HOST}
-  Relay URL       : ws://${RELAY_HOSTNAME}:${RELAY_PORT}/relay
+  Relay URL       : ${RELAY_URL}
 EOF
 }
 
@@ -299,7 +370,7 @@ start_bridge() {
   # This local helper should print the QR in the current terminal immediately.
   # Use the foreground bridge path instead of the macOS launchd wrapper so QR
   # rendering does not depend on daemon state being written back first.
-  REMODEX_RELAY="ws://${RELAY_HOSTNAME}:${RELAY_PORT}/relay" node ./bin/remodex.js run &
+  REMODEX_RELAY="${RELAY_URL}" node ./bin/remodex.js run &
   BRIDGE_PID=$!
 }
 
@@ -330,7 +401,7 @@ RELAY_BRIDGE_HOST="$(healthcheck_host)"
 ensure_prerequisites
 ensure_package_dependencies "${BRIDGE_DIR}"
 ensure_package_dependencies "${RELAY_DIR}"
-ensure_hostname_belongs_to_this_mac
+configure_relay_url
 ensure_port_available
 print_summary
 start_embedded_relay


### PR DESCRIPTION
## Summary

- add `--relay-url` to `run-local-remodex.sh` for tunnel and reverse-proxy workflows
- normalize `http(s)://` relay URLs to `ws(s)://` and append `/relay` when no path is provided
- keep LAN hostname validation on the default `--hostname` path
- document the Cloudflare Tunnel flow using `cloudflared tunnel --url http://127.0.0.1:9000` plus `./run-local-remodex.sh --relay-url https://<random>.trycloudflare.com`

## Validation

- `bash -n run-local-remodex.sh`
- `./run-local-remodex.sh --help`
- `git diff --check`
