### PR TITLE
Add Codex app paths to launch agent

### DIFF
--- a/phodex-bridge/src/macos-launch-agent.js
+++ b/phodex-bridge/src/macos-launch-agent.js
@@ -31,6 +31,7 @@ const {
 const SERVICE_LABEL = "com.remodex.bridge";
 const DEFAULT_PAIRING_WAIT_TIMEOUT_MS = 10_000;
 const DEFAULT_PAIRING_WAIT_INTERVAL_MS = 200;
+const CODEX_APP_RESOURCE_SUBPATH = path.join("Codex.app", "Contents", "Resources");
 
 // Runs the bridge inside launchd while keeping QR rendering in the foreground CLI command.
 function runMacOSBridgeService({ env = process.env } = {}) {
@@ -241,6 +242,7 @@ function buildLaunchAgentPlist({
   nodePath,
   cliPath,
 }) {
+  const launchAgentPathEnv = buildLaunchAgentPathEnv({ homeDir, pathEnv });
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -267,7 +269,7 @@ function buildLaunchAgentPlist({
     <key>HOME</key>
     <string>${escapeXml(homeDir)}</string>
     <key>PATH</key>
-    <string>${escapeXml(pathEnv)}</string>
+    <string>${escapeXml(launchAgentPathEnv)}</string>
     <key>REMODEX_DEVICE_STATE_DIR</key>
     <string>${escapeXml(stateDir)}</string>
   </dict>
@@ -278,6 +280,25 @@ function buildLaunchAgentPlist({
 </dict>
 </plist>
 `;
+}
+
+function buildLaunchAgentPathEnv({ homeDir, pathEnv }) {
+  const entries = String(pathEnv || "")
+    .split(path.delimiter)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  const fallbackEntries = [
+    path.join("/Applications", CODEX_APP_RESOURCE_SUBPATH),
+    homeDir ? path.join(homeDir, "Applications", CODEX_APP_RESOURCE_SUBPATH) : "",
+  ].filter(Boolean);
+
+  for (const entry of fallbackEntries) {
+    if (!entries.includes(entry)) {
+      entries.push(entry);
+    }
+  }
+
+  return entries.join(path.delimiter);
 }
 
 async function waitForFreshPairingSession({

--- a/phodex-bridge/test/macos-launch-agent.test.js
+++ b/phodex-bridge/test/macos-launch-agent.test.js
@@ -44,6 +44,21 @@ test("buildLaunchAgentPlist points launchd at run-service with remodex state pat
   assert.match(plist, /<key>REMODEX_DEVICE_STATE_DIR<\/key>/);
 });
 
+test("buildLaunchAgentPlist includes common Codex.app launcher paths", () => {
+  const plist = buildLaunchAgentPlist({
+    homeDir: "/Users/tester",
+    pathEnv: "/usr/local/bin:/usr/bin",
+    stateDir: "/Users/tester/.remodex",
+    stdoutLogPath: "/Users/tester/.remodex/logs/bridge.stdout.log",
+    stderrLogPath: "/Users/tester/.remodex/logs/bridge.stderr.log",
+    nodePath: "/usr/local/bin/node",
+    cliPath: "/tmp/remodex/bin/remodex.js",
+  });
+
+  assert.match(plist, /<key>PATH<\/key>\s*<string>[^<]*\/Applications\/Codex\.app\/Contents\/Resources/);
+  assert.match(plist, /<key>PATH<\/key>\s*<string>[^<]*\/Users\/tester\/Applications\/Codex\.app\/Contents\/Resources/);
+});
+
 test("resolveLaunchAgentPlistPath writes into the user's LaunchAgents folder", () => {
   assert.equal(
     resolveLaunchAgentPlistPath({


### PR DESCRIPTION
## Summary

- Add common Codex.app launcher resource directories to the generated macOS LaunchAgent `PATH`.
- Preserve the existing shell-derived `PATH` entries and append the system/user Codex.app fallbacks without duplicates.
- Add regression coverage for LaunchAgent plist generation so the daemon can resolve `codex` when Codex.app is installed in a standard macOS location.

Fixes #47.

## Test Plan

- `node --test ./test/macos-launch-agent.test.js`
- `git diff --check`
