### PR TITLE
Preserve explicit branch prefixes

### DIFF
--- a/CodexMobile/CodexMobile/Views/Turn/TurnGitBranchSelector.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnGitBranchSelector.swift
@@ -6,11 +6,11 @@
 
 import SwiftUI
 
-// Normalizes newly created local branch names toward the repo's preferred prefix without double-prefixing.
+// Defaults bare branch names to the repo prefix while preserving explicit slash prefixes.
 func remodexNormalizedCreatedBranchName(_ rawName: String) -> String {
     let trimmedName = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmedName.isEmpty else { return "" }
-    if trimmedName.hasPrefix("remodex/") {
+    if trimmedName.contains("/") {
         return trimmedName
     }
     return "remodex/\(trimmedName)"
@@ -386,7 +386,7 @@ struct TurnGitBranchPickerSheet: View {
         .environment(\.defaultMinListRowHeight, 28)
         .searchable(text: $searchText, prompt: "Search branches")
         .alert("New branch", isPresented: $isShowingCreateBranchPrompt) {
-            TextField("remodex/my-feature", text: $newBranchName)
+            TextField("my-feature or drew/my-feature", text: $newBranchName)
             Button("Cancel", role: .cancel) {
                 newBranchName = ""
             }

--- a/CodexMobile/CodexMobile/Views/Turn/TurnWorktreeHandoffOverlay.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/TurnWorktreeHandoffOverlay.swift
@@ -22,7 +22,7 @@ enum TurnWorktreeOverlayMode {
     var message: String {
         switch self {
         case .handoff:
-            return "Create and check out a branch in a new worktree to continue in parallel. The branch is normalized with the remodex/ prefix."
+            return "Create and check out a branch in a new worktree to continue in parallel. Bare names use the remodex/ prefix; slash-prefixed names keep their prefix."
         case .fork:
             return "Create and check out a branch in a new worktree, then fork this conversation into that checkout as a new chat."
         }

--- a/CodexMobile/CodexMobileTests/TurnGitBranchSelectorTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnGitBranchSelectorTests.swift
@@ -1,5 +1,5 @@
 // FILE: TurnGitBranchSelectorTests.swift
-// Purpose: Verifies new branch creation names normalize toward the remodex/ prefix without double-prefixing.
+// Purpose: Verifies new branch creation names preserve explicit prefixes while defaulting bare names.
 // Layer: Unit Test
 // Exports: TurnGitBranchSelectorTests
 // Depends on: XCTest, CodexMobile
@@ -8,10 +8,15 @@ import XCTest
 @testable import CodexMobile
 
 final class TurnGitBranchSelectorTests: XCTestCase {
-    func testNormalizesCreatedBranchNamesTowardRemodexPrefix() {
+    func testNormalizesBareCreatedBranchNamesTowardRemodexPrefix() {
         XCTAssertEqual(remodexNormalizedCreatedBranchName("foo"), "remodex/foo")
         XCTAssertEqual(remodexNormalizedCreatedBranchName("remodex/foo"), "remodex/foo")
         XCTAssertEqual(remodexNormalizedCreatedBranchName("  foo  "), "remodex/foo")
+    }
+
+    func testPreservesExplicitCreatedBranchPrefixes() {
+        XCTAssertEqual(remodexNormalizedCreatedBranchName("drew/new-branch"), "drew/new-branch")
+        XCTAssertEqual(remodexNormalizedCreatedBranchName("feature/login-page"), "feature/login-page")
     }
 
     func testNormalizesEmptyBranchNamesToEmptyString() {

--- a/phodex-bridge/src/git-handler.js
+++ b/phodex-bridge/src/git-handler.js
@@ -2077,7 +2077,7 @@ function normalizeCreatedBranchName(rawName) {
     .map((segment) => segment.trim().replace(/\s+/g, "-"))
     .join("/");
 
-  if (normalized.startsWith("remodex/")) {
+  if (normalized.includes("/")) {
     return normalized;
   }
   return `remodex/${normalized}`;

--- a/phodex-bridge/test/git-handler.test.js
+++ b/phodex-bridge/test/git-handler.test.js
@@ -316,11 +316,26 @@ test("gitCreateBranch normalizes bare names into remodex/* and checks out the ne
   }
 });
 
-test("normalizeCreatedBranchName avoids double-prefixing remodex branches", () => {
-  assert.equal(__test.normalizeCreatedBranchName("feature/foo"), "remodex/feature/foo");
+test("gitCreateBranch preserves explicit slash prefixes", async () => {
+  const repoDir = makeTempRepo();
+
+  try {
+    const result = await __test.gitCreateBranch(repoDir, { name: "drew/new-branch" });
+
+    assert.equal(result.branch, "drew/new-branch");
+    assert.equal(result.status?.branch, "drew/new-branch");
+    assert.equal(git(repoDir, "rev-parse", "--abbrev-ref", "HEAD"), "drew/new-branch");
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+test("normalizeCreatedBranchName preserves explicit prefixes and defaults bare names", () => {
+  assert.equal(__test.normalizeCreatedBranchName("feature/foo"), "feature/foo");
+  assert.equal(__test.normalizeCreatedBranchName("drew/new-branch"), "drew/new-branch");
   assert.equal(__test.normalizeCreatedBranchName("remodex/feature/foo"), "remodex/feature/foo");
   assert.equal(__test.normalizeCreatedBranchName("my new branch"), "remodex/my-new-branch");
-  assert.equal(__test.normalizeCreatedBranchName("feature / login page"), "remodex/feature/login-page");
+  assert.equal(__test.normalizeCreatedBranchName("feature / login page"), "feature/login-page");
   assert.equal(__test.normalizeCreatedBranchName("   "), "");
 });
 


### PR DESCRIPTION
## Summary

- Preserve explicit slash-prefixed branch names such as `drew/new-branch` when creating branches from the iOS app and bridge.
- Keep the existing default behavior for bare branch names, so `new-branch` still becomes `remodex/new-branch`.
- Update the branch creation prompt/help text and add regression coverage for the bridge and iOS normalization helper.

Fixes #52.

## Test Plan

- `node --test ./test/git-handler.test.js`
- `git diff --check HEAD~1..HEAD`

Not run: Xcode tests, per repository guardrails.