### PR TITLE
Fix iOS test target compile errors

### DIFF
--- a/CodexMobile/CodexMobile/Services/CodexService+RuntimeConfig.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+RuntimeConfig.swift
@@ -476,57 +476,6 @@ private extension CodexService {
         persistThreadRuntimeOverrides()
     }
 
-    func normalizeRuntimeSelectionsAfterModelsUpdate() {
-        guard !availableModels.isEmpty else {
-            if selectedModelId?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true {
-                selectedModelId = nil
-            }
-            if selectedReasoningEffort?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true {
-                selectedReasoningEffort = nil
-            }
-            persistRuntimeSelections()
-            return
-        }
-
-        let resolvedModel = selectedModelOption(from: availableModels) ?? fallbackModel(from: availableModels)
-        selectedModelId = resolvedModel?.id
-        hasPersistedSelectedModelId = resolvedModel != nil
-
-        if let resolvedModel {
-            let supported = Set(resolvedModel.supportedReasoningEfforts.map { $0.reasoningEffort })
-            if supported.isEmpty {
-                selectedReasoningEffort = nil
-            } else if let selectedReasoningEffort,
-                      supported.contains(selectedReasoningEffort) {
-                // Keep current reasoning.
-            } else if let modelDefault = resolvedModel.defaultReasoningEffort,
-                      supported.contains(modelDefault) {
-                selectedReasoningEffort = modelDefault
-            } else if supported.contains("medium") {
-                selectedReasoningEffort = "medium"
-            } else {
-                selectedReasoningEffort = resolvedModel.supportedReasoningEfforts.first?.reasoningEffort
-            }
-
-            if let selectedServiceTier,
-               !resolvedModel.supportsServiceTier(selectedServiceTier) {
-                self.selectedServiceTier = nil
-            }
-        } else {
-            selectedReasoningEffort = nil
-            selectedServiceTier = nil
-        }
-
-        if let selectedGitWriterModelId,
-           !availableModels.contains(where: {
-               $0.id == selectedGitWriterModelId || $0.model == selectedGitWriterModelId
-           }) {
-            self.selectedGitWriterModelId = nil
-        }
-
-        persistRuntimeSelections()
-    }
-
     func selectedModelOption(from models: [CodexModelOption]) -> CodexModelOption? {
         guard !models.isEmpty else {
             return nil
@@ -616,5 +565,58 @@ private extension CodexService {
         }
 
         defaults.set(encodedOverrides, forKey: Self.threadRuntimeOverridesDefaultsKey)
+    }
+}
+
+extension CodexService {
+    func normalizeRuntimeSelectionsAfterModelsUpdate() {
+        guard !availableModels.isEmpty else {
+            if selectedModelId?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true {
+                selectedModelId = nil
+            }
+            if selectedReasoningEffort?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true {
+                selectedReasoningEffort = nil
+            }
+            persistRuntimeSelections()
+            return
+        }
+
+        let resolvedModel = selectedModelOption(from: availableModels) ?? fallbackModel(from: availableModels)
+        selectedModelId = resolvedModel?.id
+        hasPersistedSelectedModelId = resolvedModel != nil
+
+        if let resolvedModel {
+            let supported = Set(resolvedModel.supportedReasoningEfforts.map { $0.reasoningEffort })
+            if supported.isEmpty {
+                selectedReasoningEffort = nil
+            } else if let selectedReasoningEffort,
+                      supported.contains(selectedReasoningEffort) {
+                // Keep current reasoning.
+            } else if let modelDefault = resolvedModel.defaultReasoningEffort,
+                      supported.contains(modelDefault) {
+                selectedReasoningEffort = modelDefault
+            } else if supported.contains("medium") {
+                selectedReasoningEffort = "medium"
+            } else {
+                selectedReasoningEffort = resolvedModel.supportedReasoningEfforts.first?.reasoningEffort
+            }
+
+            if let selectedServiceTier,
+               !resolvedModel.supportsServiceTier(selectedServiceTier) {
+                self.selectedServiceTier = nil
+            }
+        } else {
+            selectedReasoningEffort = nil
+            selectedServiceTier = nil
+        }
+
+        if let selectedGitWriterModelId,
+           !availableModels.contains(where: {
+               $0.id == selectedGitWriterModelId || $0.model == selectedGitWriterModelId
+           }) {
+            self.selectedGitWriterModelId = nil
+        }
+
+        persistRuntimeSelections()
     }
 }

--- a/CodexMobile/CodexMobileTests/CodexPlanModeTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexPlanModeTests.swift
@@ -245,11 +245,13 @@ final class CodexPlanModeTests: XCTestCase {
                     id: "scope",
                     header: "Scope",
                     question: "What scope should we use?",
+                    isOther: false,
+                    isSecret: false,
+                    selectionLimit: 1,
                     options: [
-                        CodexStructuredUserInputOption(label: "Ship now", description: nil),
-                        CodexStructuredUserInputOption(label: "Stage behind a flag", description: nil),
-                    ],
-                    allowsMultiple: false
+                        CodexStructuredUserInputOption(label: "Ship now", description: ""),
+                        CodexStructuredUserInputOption(label: "Stage behind a flag", description: ""),
+                    ]
                 ),
             ],
             answersByQuestionID: [
@@ -368,7 +370,7 @@ final class CodexPlanModeTests: XCTestCase {
 
             default:
                 XCTFail("Unexpected method \(method)")
-                return RPCMessage(id: .string(UUID().uuidString), includeJSONRPC: false)
+                return RPCMessage(id: .string(UUID().uuidString), method: method, includeJSONRPC: false)
             }
         }
 
@@ -1164,13 +1166,16 @@ final class CodexPlanModeTests: XCTestCase {
             )
             XCTFail("Expected cancelStructuredPlanSession to throw")
         } catch let error as CodexServiceError {
-            XCTAssertEqual(error, .disconnected)
+            guard case .disconnected = error else {
+                XCTFail("Unexpected CodexServiceError: \(error)")
+                return
+            }
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
 
         XCTAssertEqual(service.messages(for: threadID).filter { $0.kind == .userInputPrompt }.count, 1)
-        XCTAssertEqual(service.currentPlanSessionSource(for: threadID), .native)
+        XCTAssertTrue(service.currentPlanSessionSource(for: threadID)?.isNative == true)
     }
 
     func testDismissStructuredPlanPromptFailureKeepsPromptVisible() async {
@@ -1226,7 +1231,7 @@ final class CodexPlanModeTests: XCTestCase {
         XCTAssertFalse(viewModel.isStructuredPlanPromptDismissed(requestID, codex: service))
         XCTAssertFalse(viewModel.isStructuredPlanPromptDismissing(requestID, codex: service))
         XCTAssertEqual(service.messages(for: threadID).filter { $0.kind == .userInputPrompt }.count, 1)
-        XCTAssertEqual(service.currentPlanSessionSource(for: threadID), .native)
+        XCTAssertTrue(service.currentPlanSessionSource(for: threadID)?.isNative == true)
         XCTAssertEqual(service.lastErrorMessage, service.userFacingTurnErrorMessage(from: CodexServiceError.disconnected))
     }
 
@@ -1346,6 +1351,7 @@ final class CodexPlanModeTests: XCTestCase {
 
     func testResolvedFallbackChoiceListStillAppearsAfterNativeThreadDegradesToPlainText() {
         let assistantMessage = CodexMessage(
+            threadId: "thread-plan",
             role: .assistant,
             text: """
             Suggested Roadmap If we wanted a practical sequence, I'd do:
@@ -1360,7 +1366,6 @@ final class CodexPlanModeTests: XCTestCase {
             2. a feature-priority matrix
             3. a "v1 vs v2" product strategy doc
             """,
-            threadId: "thread-plan",
             turnId: "turn-plan",
             orderIndex: 3
         )
@@ -1375,7 +1380,7 @@ final class CodexPlanModeTests: XCTestCase {
         XCTAssertEqual(questionnaire?.questions.count, 1)
         XCTAssertEqual(questionnaire?.questions.first?.header, "Next step")
         XCTAssertEqual(
-            questionnaire?.questions.first?.options.map(\.label),
+            questionnaire?.questions.first?.options.map { $0.label },
             [
                 "a concrete 2-week roadmap",
                 "a feature-priority matrix",
@@ -1386,6 +1391,7 @@ final class CodexPlanModeTests: XCTestCase {
 
     func testResolvedFallbackChoiceListDoesNotAppearOutsidePlanModeSession() {
         let assistantMessage = CodexMessage(
+            threadId: "thread-default",
             role: .assistant,
             text: """
             If you want, next I can turn this into one of these:
@@ -1394,7 +1400,6 @@ final class CodexPlanModeTests: XCTestCase {
             2. a feature-priority matrix
             3. a "v1 vs v2" product strategy doc
             """,
-            threadId: "thread-default",
             turnId: "turn-default",
             orderIndex: 3
         )
@@ -1415,6 +1420,7 @@ final class CodexPlanModeTests: XCTestCase {
         service.markNativePlanSession(for: "thread-native")
 
         let assistantMessage = CodexMessage(
+            threadId: "thread-native",
             role: .assistant,
             text: """
             If you want, next I can turn this into one of these:
@@ -1423,7 +1429,6 @@ final class CodexPlanModeTests: XCTestCase {
             2. a feature-priority matrix
             3. a "v1 vs v2" product strategy doc
             """,
-            threadId: "thread-native",
             turnId: "turn-native",
             orderIndex: 3
         )

--- a/CodexMobile/CodexMobileTests/CodexServiceIncomingRunIndicatorTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceIncomingRunIndicatorTests.swift
@@ -28,8 +28,8 @@ final class CodexServiceIncomingRunIndicatorTests: XCTestCase {
         let turnID = "turn-\(UUID().uuidString)"
         let itemID = "item-\(UUID().uuidString)"
 
-        service.enqueueAssistantDelta(threadId: threadID, turnId: turnID, itemId: itemID, delta: "Hello")
-        service.enqueueAssistantDelta(threadId: threadID, turnId: turnID, itemId: itemID, delta: " world")
+        service.appendAssistantDelta(threadId: threadID, turnId: turnID, itemId: itemID, delta: "Hello")
+        service.appendAssistantDelta(threadId: threadID, turnId: turnID, itemId: itemID, delta: " world")
 
         XCTAssertTrue(service.messages(for: threadID).isEmpty)
 
@@ -48,9 +48,9 @@ final class CodexServiceIncomingRunIndicatorTests: XCTestCase {
         let turnID = "turn-\(UUID().uuidString)"
         let itemID = "item-\(UUID().uuidString)"
 
-        service.enqueueAssistantDelta(threadId: threadID, turnId: turnID, itemId: itemID, delta: "Yes")
-        service.enqueueAssistantDelta(threadId: threadID, turnId: turnID, itemId: itemID, delta: "Yes, the")
-        service.enqueueAssistantDelta(threadId: threadID, turnId: turnID, itemId: itemID, delta: "Yes, the imagegen skill")
+        service.appendAssistantDelta(threadId: threadID, turnId: turnID, itemId: itemID, delta: "Yes")
+        service.appendAssistantDelta(threadId: threadID, turnId: turnID, itemId: itemID, delta: "Yes, the")
+        service.appendAssistantDelta(threadId: threadID, turnId: turnID, itemId: itemID, delta: "Yes, the imagegen skill")
 
         service.flushAllPendingStreamingDeltas()
 

--- a/CodexMobile/CodexMobileTests/TurnViewModelQueueTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnViewModelQueueTests.swift
@@ -233,7 +233,7 @@ final class TurnViewModelQueueTests: XCTestCase {
         XCTAssertTrue(service.messagesByThread["thread-queue"]?.isEmpty ?? true)
     }
 
-    func testSendTurnStoresOnlyConfirmedFileMentionsOnUserMessage() async {
+    func testSendTurnStoresOnlyConfirmedFileMentionsOnUserMessage() async throws {
         let service = makeService()
         service.isConnected = true
         service.resumedThreadIDs.insert("thread-queue")
@@ -263,7 +263,7 @@ final class TurnViewModelQueueTests: XCTestCase {
         XCTAssertEqual(message.fileMentions, ["CodexMobile/Views/Turn/TurnView.swift"])
     }
 
-    func testSendTurnDoesNotStoreManualFileLikeTextAsConfirmedMention() async {
+    func testSendTurnDoesNotStoreManualFileLikeTextAsConfirmedMention() async throws {
         let service = makeService()
         service.isConnected = true
         service.resumedThreadIDs.insert("thread-queue")


### PR DESCRIPTION
## Summary

Fixes current Swift compile blockers in the iOS unit test target.

This is related to #54, but it does not close it. The broader simulator/XCTest runtime failures are still separate from this compile cleanup.

## Changes

- Expose `normalizeRuntimeSelectionsAfterModelsUpdate()` internally so `@testable` unit tests can call it.
- Update async tests that use `try XCTUnwrap(...)` to be `async throws`.
- Refresh stale test call sites for current helper/API shapes that were preventing the test target from compiling.

No app runtime, UI, protocol, bridge, relay, pairing, persistence, or product behavior changes.

## Validation

- `git diff --check` passed.
- `xcodebuild build -project CodexMobile/CodexMobile.xcodeproj -scheme CodexMobile -destination 'platform=iOS Simulator,id=D6D322CA-87B1-4FE2-855B-659FB5B2B24A'` passed.
- `xcodebuild build-for-testing -project CodexMobile/CodexMobile.xcodeproj -scheme CodexMobile -destination 'platform=iOS Simulator,id=D6D322CA-87B1-4FE2-855B-659FB5B2B24A'` passed.
- `xcodebuild test -project CodexMobile/CodexMobile.xcodeproj -scheme CodexMobile -destination 'platform=iOS Simulator,id=D6D322CA-87B1-4FE2-855B-659FB5B2B24A' -only-testing:CodexMobileTests/CodexThreadRuntimeOverrideTests -only-testing:CodexMobileTests/TurnViewModelQueueTests` now compiles and launches tests, then fails in existing runtime assertions around workspace checkpoint calls / turn state mocks. I left those broader behavior updates out of this compile-only PR.
