### PR TITLE
bump: version 1.5.0 → 1.5.1

### DIFF
--- a/CodexMobile/CodexMobile/Views/Home/WhatsNewSheet.swift
+++ b/CodexMobile/CodexMobile/Views/Home/WhatsNewSheet.swift
@@ -7,7 +7,7 @@
 import SwiftUI
 
 private let whatsNewItems: [String] = [
-    "New Remodex CLI v1.5.0",
+    "New Remodex CLI v1.5.1",
     "New message bubble colors",
     "Image Gen is now available",
     "Plugin mentions in the composer",

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Prints the installed Remodex CLI version.
 
 ```sh
 remodex --version
-# => 1.5.0
+# => 1.5.1
 ```
 
 ### `remodex reset-pairing`

--- a/phodex-bridge/package-lock.json
+++ b/phodex-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remodex",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remodex",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/phodex-bridge/package.json
+++ b/phodex-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remodex",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Local bridge between Codex and the Remodex mobile app. Run `remodex up` to start.",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
Bumps phodex-bridge and related references from 1.5.0 to 1.5.1 to match the latest published npm package.