### PR TITLE
Fix secure transport initial resume state

### DIFF
--- a/phodex-bridge/src/secure-transport.js
+++ b/phodex-bridge/src/secure-transport.js
@@ -344,7 +344,7 @@ function createBridgeSecureTransport({
       macToPhoneKey: deriveAesKey(sharedSecret, salt, `${infoPrefix}|macToPhone`),
       lastInboundCounter: -1,
       nextOutboundCounter: 0,
-      isResumed: false,
+      isResumed: true,
       sendWireMessage: liveSendWireMessage,
     };
 

--- a/phodex-bridge/test/secure-transport.test.js
+++ b/phodex-bridge/test/secure-transport.test.js
@@ -346,6 +346,50 @@ test("qr bootstrap starts a fresh replay window instead of leaking buffered mess
   assert.equal(wireMessages.length, 1);
 });
 
+test("secure transport sends initial bridge output without waiting for resumeState", () => {
+  const macIdentity = createOkpKeyPair("ed25519");
+  const phoneIdentity = createOkpKeyPair("ed25519");
+  const phoneEphemeral = createOkpKeyPair("x25519");
+  const secureTransport = createBridgeSecureTransport({
+    sessionId: "session-initial-output",
+    relayUrl: "wss://relay.example/relay",
+    deviceState: {
+      macDeviceId: "mac-initial-output",
+      macIdentityPrivateKey: macIdentity.privateKey,
+      macIdentityPublicKey: macIdentity.publicKey,
+      trustedPhones: {},
+    },
+  });
+  const wireMessages = [];
+  secureTransport.bindLiveSendWireMessage((message) => {
+    wireMessages.push(message);
+    return true;
+  });
+
+  finishHandshake({
+    secureTransport,
+    sessionId: "session-initial-output",
+    macDeviceId: "mac-initial-output",
+    phoneDeviceId: "phone-initial-output",
+    macIdentity,
+    phoneIdentity,
+    phoneEphemeral,
+    handshakeMode: HANDSHAKE_MODE_QR_BOOTSTRAP,
+    lastAppliedBridgeOutboundSeq: 0,
+    skipResumeState: true,
+  });
+
+  assert.equal(secureTransport.isSecureChannelReady(), true);
+  secureTransport.queueOutboundApplicationMessage(
+    JSON.stringify({ id: "initialize", result: { ok: true } }),
+    () => {
+      throw new Error("expected bound sender to handle initial output");
+    }
+  );
+
+  assert.equal(wireMessages.length, 1);
+});
+
 test("rebinding the relay socket replays bridge output from the last phone ack", () => {
   const macIdentity = createOkpKeyPair("ed25519");
   const phoneIdentity = createOkpKeyPair("ed25519");
@@ -519,7 +563,15 @@ test("resume replay does not advance the replay watermark before a phone ack", (
     hkdfSync("sha256", sharedSecret, salt, Buffer.from(`${infoPrefix}|macToPhone`, "utf8"), 32)
   );
 
-  assert.equal(initialReplayWireMessages.length, 1);
+  assert.equal(initialReplayWireMessages.length, 2);
+  const initialReplayPayloads = initialReplayWireMessages.map((message) => {
+    const envelope = JSON.parse(message);
+    return decryptEnvelope(envelope, macToPhoneKey);
+  });
+  assert.deepEqual(
+    initialReplayPayloads.map((payload) => payload.bridgeOutboundSeq),
+    [1, 1]
+  );
 
   const reboundWireMessages = [];
   secureTransport.bindLiveSendWireMessage((message) => {


### PR DESCRIPTION
## Summary

- Mark the secure transport session ready immediately after `clientAuth` completes, so initial bridge responses are sent even when the phone does not send `resumeState`.
- Add regression coverage for initial bridge output after secure handshake without `resumeState`.
- Keep the replay watermark behavior covered so local socket writes still do not count as phone acknowledgements.

Fixes #105.

## Test Plan

- `node --test ./test/secure-transport.test.js`
- `git diff --check`
