### PR TITLE
relay: accept role from query string (unblocks Android / browser clients)

### DIFF
--- a/relay/relay.js
+++ b/relay/relay.js
@@ -73,13 +73,23 @@ function setupRelay(
     const urlPath = req.url || "";
     const match = urlPath.match(/^\/relay\/([^/?]+)/);
     const sessionId = match?.[1];
-    const role = normalizeRelayRole(req.headers["x-role"]);
+    // Accept role from `x-role` header (preferred) or `?role=...` query string.
+    // The query-string fallback exists for WebSocket clients that can't send
+    // custom request headers — notably React Native's WebSocket on Android,
+    // and Web browsers (which have never allowed custom WS headers). The
+    // header path is unchanged for the bridge and the iOS app.
+    const headerRole = normalizeRelayRole(req.headers["x-role"]);
+    const queryUrl = (() => {
+      try { return new URL(urlPath, "http://relay.local"); } catch { return null; }
+    })();
+    const queryRole = queryUrl ? normalizeRelayRole(queryUrl.searchParams.get("role")) : "";
+    const role = headerRole || queryRole;
     relayMetrics.acceptedConnections += 1;
     ws._relaySessionId = sessionId;
     ws._relayRole = role;
 
     if (!sessionId || (role !== "mac" && !isRelayMobileRole(role))) {
-      ws.close(4000, "Missing sessionId or invalid x-role header");
+      ws.close(4000, "Missing sessionId or invalid x-role header/query");
       return;
     }
 


### PR DESCRIPTION
## Summary

The relay currently rejects any WebSocket connection that doesn't include an `x-role` header (relay.js:81-84, close code 4000). This blocks any client that can't reliably set custom request headers on its WebSocket handshake — most notably **React Native's WebSocket on Android** (Expo Go strips custom headers) and **Web browsers** (which have never allowed custom WS headers per the spec).

This PR adds a **`?role=...` query-string fallback** that's only consulted when the header is absent. Same allow-list (\`mac\`, \`iphone\`, \`android\`). Header path is unchanged for the bridge and the iOS app.

## Why

I'm building a clean-room **Android client** for the Remodex protocol ([jeemitsha/remodex-android](https://github.com/jeemitsha/remodex-android), Apache-2.0, separate repo). The relay's role-allow-list already includes `\"android\"` (relay.js:38), so the protocol layer was clearly designed with an Android client in mind — but the requirement for a header-only role made it unreachable from React Native's WebSocket implementation.

This 12-line change unblocks Android (and any future Web client) without disturbing the iOS / bridge path. After applying it, an Android client that appends \`?role=android\` to the relay URL pairs end-to-end through the existing handshake.

## Diff

12 lines, additive, in \`relay/relay.js\`. The header check stays first; query string is only consulted as a fallback. Same close code (4000) for missing/invalid role.

\`\`\`js
const headerRole = normalizeRelayRole(req.headers[\"x-role\"]);
const queryUrl = (() => {
  try { return new URL(urlPath, \"http://relay.local\"); } catch { return null; }
})();
const queryRole = queryUrl ? normalizeRelayRole(queryUrl.searchParams.get(\"role\")) : \"\";
const role = headerRole || queryRole;
\`\`\`

## Security

The role doesn't grant any privilege beyond being slotted into the right session role; the actual authentication happens at the E2EE handshake layer via Ed25519 identity signatures, which this PR doesn't touch. A query-string role is not more forgeable than a header role — both come from the same untrusted client.

## Test plan

- [x] Existing 32 relay tests pass unchanged (\`cd relay && npm test\`)
- [x] Manually verified an Android (Expo Go) client now pairs end-to-end
- [x] Bridge + iOS path unchanged (header still primary)
- [ ] Reviewer happy with naming / placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)