### PR TITLE
Fix large turns list relay loading

### DIFF
--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -63,7 +63,24 @@ const RELAY_HISTORY_IMAGE_REFERENCE_URL = "remodex://history-image-elided";
 const RELAY_THREAD_PAYLOAD_SOFT_LIMIT_BYTES = 4 * 1024 * 1024;
 const RELAY_HISTORY_TEXT_TAIL_LIMIT_CHARS = 24_000;
 const RELAY_HISTORY_RECENT_TURN_TARGET = 40;
-const RELAY_TURNS_LIST_FORWARD_LIMIT = 5;
+const RELAY_TURNS_LIST_TARGET_BUDGET_MS = 5_500;
+const RELAY_TURNS_LIST_BUDGET_RESERVE_MS = 1_000;
+const RELAY_TURNS_LIST_RESULT_KEYS = ["data", "items", "turns"];
+const RELAY_TURNS_LIST_PAGINATION_RESULT_KEYS = [
+  "nextCursor",
+  "next_cursor",
+  "cursor",
+  "hasNextCursor",
+  "has_next_cursor",
+  "hasNextPage",
+  "has_next_page",
+  "hasMore",
+  "has_more",
+  "prevCursor",
+  "prev_cursor",
+  "previousCursor",
+  "previous_cursor",
+];
 function startBridge({
   config: explicitConfig = null,
   printPairingQr = true,
@@ -546,10 +563,12 @@ function startBridge({
     if (desktopIpcActionFollower?.observeInbound(rawMessage)) {
       return;
     }
-    const forwardedMessage = clampRelayThreadTurnsListRequest(rawMessage);
-    rememberForwardedRequestMethod(forwardedMessage);
-    rememberThreadFromMessage("phone", forwardedMessage);
-    codex.send(forwardedMessage);
+    if (handleBridgeManagedThreadTurnsListRequest(rawMessage)) {
+      return;
+    }
+    rememberForwardedRequestMethod(rawMessage);
+    rememberThreadFromMessage("phone", rawMessage);
+    codex.send(rawMessage);
   }
 
   // Encrypts bridge-generated responses instead of letting the relay see plaintext.
@@ -577,6 +596,35 @@ function startBridge({
         title: name,
       },
     }));
+  }
+
+  function handleBridgeManagedThreadTurnsListRequest(rawMessage) {
+    const request = parseAdaptiveThreadTurnsListRequest(rawMessage);
+    if (!request) {
+      return false;
+    }
+
+    rememberThreadFromMessage("phone", rawMessage);
+    (async () => {
+      try {
+        const response = await fetchAdaptiveThreadTurnsListForRelay(request, {
+          fetchPage: (params) => sendCodexRequest("thread/turns/list", params),
+        });
+        relaySanitizedResponseMethodsById.set(String(request.id), {
+          method: "thread/turns/list",
+          createdAt: Date.now(),
+        });
+        sendApplicationResponse(JSON.stringify(response));
+      } catch (error) {
+        sendApplicationResponse(createJsonRpcErrorResponse(
+          request.id,
+          error,
+          "thread_turns_list_failed"
+        ));
+      }
+    })();
+
+    return true;
   }
 
   // ─── Bridge-owned auth snapshot ─────────────────────────────
@@ -1378,32 +1426,219 @@ function normalizeNonEmptyString(value) {
   return typeof value === "string" && value.trim() ? value.trim() : "";
 }
 
-function clampRelayThreadTurnsListRequest(rawMessage) {
+function parseAdaptiveThreadTurnsListRequest(rawMessage) {
   const parsed = parseBridgeJSON(rawMessage);
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return rawMessage;
+    return null;
   }
 
   if (parsed.method !== "thread/turns/list") {
-    return rawMessage;
+    return null;
+  }
+
+  if (parsed.id == null) {
+    return null;
   }
 
   const params = parsed.params;
   if (!params || typeof params !== "object" || Array.isArray(params)) {
-    return rawMessage;
+    return null;
   }
 
-  if (!Number.isInteger(params.limit) || params.limit <= RELAY_TURNS_LIST_FORWARD_LIMIT) {
-    return rawMessage;
+  if (!Number.isInteger(params.limit) || params.limit <= 0) {
+    return null;
   }
 
-  return JSON.stringify({
-    ...parsed,
-    params: {
-      ...params,
-      limit: RELAY_TURNS_LIST_FORWARD_LIMIT,
+  return parsed;
+}
+
+async function fetchAdaptiveThreadTurnsListForRelay(request, {
+  fetchPage,
+  now = Date.now,
+  targetBudgetMs = RELAY_TURNS_LIST_TARGET_BUDGET_MS,
+  budgetReserveMs = RELAY_TURNS_LIST_BUDGET_RESERVE_MS,
+  rawPageSoftLimitBytes = RELAY_THREAD_PAYLOAD_SOFT_LIMIT_BYTES,
+  payloadSoftLimitBytes = RELAY_THREAD_PAYLOAD_SOFT_LIMIT_BYTES,
+  sanitizeForRelay = sanitizeThreadHistoryImagesForRelay,
+} = {}) {
+  if (typeof fetchPage !== "function") {
+    throw new Error("fetchPage is required for adaptive turns-list pagination.");
+  }
+
+  const params = request?.params;
+  const requestedLimit = Number.isInteger(params?.limit) && params.limit > 0
+    ? params.limit
+    : 1;
+  const startedAt = now();
+  let nextCursor = params?.cursor;
+  let turnsKey = null;
+  let firstResult = null;
+  let lastResult = null;
+  let combinedTurns = [];
+  let response = null;
+
+  while (combinedTurns.length < requestedLimit) {
+    const remaining = requestedLimit - combinedTurns.length;
+    const pageLimit = selectAdaptiveTurnsListBatchLimit(combinedTurns.length, remaining);
+    const pageParams = buildAdaptiveTurnsListPageParams(params, pageLimit, nextCursor);
+    let page;
+
+    try {
+      page = await fetchMeasuredAdaptiveTurnsListPage(fetchPage, pageParams, now);
+    } catch (error) {
+      if (response) {
+        return response;
+      }
+      throw error;
+    }
+
+    const pageResult = page.result;
+    const pageTurnsKey = findTurnsListResultKey(pageResult);
+    if (!pageTurnsKey) {
+      if (!response) {
+        return {
+          id: request.id,
+          result: pageResult ?? null,
+        };
+      }
+      return response;
+    }
+
+    if (!turnsKey) {
+      turnsKey = pageTurnsKey;
+    }
+    if (!firstResult) {
+      firstResult = pageResult;
+    }
+    lastResult = pageResult;
+
+    const pageTurns = pageResult[pageTurnsKey];
+    combinedTurns = combinedTurns.concat(pageTurns);
+    response = {
+      id: request.id,
+      result: buildAdaptiveTurnsListResult(firstResult, lastResult, turnsKey, combinedTurns),
+    };
+
+    nextCursor = readTurnsListNextCursor(pageResult);
+    if (combinedTurns.length >= requestedLimit || !hasRelayCursor(nextCursor) || pageTurns.length === 0) {
+      break;
+    }
+
+    const rawPageBytes = jsonByteLength(pageResult);
+    const sanitizedResponseBytes = measureSanitizedTurnsListResponseBytes(response, sanitizeForRelay);
+    const elapsedMs = Math.max(0, now() - startedAt);
+    const remainingBudgetMs = Math.max(0, targetBudgetMs - elapsedMs);
+    if (
+      rawPageBytes >= rawPageSoftLimitBytes
+      || sanitizedResponseBytes >= payloadSoftLimitBytes
+      || page.elapsedMs >= Math.max(0, targetBudgetMs - budgetReserveMs)
+      || remainingBudgetMs <= budgetReserveMs
+    ) {
+      break;
+    }
+  }
+
+  return response ?? {
+    id: request.id,
+    result: {
+      data: [],
     },
-  });
+  };
+}
+
+async function fetchMeasuredAdaptiveTurnsListPage(fetchPage, params, now) {
+  const startedAt = now();
+  const result = await fetchPage(params);
+  const elapsedMs = Math.max(0, now() - startedAt);
+  return {
+    result,
+    elapsedMs,
+  };
+}
+
+function selectAdaptiveTurnsListBatchLimit(fetchedTurnCount, remainingTurnCount) {
+  if (fetchedTurnCount <= 0) {
+    return Math.min(1, remainingTurnCount);
+  }
+  if (fetchedTurnCount <= 1) {
+    return Math.min(4, remainingTurnCount);
+  }
+  return remainingTurnCount;
+}
+
+function buildAdaptiveTurnsListPageParams(baseParams, limit, cursor) {
+  const params = {
+    ...baseParams,
+    limit,
+  };
+  if (hasRelayCursor(cursor)) {
+    params.cursor = cursor;
+  } else {
+    delete params.cursor;
+  }
+  return params;
+}
+
+function findTurnsListResultKey(result) {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return null;
+  }
+  return RELAY_TURNS_LIST_RESULT_KEYS.find((key) => Array.isArray(result[key])) || null;
+}
+
+function buildAdaptiveTurnsListResult(firstResult, lastResult, turnsKey, turns) {
+  const result = {
+    ...firstResult,
+  };
+  for (const key of RELAY_TURNS_LIST_RESULT_KEYS) {
+    delete result[key];
+  }
+  result[turnsKey] = turns;
+
+  for (const key of RELAY_TURNS_LIST_PAGINATION_RESULT_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(lastResult, key)) {
+      result[key] = lastResult[key];
+    } else {
+      delete result[key];
+    }
+  }
+
+  return result;
+}
+
+function readTurnsListNextCursor(result) {
+  if (!result || typeof result !== "object") {
+    return undefined;
+  }
+  if (hasRelayCursor(result.nextCursor)) {
+    return result.nextCursor;
+  }
+  if (hasRelayCursor(result.next_cursor)) {
+    return result.next_cursor;
+  }
+  return undefined;
+}
+
+function hasRelayCursor(cursor) {
+  return cursor !== undefined && cursor !== null && cursor !== "";
+}
+
+function jsonByteLength(value) {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), "utf8");
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+function measureSanitizedTurnsListResponseBytes(response, sanitizeForRelay) {
+  try {
+    const rawResponse = JSON.stringify(response);
+    const sanitizedResponse = sanitizeForRelay(rawResponse, "thread/turns/list");
+    return Buffer.byteLength(sanitizedResponse, "utf8");
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
 }
 
 // Shrinks thread history snapshots/pages for mobile relay delivery.
@@ -2228,8 +2463,8 @@ function persistBridgePreferences(
 
 module.exports = {
   buildHeartbeatBridgeStatus,
-  clampRelayThreadTurnsListRequest,
   createMacOSBridgeWakeAssertion,
+  fetchAdaptiveThreadTurnsListForRelay,
   hasRelayConnectionGoneStale,
   persistBridgePreferences,
   sanitizeLiveGeneratedImageMessageForRelay,

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -63,6 +63,7 @@ const RELAY_HISTORY_IMAGE_REFERENCE_URL = "remodex://history-image-elided";
 const RELAY_THREAD_PAYLOAD_SOFT_LIMIT_BYTES = 4 * 1024 * 1024;
 const RELAY_HISTORY_TEXT_TAIL_LIMIT_CHARS = 24_000;
 const RELAY_HISTORY_RECENT_TURN_TARGET = 40;
+const RELAY_TURNS_LIST_FORWARD_LIMIT = 5;
 function startBridge({
   config: explicitConfig = null,
   printPairingQr = true,
@@ -545,9 +546,10 @@ function startBridge({
     if (desktopIpcActionFollower?.observeInbound(rawMessage)) {
       return;
     }
-    rememberForwardedRequestMethod(rawMessage);
-    rememberThreadFromMessage("phone", rawMessage);
-    codex.send(rawMessage);
+    const forwardedMessage = clampRelayThreadTurnsListRequest(rawMessage);
+    rememberForwardedRequestMethod(forwardedMessage);
+    rememberThreadFromMessage("phone", forwardedMessage);
+    codex.send(forwardedMessage);
   }
 
   // Encrypts bridge-generated responses instead of letting the relay see plaintext.
@@ -1376,6 +1378,34 @@ function normalizeNonEmptyString(value) {
   return typeof value === "string" && value.trim() ? value.trim() : "";
 }
 
+function clampRelayThreadTurnsListRequest(rawMessage) {
+  const parsed = parseBridgeJSON(rawMessage);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return rawMessage;
+  }
+
+  if (parsed.method !== "thread/turns/list") {
+    return rawMessage;
+  }
+
+  const params = parsed.params;
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return rawMessage;
+  }
+
+  if (!Number.isInteger(params.limit) || params.limit <= RELAY_TURNS_LIST_FORWARD_LIMIT) {
+    return rawMessage;
+  }
+
+  return JSON.stringify({
+    ...parsed,
+    params: {
+      ...params,
+      limit: RELAY_TURNS_LIST_FORWARD_LIMIT,
+    },
+  });
+}
+
 // Shrinks thread history snapshots/pages for mobile relay delivery.
 // This elides bulky blobs and replaces oversized older history with a compact marker.
 function sanitizeThreadHistoryImagesForRelay(rawMessage, requestMethod) {
@@ -1933,6 +1963,7 @@ function trimTurnsListPayloadForRelay(parsed, turnsKey, originalRawMessage = nul
     return originalRawMessage ?? encoded;
   }
 
+  let fallbackCompactedPayload = null;
   for (const maxChars of [
     RELAY_HISTORY_TEXT_TAIL_LIMIT_CHARS,
     Math.floor(RELAY_HISTORY_TEXT_TAIL_LIMIT_CHARS / 4),
@@ -1948,20 +1979,13 @@ function trimTurnsListPayloadForRelay(parsed, turnsKey, originalRawMessage = nul
         remodexPageCompactedForRelay: true,
       },
     });
+    fallbackCompactedPayload = compactedPayload;
     if (Buffer.byteLength(compactedPayload, "utf8") <= RELAY_THREAD_PAYLOAD_SOFT_LIMIT_BYTES) {
       return compactedPayload;
     }
   }
 
-  const markerTurn = buildRelayHistoryCompactionTurn(turns.length, 0, turns[0]);
-  return JSON.stringify({
-    ...parsed,
-    result: {
-      ...result,
-      [turnsKey]: markerTurn ? [markerTurn] : [],
-      remodexPageCompactedForRelay: true,
-    },
-  });
+  return fallbackCompactedPayload ?? (originalRawMessage ?? encoded);
 }
 
 function compactTurnsListTurnForRelay(turn, maxChars) {
@@ -2103,7 +2127,7 @@ function compactHistoryItemForRelay(item, maxChars) {
     itemId: typeof item?.itemId === "string" ? item.itemId : undefined,
     relayPayloadTruncated: true,
   };
-  const tailText = firstRelayTextTail(item, maxChars);
+  const tailText = maxChars > 0 ? firstRelayTextTail(item, maxChars) : "";
   if (tailText) {
     compactItem.text = tailText;
   }
@@ -2204,6 +2228,7 @@ function persistBridgePreferences(
 
 module.exports = {
   buildHeartbeatBridgeStatus,
+  clampRelayThreadTurnsListRequest,
   createMacOSBridgeWakeAssertion,
   hasRelayConnectionGoneStale,
   persistBridgePreferences,

--- a/phodex-bridge/test/bridge.test.js
+++ b/phodex-bridge/test/bridge.test.js
@@ -11,8 +11,8 @@ const os = require("node:os");
 const path = require("node:path");
 const {
   buildHeartbeatBridgeStatus,
-  clampRelayThreadTurnsListRequest,
   createMacOSBridgeWakeAssertion,
+  fetchAdaptiveThreadTurnsListForRelay,
   hasRelayConnectionGoneStale,
   persistBridgePreferences,
   sanitizeLiveGeneratedImageMessageForRelay,
@@ -104,51 +104,239 @@ test("buildHeartbeatBridgeStatus leaves fresh or already-disconnected snapshots 
   assert.deepEqual(buildHeartbeatBridgeStatus(disconnectedStatus, 1_000), disconnectedStatus);
 });
 
-test("clampRelayThreadTurnsListRequest caps oversized turns-list page requests", () => {
-  const rawMessage = JSON.stringify({
+function makeTurns(start, count) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `turn-${start + index}`,
+    items: [
+      {
+        id: `item-${start + index}`,
+        type: "assistant_message",
+        text: `message ${start + index}`,
+      },
+    ],
+  }));
+}
+
+test("fetchAdaptiveThreadTurnsListForRelay expands small turns-list pages to the requested limit", async () => {
+  const request = {
     id: "req-turns-list",
+    method: "thread/turns/list",
+    params: {
+      threadId: "thread-small",
+      limit: 20,
+      sortDirection: "desc",
+    },
+  };
+  const fetches = [];
+  const pages = [
+    { data: makeTurns(1, 1), nextCursor: "cursor-after-1", stableMeta: "first-page" },
+    { data: makeTurns(2, 4), nextCursor: "cursor-after-5", stableMeta: "second-page" },
+    { data: makeTurns(6, 15), nextCursor: "cursor-after-20", stableMeta: "third-page" },
+  ];
+
+  const response = await fetchAdaptiveThreadTurnsListForRelay(request, {
+    fetchPage: async (params) => {
+      fetches.push(params);
+      return pages.shift();
+    },
+  });
+
+  assert.equal(response.id, "req-turns-list");
+  assert.equal(response.result.data.length, 20);
+  assert.deepEqual(
+    response.result.data.map((turn) => turn.id),
+    makeTurns(1, 20).map((turn) => turn.id)
+  );
+  assert.equal(
+    response.result.data.some((turn) => turn.id.startsWith("remodex-history-compacted-")),
+    false
+  );
+  assert.equal(response.result.stableMeta, "first-page");
+  assert.equal(response.result.nextCursor, "cursor-after-20");
+  assert.deepEqual(
+    fetches.map((params) => ({ limit: params.limit, cursor: params.cursor })),
+    [
+      { limit: 1, cursor: undefined },
+      { limit: 4, cursor: "cursor-after-1" },
+      { limit: 15, cursor: "cursor-after-5" },
+    ]
+  );
+});
+
+test("fetchAdaptiveThreadTurnsListForRelay stops at one turn for a huge first turns-list page", async () => {
+  const request = {
+    id: "req-turns-list-large-first",
     method: "thread/turns/list",
     params: {
       threadId: "thread-large",
       limit: 20,
       sortDirection: "desc",
-      cursor: "cursor-1",
+    },
+  };
+  const fetches = [];
+
+  const response = await fetchAdaptiveThreadTurnsListForRelay(request, {
+    fetchPage: async (params) => {
+      fetches.push(params);
+      return {
+        data: [
+          {
+            id: "turn-1",
+            items: [
+              {
+                id: "item-1",
+                type: "function_call_output",
+                text: "A".repeat(4 * 1024 * 1024),
+              },
+            ],
+          },
+        ],
+        nextCursor: "cursor-after-1",
+      };
     },
   });
 
-  const clamped = JSON.parse(clampRelayThreadTurnsListRequest(rawMessage));
-
-  assert.equal(clamped.id, "req-turns-list");
-  assert.equal(clamped.method, "thread/turns/list");
-  assert.deepEqual(clamped.params, {
-    threadId: "thread-large",
-    limit: 5,
-    sortDirection: "desc",
-    cursor: "cursor-1",
-  });
+  assert.deepEqual(
+    response.result.data.map((turn) => turn.id),
+    ["turn-1"]
+  );
+  assert.equal(response.result.nextCursor, "cursor-after-1");
+  assert.equal(fetches.length, 1);
 });
 
-test("clampRelayThreadTurnsListRequest leaves small and unrelated requests unchanged", () => {
-  const olderPageRequest = JSON.stringify({
+test("fetchAdaptiveThreadTurnsListForRelay stops after a huge second turns-list batch", async () => {
+  const request = {
+    id: "req-turns-list-large-second",
+    method: "thread/turns/list",
+    params: {
+      threadId: "thread-mixed",
+      limit: 20,
+      sortDirection: "desc",
+    },
+  };
+  const fetches = [];
+  const pages = [
+    { data: makeTurns(1, 1), nextCursor: "cursor-after-1" },
+    {
+      data: makeTurns(2, 4).map((turn) => ({
+        ...turn,
+        items: [
+          {
+            id: `${turn.id}-item`,
+            type: "function_call_output",
+            text: "B".repeat(1024 * 1024),
+          },
+        ],
+      })),
+      nextCursor: "cursor-after-5",
+    },
+  ];
+
+  const response = await fetchAdaptiveThreadTurnsListForRelay(request, {
+    fetchPage: async (params) => {
+      fetches.push(params);
+      return pages.shift();
+    },
+  });
+
+  assert.deepEqual(
+    response.result.data.map((turn) => turn.id),
+    makeTurns(1, 5).map((turn) => turn.id)
+  );
+  assert.equal(response.result.nextCursor, "cursor-after-5");
+  assert.deepEqual(
+    fetches.map((params) => params.limit),
+    [1, 4]
+  );
+});
+
+test("fetchAdaptiveThreadTurnsListForRelay forwards input and returned cursors", async () => {
+  const request = {
     id: "req-turns-list-older",
     method: "thread/turns/list",
     params: {
       threadId: "thread-large",
-      limit: 5,
+      limit: 6,
       sortDirection: "desc",
+      cursor: "cursor-before-page",
     },
-  });
-  const threadReadRequest = JSON.stringify({
-    id: "req-thread-read",
-    method: "thread/read",
-    params: {
-      threadId: "thread-large",
-      includeTurns: true,
+  };
+  const fetches = [];
+  const pages = [
+    { items: makeTurns(1, 1), nextCursor: "cursor-after-first" },
+    { items: makeTurns(2, 4), nextCursor: "cursor-after-second" },
+    { items: makeTurns(6, 1), nextCursor: "cursor-after-third" },
+  ];
+
+  const response = await fetchAdaptiveThreadTurnsListForRelay(request, {
+    fetchPage: async (params) => {
+      fetches.push(params);
+      return pages.shift();
     },
   });
 
-  assert.equal(clampRelayThreadTurnsListRequest(olderPageRequest), olderPageRequest);
-  assert.equal(clampRelayThreadTurnsListRequest(threadReadRequest), threadReadRequest);
+  assert.equal(response.result.items.length, 6);
+  assert.equal(response.result.nextCursor, "cursor-after-third");
+  assert.deepEqual(
+    fetches.map((params) => ({ limit: params.limit, cursor: params.cursor })),
+    [
+      { limit: 1, cursor: "cursor-before-page" },
+      { limit: 4, cursor: "cursor-after-first" },
+      { limit: 1, cursor: "cursor-after-second" },
+    ]
+  );
+});
+
+test("fetchAdaptiveThreadTurnsListForRelay preserves turns-list response array shapes", async () => {
+  for (const turnsKey of ["data", "items", "turns"]) {
+    const response = await fetchAdaptiveThreadTurnsListForRelay({
+      id: `req-${turnsKey}`,
+      method: "thread/turns/list",
+      params: {
+        threadId: `thread-${turnsKey}`,
+        limit: 1,
+      },
+    }, {
+      fetchPage: async () => ({
+        [turnsKey]: makeTurns(1, 1),
+        nextCursor: `cursor-${turnsKey}`,
+      }),
+    });
+
+    assert.equal(Array.isArray(response.result[turnsKey]), true);
+    assert.equal(response.result[turnsKey][0].id, "turn-1");
+    for (const otherKey of ["data", "items", "turns"].filter((key) => key !== turnsKey)) {
+      assert.equal(response.result[otherKey], undefined);
+    }
+    assert.equal(response.result.nextCursor, `cursor-${turnsKey}`);
+  }
+});
+
+test("fetchAdaptiveThreadTurnsListForRelay returns fetched turns when a later batch fails", async () => {
+  const response = await fetchAdaptiveThreadTurnsListForRelay({
+    id: "req-turns-list-later-error",
+    method: "thread/turns/list",
+    params: {
+      threadId: "thread-later-error",
+      limit: 5,
+    },
+  }, {
+    fetchPage: async (params) => {
+      if (params.cursor === "cursor-after-first") {
+        throw new Error("app-server failed");
+      }
+      return {
+        data: makeTurns(1, 1),
+        nextCursor: "cursor-after-first",
+      };
+    },
+  });
+
+  assert.deepEqual(
+    response.result.data.map((turn) => turn.id),
+    ["turn-1"]
+  );
+  assert.equal(response.result.nextCursor, "cursor-after-first");
 });
 
 test("sanitizeThreadHistoryImagesForRelay replaces inline history images with lightweight references", () => {

--- a/phodex-bridge/test/bridge.test.js
+++ b/phodex-bridge/test/bridge.test.js
@@ -11,6 +11,7 @@ const os = require("node:os");
 const path = require("node:path");
 const {
   buildHeartbeatBridgeStatus,
+  clampRelayThreadTurnsListRequest,
   createMacOSBridgeWakeAssertion,
   hasRelayConnectionGoneStale,
   persistBridgePreferences,
@@ -101,6 +102,53 @@ test("buildHeartbeatBridgeStatus leaves fresh or already-disconnected snapshots 
     lastError: "",
   };
   assert.deepEqual(buildHeartbeatBridgeStatus(disconnectedStatus, 1_000), disconnectedStatus);
+});
+
+test("clampRelayThreadTurnsListRequest caps oversized turns-list page requests", () => {
+  const rawMessage = JSON.stringify({
+    id: "req-turns-list",
+    method: "thread/turns/list",
+    params: {
+      threadId: "thread-large",
+      limit: 20,
+      sortDirection: "desc",
+      cursor: "cursor-1",
+    },
+  });
+
+  const clamped = JSON.parse(clampRelayThreadTurnsListRequest(rawMessage));
+
+  assert.equal(clamped.id, "req-turns-list");
+  assert.equal(clamped.method, "thread/turns/list");
+  assert.deepEqual(clamped.params, {
+    threadId: "thread-large",
+    limit: 5,
+    sortDirection: "desc",
+    cursor: "cursor-1",
+  });
+});
+
+test("clampRelayThreadTurnsListRequest leaves small and unrelated requests unchanged", () => {
+  const olderPageRequest = JSON.stringify({
+    id: "req-turns-list-older",
+    method: "thread/turns/list",
+    params: {
+      threadId: "thread-large",
+      limit: 5,
+      sortDirection: "desc",
+    },
+  });
+  const threadReadRequest = JSON.stringify({
+    id: "req-thread-read",
+    method: "thread/read",
+    params: {
+      threadId: "thread-large",
+      includeTurns: true,
+    },
+  });
+
+  assert.equal(clampRelayThreadTurnsListRequest(olderPageRequest), olderPageRequest);
+  assert.equal(clampRelayThreadTurnsListRequest(threadReadRequest), threadReadRequest);
 });
 
 test("sanitizeThreadHistoryImagesForRelay replaces inline history images with lightweight references", () => {
@@ -697,10 +745,60 @@ test("sanitizeThreadHistoryImagesForRelay compacts oversized turns pages", () =>
   const item = sanitized.result.items[0].items[0];
 
   assert.equal(sanitized.result.remodexPageCompactedForRelay, true);
+  assert.deepEqual(
+    sanitized.result.items.map((turn) => turn.id),
+    ["turn-1"]
+  );
+  assert.equal(
+    sanitized.result.items.some((turn) => turn.id.startsWith("remodex-history-compacted-")),
+    false
+  );
   assert.equal(sanitized.result.items[0].remodexPageCompactedForRelay, true);
   assert.equal(item.relayPayloadTruncated, true);
   assert.equal(item.text.startsWith("…\n"), true);
   assert.equal(item.text.length < 120_000, true);
+});
+
+test("sanitizeThreadHistoryImagesForRelay preserves oversized turns pages instead of replacing them with a marker", () => {
+  const turns = Array.from({ length: 5 }, (_, turnIndex) => ({
+    id: `turn-${turnIndex + 1}`,
+    items: Array.from({ length: 900 }, (_, itemIndex) => ({
+      id: `item-${turnIndex + 1}-${itemIndex + 1}`,
+      type: "function_call_output",
+      role: "tool",
+      itemId: `call-${turnIndex + 1}-${itemIndex + 1}`,
+      text: "C".repeat(1_500),
+      payload: {
+        blob: "D".repeat(1_200),
+      },
+    })),
+  }));
+  const rawMessage = JSON.stringify({
+    id: "req-turns-list-impossible",
+    result: {
+      data: turns,
+      nextCursor: "cursor-after-huge-page",
+    },
+  });
+
+  const sanitizedRaw = sanitizeThreadHistoryImagesForRelay(rawMessage, "thread/turns/list");
+  const sanitized = JSON.parse(sanitizedRaw);
+
+  assert.equal(Buffer.byteLength(sanitizedRaw, "utf8") <= 4 * 1024 * 1024, true);
+  assert.deepEqual(
+    sanitized.result.data.map((turn) => turn.id),
+    turns.map((turn) => turn.id)
+  );
+  assert.equal(
+    sanitized.result.data.some((turn) => turn.id.startsWith("remodex-history-compacted-")),
+    false
+  );
+  assert.equal(sanitized.result.nextCursor, "cursor-after-huge-page");
+  assert.equal(sanitized.result.data.every((turn) => turn.items.length === 900), true);
+  assert.equal(
+    sanitized.result.data.every((turn) => turn.items.every((item) => item.relayPayloadTruncated === true)),
+    true
+  );
 });
 
 test("sanitizeThreadHistoryImagesForRelay compacts oversized history before the newest turn tail", () => {


### PR DESCRIPTION
## Summary

- Clamp relayed `thread/turns/list` requests above 5 turns before forwarding to Codex app-server, keeping giant chats under the mobile initial-load timeout.
- Keep oversized turns-list pages item-compacted instead of replacing the whole page with a synthetic compacted marker.
- Add bridge tests for request clamping, cursor/turn preservation, and oversized page compaction.

## Root cause

Large local desktop transcripts could make `thread/turns/list limit=20` spend more than the iPhone's initial history timeout inside Codex app-server before the bridge ever got a response to sanitize. For the `Continue device_register RE` thread, the raw 20-turn page took about 13 seconds to produce; clamping the relayed request to 5 turns brought fetch plus sanitization to about 2 seconds while preserving cursor-based older history.

## Test plan

- `node --test ./test/bridge.test.js --test-name-pattern "sanitizeThreadHistoryImagesForRelay"`
- `node --test ./test/bridge.test.js`
