### PR TITLE
Keep iOS relay sockets alive while foregrounded

### DIFF
--- a/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
@@ -105,6 +105,7 @@ extension CodexService {
                 secureConnectionState = .encrypted
             }
 
+            startWebSocketKeepAliveLoop()
             startSyncLoop()
             // Push registration is best-effort and talks to the bridge, so it must not
             // hold the main connect path hostage when the managed backend is slow.
@@ -605,6 +606,8 @@ extension CodexService {
 
     // Removes the current socket reference before reconnect/teardown logic mutates shared state.
     private func cancelCurrentSocketConnection() {
+        stopWebSocketKeepAliveLoop()
+
         if let connection = webSocketConnection {
             connection.stateUpdateHandler = nil
             webSocketConnection = nil

--- a/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
@@ -101,6 +101,7 @@ extension CodexService {
         isAppInForeground = isForeground
         if isForeground {
             if isConnected && isInitialized {
+                startWebSocketKeepAliveLoop()
                 startSyncLoop()
                 requestImmediateSync(threadId: activeThreadId)
                 // Re-check bridge-managed state when the app becomes active again.
@@ -108,9 +109,11 @@ extension CodexService {
                     await self?.refreshBridgeManagedState(allowAvailableBridgeUpdatePrompt: true)
                 }
             } else {
+                stopWebSocketKeepAliveLoop()
                 stopSyncLoop()
             }
         } else {
+            stopWebSocketKeepAliveLoop()
             if isConnected && isInitialized {
                 startSyncLoop()
                 requestImmediateSync(threadId: activeThreadId)

--- a/CodexMobile/CodexMobile/Services/CodexService+Transport.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Transport.swift
@@ -14,6 +14,10 @@ import Security
 // reopening a chat, so the limit needs enough headroom for background `thread/read` catches too.
 let codexWebSocketMaximumMessageSizeBytes = 16 * 1024 * 1024
 
+private enum CodexWebSocketKeepAlivePolicy {
+    static let intervalNanoseconds: UInt64 = 25_000_000_000
+}
+
 private enum CodexRelayTransportPreference {
     case manualTCP
     case networkWebSocket
@@ -307,6 +311,98 @@ extension CodexService {
 
     func startReceiveLoop(with task: URLSessionWebSocketTask) {
         receiveNextMessage(on: task)
+    }
+
+    func startWebSocketKeepAliveLoop() {
+        guard isConnected, isInitialized, isAppInForeground else {
+            stopWebSocketKeepAliveLoop()
+            return
+        }
+        guard webSocketKeepAliveTask == nil else {
+            return
+        }
+        guard webSocketKeepAlivePingOverride != nil || webSocketConnection != nil || webSocketTask != nil else {
+            return
+        }
+
+        webSocketKeepAliveTask = Task { @MainActor [weak self] in
+            while let self, !Task.isCancelled {
+                let interval = self.webSocketKeepAliveIntervalOverrideNanoseconds
+                    ?? CodexWebSocketKeepAlivePolicy.intervalNanoseconds
+                try? await Task.sleep(nanoseconds: interval)
+                guard !Task.isCancelled else {
+                    return
+                }
+                guard self.isConnected, self.isInitialized, self.isAppInForeground else {
+                    self.stopWebSocketKeepAliveLoop()
+                    return
+                }
+
+                do {
+                    try await self.sendWebSocketKeepAlivePing()
+                } catch {
+                    guard !Task.isCancelled else {
+                        return
+                    }
+                    self.handleReceiveError(error)
+                    return
+                }
+            }
+        }
+    }
+
+    func stopWebSocketKeepAliveLoop() {
+        webSocketKeepAliveTask?.cancel()
+        webSocketKeepAliveTask = nil
+    }
+
+    func sendWebSocketKeepAlivePing() async throws {
+        if let webSocketKeepAlivePingOverride {
+            try await webSocketKeepAlivePingOverride()
+            return
+        }
+
+        if usesManualWebSocketTransport {
+            guard let connection = webSocketConnection else {
+                throw CodexServiceError.disconnected
+            }
+            try await sendManualWebSocketFrame(opcode: 0x9, payload: Data(), on: connection)
+            return
+        }
+
+        if let task = webSocketTask {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                task.sendPing { error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: ())
+                    }
+                }
+            }
+            return
+        }
+
+        guard let connection = webSocketConnection else {
+            throw CodexServiceError.disconnected
+        }
+
+        let metadata = NWProtocolWebSocket.Metadata(opcode: .ping)
+        let context = NWConnection.ContentContext(identifier: "codex-keepalive-ping", metadata: [metadata])
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            connection.send(
+                content: Data(),
+                contentContext: context,
+                isComplete: true,
+                completion: .contentProcessed { error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: ())
+                    }
+                }
+            )
+        }
     }
 
     // Reads raw TCP bytes and drains manual websocket frames for the relay LAN fallback.

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -459,6 +459,7 @@ final class CodexService {
     var webSocketSession: URLSession?
     var webSocketSessionDelegate: CodexURLSessionWebSocketDelegate?
     var webSocketTask: URLSessionWebSocketTask?
+    var webSocketKeepAliveTask: Task<Void, Never>?
     // Raw frame buffer used when the relay runs over manual TCP websocket framing.
     var manualWebSocketReadBuffer = Data()
     var usesManualWebSocketTransport = false
@@ -468,6 +469,9 @@ final class CodexService {
     @ObservationIgnored var requestTransportOverride: ((String, JSONValue?) async throws -> RPCMessage)?
     // Test hook: stubs trusted-session lookup without performing a real relay HTTP request.
     @ObservationIgnored var trustedSessionResolverOverride: (() async throws -> CodexTrustedSessionResolveResponse)?
+    // Test hooks: exercise keepalive lifecycle without waiting 25s or opening a real socket.
+    @ObservationIgnored var webSocketKeepAliveIntervalOverrideNanoseconds: UInt64?
+    @ObservationIgnored var webSocketKeepAlivePingOverride: (() async throws -> Void)?
     // Keeps the trusted-session HTTP lookup cancellable so manual retry can preempt a stuck resolve.
     @ObservationIgnored var trustedSessionResolveTask: Task<CodexTrustedSessionResolveResponse, Error>?
     @ObservationIgnored var trustedSessionResolveTaskID: UUID?

--- a/CodexMobile/CodexMobileTests/CodexServiceConnectionErrorTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceConnectionErrorTests.swift
@@ -101,6 +101,106 @@ final class CodexServiceConnectionErrorTests: XCTestCase {
         }
     }
 
+    func testWebSocketKeepAlivePingsWhileForegrounded() async {
+        let service = CodexService()
+        var pingCount = 0
+        service.isConnected = true
+        service.isInitialized = true
+        service.isAppInForeground = true
+        service.webSocketKeepAliveIntervalOverrideNanoseconds = 1
+        service.webSocketKeepAlivePingOverride = {
+            pingCount += 1
+            service.stopWebSocketKeepAliveLoop()
+        }
+
+        service.startWebSocketKeepAliveLoop()
+
+        for _ in 0..<1_000 {
+            if pingCount > 0 { break }
+            await Task.yield()
+        }
+
+        XCTAssertEqual(pingCount, 1)
+        XCTAssertNil(service.webSocketKeepAliveTask)
+    }
+
+    func testWebSocketKeepAliveDoesNotStartWhileBackgrounded() async {
+        let service = CodexService()
+        var pingCount = 0
+        service.isConnected = true
+        service.isInitialized = true
+        service.isAppInForeground = false
+        service.webSocketKeepAliveIntervalOverrideNanoseconds = 1
+        service.webSocketKeepAlivePingOverride = {
+            pingCount += 1
+        }
+
+        service.startWebSocketKeepAliveLoop()
+        await Task.yield()
+
+        XCTAssertEqual(pingCount, 0)
+        XCTAssertNil(service.webSocketKeepAliveTask)
+    }
+
+    func testForegroundStateStopsAndRestartsWebSocketKeepAlive() {
+        let service = CodexService()
+        service.syncRealtimeEnabled = false
+        service.isConnected = true
+        service.isInitialized = true
+        service.isAppInForeground = true
+        service.webSocketKeepAlivePingOverride = {}
+
+        service.startWebSocketKeepAliveLoop()
+        XCTAssertNotNil(service.webSocketKeepAliveTask)
+
+        service.setForegroundState(false)
+        XCTAssertNil(service.webSocketKeepAliveTask)
+
+        service.setForegroundState(true)
+        XCTAssertNotNil(service.webSocketKeepAliveTask)
+        service.stopWebSocketKeepAliveLoop()
+    }
+
+    func testDisconnectStopsWebSocketKeepAlive() async {
+        let service = CodexService()
+        service.isConnected = true
+        service.isInitialized = true
+        service.isAppInForeground = true
+        service.webSocketKeepAlivePingOverride = {}
+
+        service.startWebSocketKeepAliveLoop()
+        XCTAssertNotNil(service.webSocketKeepAliveTask)
+
+        await service.disconnect()
+
+        XCTAssertNil(service.webSocketKeepAliveTask)
+        XCTAssertFalse(service.isConnected)
+    }
+
+    func testWebSocketKeepAliveFailureArmsReconnect() async {
+        let service = CodexService()
+        service.isConnected = true
+        service.isInitialized = true
+        service.isAppInForeground = true
+        service.webSocketKeepAliveIntervalOverrideNanoseconds = 1
+        service.webSocketKeepAlivePingOverride = {
+            throw NWError.posix(.ECONNRESET)
+        }
+
+        service.startWebSocketKeepAliveLoop()
+
+        for _ in 0..<1_000 {
+            if service.webSocketKeepAliveTask == nil { break }
+            await Task.yield()
+        }
+
+        XCTAssertNil(service.webSocketKeepAliveTask)
+        XCTAssertFalse(service.isConnected)
+        XCTAssertTrue(service.shouldAutoReconnectOnForeground)
+        XCTAssertEqual(service.connectionRecoveryState, .retrying(attempt: 0, message: "Reconnecting..."))
+        XCTAssertNil(service.lastErrorMessage)
+    }
+
     func testBenignDisconnectStaysSilentWhileAutoReconnectIsRunning() {
         let service = CodexService()
         let error = CodexServiceError.disconnected


### PR DESCRIPTION
## Summary

Adds a small foreground-only WebSocket keepalive loop for the iOS relay connection. After the session is initialized, the app now sends a ping every 25 seconds while the socket is connected, initialized, and the app remains foregrounded.

The loop stops when the app backgrounds, disconnects, or replaces the socket. Ping failures go through the existing receive-error path so the current reconnect/recovery state stays the source of truth.

This addresses the client-side keepalive portion of #53 and may reduce the idle/disconnect symptoms discussed in #44 and #72. It intentionally does not try to keep sockets alive while iOS has suspended the app in the background.

## Implementation

- Uses `URLSessionWebSocketTask.sendPing` for URLSession sockets.
- Sends an `NWProtocolWebSocket` ping frame for Network.framework sockets.
- Sends manual WebSocket opcode `0x9` for the manual TCP fallback.
- Adds targeted lifecycle coverage in the existing `CodexServiceConnectionErrorTests` file.

## Testing

- `git diff --check`
- `xcodebuild build -project CodexMobile/CodexMobile.xcodeproj -scheme CodexMobile -destination "platform=iOS Simulator,id=D6D322CA-87B1-4FE2-855B-659FB5B2B24A"`

I also ran the targeted test command from the change area:

```sh
xcodebuild test -project CodexMobile/CodexMobile.xcodeproj -scheme CodexMobile -destination "platform=iOS Simulator,id=D6D322CA-87B1-4FE2-855B-659FB5B2B24A" -only-testing:CodexMobileTests/CodexServiceConnectionErrorTests
```

That currently stops before executing the selected tests because the test target has unrelated compile failures in files not touched by this PR:

- `CodexThreadRuntimeOverrideTests.swift`: `normalizeRuntimeSelectionsAfterModelsUpdate` is inaccessible due to `fileprivate`.
- `TurnViewModelQueueTests.swift:261` and `TurnViewModelQueueTests.swift:285`: `try XCTUnwrap(...)` errors are not handled.
