### PR TITLE
Add native SSH terminal support

### DIFF
--- a/CodexMobile/CodexMobile.xcodeproj/project.pbxproj
+++ b/CodexMobile/CodexMobile.xcodeproj/project.pbxproj
@@ -28,6 +28,14 @@
 		90120FC72C9B8D0F5F03F14D /* CodexMobileUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D523A0A98D6540D0E2EE6131 /* CodexMobileUITests.swift */; };
 		9D7C9A8B7E6D5C4B3A291817 /* TurnViewModelQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7C9A8B7E6D5C4B3A291818 /* TurnViewModelQueueTests.swift */; };
 		A2B3C4D5E6F708192A3B4C6 /* CodexServiceThreadListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D5E6F708192A3B4C7 /* CodexServiceThreadListTests.swift */; };
+		A4B0C1D2E3F4051627384A02 /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4B0C1D2E3F4051627384A01 /* GhosttyKit.xcframework */; };
+		A4B0C1D2E3F4051627384A04 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4B0C1D2E3F4051627384A03 /* IOSurface.framework */; };
+		A4B0C1D2E3F4051627384A06 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4B0C1D2E3F4051627384A05 /* Metal.framework */; };
+		A4B0C1D2E3F4051627384A08 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4B0C1D2E3F4051627384A07 /* MetalKit.framework */; };
+		A4B0C1D2E3F4051627384A0A /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4B0C1D2E3F4051627384A09 /* QuartzCore.framework */; };
+		A4B0C1D2E3F4051627384A0C /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = A4B0C1D2E3F4051627384A0B /* libc++.tbd */; };
+		A4B0C1D2E3F4051627384A0E /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = A4B0C1D2E3F4051627384A0D /* libz.tbd */; };
+		A4B0C1D2E3F4051627384A10 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4B0C1D2E3F4051627384A0F /* UIKit.framework */; };
 		A9F1B2C3D4E5F60718293A40 /* TurnSkillAutocompleteTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F1B2C3D4E5F60718293A41 /* TurnSkillAutocompleteTokenTests.swift */; };
 		A9F1B2C3D4E5F60718293A42 /* CodexSkillsListDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F1B2C3D4E5F60718293A43 /* CodexSkillsListDecodeTests.swift */; };
 		A9F1B2C3D4E5F60718293A44 /* CodexTurnInputPayloadSkillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F1B2C3D4E5F60718293A45 /* CodexTurnInputPayloadSkillTests.swift */; };
@@ -39,6 +47,7 @@
 		B7A1C2D3E4F5061728394051 /* SidebarThreadGroupingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A1C2D3E4F5061728394052 /* SidebarThreadGroupingTests.swift */; };
 		C04E214B2F71D34100AA3193 /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = C04E214A2F71D34100AA3193 /* RevenueCat */; };
 		C04E214D2F71D4DB00AA3193 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C04E214C2F71D4DB00AA3193 /* StoreKit.framework */; };
+		C078C1A22F79000100BEEF01 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = C078C1A12F79000100BEEF01 /* Citadel */; };
 		C0DED3362F5E39DC0021A8E8 /* Textual in Frameworks */ = {isa = PBXBuildFile; productRef = C0DED3352F5E39DC0021A8E8 /* Textual */; };
 		C0F0D1FF2F7210A700A17B41 /* MarkdownView in Frameworks */ = {isa = PBXBuildFile; productRef = C0F0D1FE2F7210A700A17B41 /* MarkdownView */; };
 		D0C0FFEE0000000000000001 /* TextualMarkdownRenderingRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C0FFEE0000000000000002 /* TextualMarkdownRenderingRegressionTests.swift */; };
@@ -89,6 +98,14 @@
 		9A37794F4B32C1952A3770E0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		9D7C9A8B7E6D5C4B3A291818 /* TurnViewModelQueueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TurnViewModelQueueTests.swift; sourceTree = "<group>"; };
 		A2B3C4D5E6F708192A3B4C7 /* CodexServiceThreadListTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodexServiceThreadListTests.swift; sourceTree = "<group>"; };
+		A4B0C1D2E3F4051627384A01 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = CodexMobile/Terminal/Vendor/GhosttyKit.xcframework; sourceTree = SOURCE_ROOT; };
+		A4B0C1D2E3F4051627384A03 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
+		A4B0C1D2E3F4051627384A05 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
+		A4B0C1D2E3F4051627384A07 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
+		A4B0C1D2E3F4051627384A09 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		A4B0C1D2E3F4051627384A0B /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
+		A4B0C1D2E3F4051627384A0D /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		A4B0C1D2E3F4051627384A0F /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		A932BE773A84EFEA525DF684 /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = CodexMobile/Assets.xcassets; sourceTree = "<group>"; };
 		A9F1B2C3D4E5F60718293A41 /* TurnSkillAutocompleteTokenTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TurnSkillAutocompleteTokenTests.swift; sourceTree = "<group>"; };
 		A9F1B2C3D4E5F60718293A43 /* CodexSkillsListDecodeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodexSkillsListDecodeTests.swift; sourceTree = "<group>"; };
@@ -126,7 +143,16 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A4B0C1D2E3F4051627384A02 /* GhosttyKit.xcframework in Frameworks */,
+				A4B0C1D2E3F4051627384A04 /* IOSurface.framework in Frameworks */,
+				A4B0C1D2E3F4051627384A06 /* Metal.framework in Frameworks */,
+				A4B0C1D2E3F4051627384A08 /* MetalKit.framework in Frameworks */,
+				A4B0C1D2E3F4051627384A0A /* QuartzCore.framework in Frameworks */,
+				A4B0C1D2E3F4051627384A10 /* UIKit.framework in Frameworks */,
+				A4B0C1D2E3F4051627384A0C /* libc++.tbd in Frameworks */,
+				A4B0C1D2E3F4051627384A0E /* libz.tbd in Frameworks */,
 				C04E214D2F71D4DB00AA3193 /* StoreKit.framework in Frameworks */,
+				C078C1A22F79000100BEEF01 /* Citadel in Frameworks */,
 				C04E214B2F71D34100AA3193 /* RevenueCat in Frameworks */,
 				C0DED3362F5E39DC0021A8E8 /* Textual in Frameworks */,
 				C0F0D1FF2F7210A700A17B41 /* MarkdownView in Frameworks */,
@@ -250,6 +276,14 @@
 			isa = PBXGroup;
 			children = (
 				9A37794F4B32C1952A3770E0 /* Foundation.framework */,
+				A4B0C1D2E3F4051627384A01 /* GhosttyKit.xcframework */,
+				A4B0C1D2E3F4051627384A03 /* IOSurface.framework */,
+				A4B0C1D2E3F4051627384A05 /* Metal.framework */,
+				A4B0C1D2E3F4051627384A07 /* MetalKit.framework */,
+				A4B0C1D2E3F4051627384A09 /* QuartzCore.framework */,
+				A4B0C1D2E3F4051627384A0F /* UIKit.framework */,
+				A4B0C1D2E3F4051627384A0B /* libc++.tbd */,
+				A4B0C1D2E3F4051627384A0D /* libz.tbd */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
@@ -364,6 +398,7 @@
 			name = CodexMobile;
 			packageProductDependencies = (
 				C04E214A2F71D34100AA3193 /* RevenueCat */,
+				C078C1A12F79000100BEEF01 /* Citadel */,
 				C0DED3352F5E39DC0021A8E8 /* Textual */,
 				C0F0D1FE2F7210A700A17B41 /* MarkdownView */,
 			);
@@ -399,6 +434,7 @@
 				C0DED3342F5E39DC0021A8E8 /* XCRemoteSwiftPackageReference "textual" */,
 				C04E21492F71D34100AA3193 /* XCRemoteSwiftPackageReference "purchases-ios-spm" */,
 				C0F0D1FD2F7210A700A17B41 /* XCRemoteSwiftPackageReference "MarkdownView" */,
+				C078C1A02F79000100BEEF01 /* XCRemoteSwiftPackageReference "Citadel" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = C09A76AF2F4B8D7B003B3F3A /* Products */;
@@ -943,6 +979,14 @@
 				minimumVersion = 5.66.0;
 			};
 		};
+		C078C1A02F79000100BEEF01 /* XCRemoteSwiftPackageReference "Citadel" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/orlandos-nl/Citadel.git";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 		C0DED3342F5E39DC0021A8E8 /* XCRemoteSwiftPackageReference "textual" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/devnoname120/textual.git";
@@ -966,6 +1010,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C04E21492F71D34100AA3193 /* XCRemoteSwiftPackageReference "purchases-ios-spm" */;
 			productName = RevenueCat;
+		};
+		C078C1A12F79000100BEEF01 /* Citadel */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C078C1A02F79000100BEEF01 /* XCRemoteSwiftPackageReference "Citadel" */;
+			productName = Citadel;
 		};
 		C0DED3352F5E39DC0021A8E8 /* Textual */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CodexMobile/CodexMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodexMobile/CodexMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "1d8c3209a8395d2306d798e5a278e545d90f0359ce37e022f8de77fb32939e27",
+  "originHash" : "6258034da56d47e02caec88b778b47dfa9472bcefa026488a7a946a435f12746",
   "pins" : [
+    {
+      "identity" : "bigint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attaswift/BigInt.git",
+      "state" : {
+        "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
+        "version" : "5.7.0"
+      }
+    },
+    {
+      "identity" : "citadel",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/orlandos-nl/Citadel.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "ae8562f895de06ccb86fdb1cbb65fd99c8976e12"
+      }
+    },
     {
       "identity" : "markdownview",
       "kind" : "remoteSourceControl",
@@ -19,6 +37,24 @@
       }
     },
     {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
       "identity" : "swift-cmark",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-cmark",
@@ -28,12 +64,66 @@
       }
     },
     {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
+        "version" : "1.5.0"
+      }
+    },
+    {
       "identity" : "swift-concurrency-extras",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
         "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
         "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssh",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Wellz26/swift-nio-ssh.git",
+      "state" : {
+        "revision" : "a05e6bbe6b141ee68da3030e00275504c0595d4d",
+        "version" : "0.3.6"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
       }
     },
     {

--- a/CodexMobile/CodexMobile/ContentView.swift
+++ b/CodexMobile/CodexMobile/ContentView.swift
@@ -21,6 +21,10 @@ private enum RootSheetRoute: Identifiable, Equatable {
     }
 }
 
+private struct TerminalNavigationRoute: Hashable {
+    let preferredWorkingDirectory: String?
+}
+
 struct ContentView: View {
     @Environment(CodexService.self) private var codex
     @Environment(SubscriptionService.self) private var subscriptions
@@ -355,6 +359,9 @@ struct ContentView: View {
                         showsInlineCloseButton: shouldUseFullWidthSidebar,
                         isVisible: sidebarVisible,
                         onClose: { closeSidebar() },
+                        onOpenTerminal: {
+                            openTerminal(preferredWorkingDirectory: nil)
+                        },
                         onNewChatCreationStateChange: { isCreating in
                             setNewChatOpeningState(isCreating)
                         },
@@ -411,6 +418,10 @@ struct ContentView: View {
                             .adaptiveNavigationBar()
                     }
                 }
+                .navigationDestination(for: TerminalNavigationRoute.self) { route in
+                    TerminalScreen(preferredWorkingDirectory: route.preferredWorkingDirectory)
+                        .adaptiveNavigationBar()
+                }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -427,7 +438,10 @@ struct ContentView: View {
         } else if let thread = selectedThread {
             TurnView(
                 thread: thread,
-                isWakingMacDisplayRecovery: isWakingSavedMacDisplay
+                isWakingMacDisplayRecovery: isWakingSavedMacDisplay,
+                onOpenTerminal: { workingDirectory in
+                    openTerminal(preferredWorkingDirectory: workingDirectory)
+                }
             )
                 .id(thread.id)
                 .environment(\.reconnectAction, {
@@ -768,6 +782,10 @@ struct ContentView: View {
 
             codex.requestImmediateActiveThreadSync(threadId: thread.id)
         }
+    }
+
+    private func openTerminal(preferredWorkingDirectory: String?) {
+        navigationPath.append(TerminalNavigationRoute(preferredWorkingDirectory: preferredWorkingDirectory))
     }
 
     // Prevents a close-swipe release from also activating whichever sidebar row was under the finger.

--- a/CodexMobile/CodexMobile/Services/CodexService+Account.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Account.swift
@@ -120,16 +120,49 @@ enum CodexBridgeHostPlatform: String, Codable, Sendable {
 }
 
 struct CodexBridgeHostCapabilities: Codable, Equatable, Sendable {
+    private enum CodingKeys: String, CodingKey {
+        case desktopHandoff
+        case displayWake
+        case keepAwake
+        case hostBrowserLogin
+        case terminal
+    }
+
     var desktopHandoff: Bool = false
     var displayWake: Bool = false
     var keepAwake: Bool = false
     var hostBrowserLogin: Bool = false
+    var terminal: Bool = false
+
+    init(
+        desktopHandoff: Bool = false,
+        displayWake: Bool = false,
+        keepAwake: Bool = false,
+        hostBrowserLogin: Bool = false,
+        terminal: Bool = false
+    ) {
+        self.desktopHandoff = desktopHandoff
+        self.displayWake = displayWake
+        self.keepAwake = keepAwake
+        self.hostBrowserLogin = hostBrowserLogin
+        self.terminal = terminal
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        desktopHandoff = try container.decodeIfPresent(Bool.self, forKey: .desktopHandoff) ?? false
+        displayWake = try container.decodeIfPresent(Bool.self, forKey: .displayWake) ?? false
+        keepAwake = try container.decodeIfPresent(Bool.self, forKey: .keepAwake) ?? false
+        hostBrowserLogin = try container.decodeIfPresent(Bool.self, forKey: .hostBrowserLogin) ?? false
+        terminal = try container.decodeIfPresent(Bool.self, forKey: .terminal) ?? false
+    }
 
     static let legacyMacOS = CodexBridgeHostCapabilities(
         desktopHandoff: true,
         displayWake: true,
         keepAwake: true,
-        hostBrowserLogin: true
+        hostBrowserLogin: true,
+        terminal: false
     )
 }
 
@@ -1173,7 +1206,8 @@ extension CodexService {
             desktopHandoff: firstBoolValue(in: capabilitiesObject, keys: ["desktopHandoff", "desktop_handoff"]) ?? false,
             displayWake: firstBoolValue(in: capabilitiesObject, keys: ["displayWake", "display_wake"]) ?? false,
             keepAwake: firstBoolValue(in: capabilitiesObject, keys: ["keepAwake", "keep_awake"]) ?? false,
-            hostBrowserLogin: firstBoolValue(in: capabilitiesObject, keys: ["hostBrowserLogin", "host_browser_login"]) ?? false
+            hostBrowserLogin: firstBoolValue(in: capabilitiesObject, keys: ["hostBrowserLogin", "host_browser_login"]) ?? false,
+            terminal: firstBoolValue(in: capabilitiesObject, keys: ["terminal", "sshTerminal", "ssh_terminal"]) ?? false
         )
     }
 

--- a/CodexMobile/CodexMobile/Services/CodexService+Incoming.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Incoming.swift
@@ -296,6 +296,9 @@ extension CodexService {
         case "git/stackedAction/progress":
             handleGitStackedActionProgress(paramsObject)
 
+        case "terminal/event":
+            handleTerminalEvent(paramsObject)
+
         default:
             if method.hasPrefix("codex/event/"),
                handleLegacyCodexNamedEvent(method: method, paramsObject: paramsObject) {

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -452,6 +452,12 @@ final class CodexService {
     var threadCompletionBanner: CodexThreadCompletionBanner?
     // Explains why a push-opened chat could not be restored and offers a recovery path.
     var missingNotificationThreadPrompt: CodexMissingNotificationThreadPrompt?
+    // Interactive SSH terminal state is owned on-device so it can bootstrap a Mac before the bridge runs.
+    var terminalSnapshot: RemodexTerminalSnapshot = .idle
+    var terminalSnapshotsById: [String: RemodexTerminalSnapshot] = [:]
+    var terminalProfile: RemodexTerminalProfile = RemodexTerminalProfileStore.load()
+    @ObservationIgnored let nativeSSHTerminal = RemodexNativeSSHTerminal()
+    @ObservationIgnored var nativeSSHTerminalsById: [String: RemodexNativeSSHTerminal] = [:]
 
     // --- Internal wiring ------------------------------------------------------
 

--- a/CodexMobile/CodexMobile/Services/SecureStore.swift
+++ b/CodexMobile/CodexMobile/Services/SecureStore.swift
@@ -8,22 +8,26 @@ import Foundation
 import Security
 
 enum CodexSecureKeys {
-    static let relaySessionId = "codex.relay.sessionId"
-    static let relayUrl = "codex.relay.url"
-    static let relayMacDeviceId = "codex.relay.macDeviceId"
-    static let relayMacIdentityPublicKey = "codex.relay.macIdentityPublicKey"
-    static let relayProtocolVersion = "codex.relay.protocolVersion"
-    static let relayLastAppliedBridgeOutboundSeq = "codex.relay.lastAppliedBridgeOutboundSeq"
-    static let pushDeviceToken = "codex.push.deviceToken"
-    static let trustedMacRegistry = "codex.secure.trustedMacRegistry"
-    static let lastTrustedMacDeviceId = "codex.secure.lastTrustedMacDeviceId"
-    static let phoneIdentityState = "codex.secure.phoneIdentityState"
-    static let messageHistoryKey = "codex.local.messageHistoryKey"
+    nonisolated static let relaySessionId = "codex.relay.sessionId"
+    nonisolated static let relayUrl = "codex.relay.url"
+    nonisolated static let relayMacDeviceId = "codex.relay.macDeviceId"
+    nonisolated static let relayMacIdentityPublicKey = "codex.relay.macIdentityPublicKey"
+    nonisolated static let relayProtocolVersion = "codex.relay.protocolVersion"
+    nonisolated static let relayLastAppliedBridgeOutboundSeq = "codex.relay.lastAppliedBridgeOutboundSeq"
+    nonisolated static let pushDeviceToken = "codex.push.deviceToken"
+    nonisolated static let trustedMacRegistry = "codex.secure.trustedMacRegistry"
+    nonisolated static let lastTrustedMacDeviceId = "codex.secure.lastTrustedMacDeviceId"
+    nonisolated static let phoneIdentityState = "codex.secure.phoneIdentityState"
+    nonisolated static let messageHistoryKey = "codex.local.messageHistoryKey"
+    nonisolated static let terminalSSHProfile = "codex.terminal.sshProfile"
+    nonisolated static let terminalSSHPrivateKey = "codex.terminal.sshPrivateKey"
+    nonisolated static let terminalSSHPrivateKeyPassphrase = "codex.terminal.sshPrivateKeyPassphrase"
+    nonisolated static let terminalSSHKnownHostPrefix = "codex.terminal.sshKnownHost"
 }
 
 enum SecureStore {
     // Reads a UTF-8 string value from Keychain.
-    static func readString(for key: String) -> String? {
+    nonisolated static func readString(for key: String) -> String? {
         var query = baseQuery(for: key)
         query[kSecReturnData as String] = kCFBooleanTrue
         query[kSecMatchLimit as String] = kSecMatchLimitOne
@@ -41,7 +45,7 @@ enum SecureStore {
     }
 
     // Reads opaque key material or encrypted payload blobs from Keychain.
-    static func readData(for key: String) -> Data? {
+    nonisolated static func readData(for key: String) -> Data? {
         var query = baseQuery(for: key)
         query[kSecReturnData as String] = kCFBooleanTrue
         query[kSecMatchLimit as String] = kSecMatchLimitOne
@@ -58,17 +62,27 @@ enum SecureStore {
     }
 
     // Writes a UTF-8 string to Keychain; empty values are treated as delete.
-    static func writeString(_ value: String, for key: String) {
+    nonisolated static func writeString(_ value: String, for key: String) {
+        writeString(value, for: key, accessibility: nil)
+    }
+
+    // Writes sensitive strings with optional Keychain accessibility constraints.
+    nonisolated static func writeString(_ value: String, for key: String, accessibility: CFString?) {
         if value.isEmpty {
             deleteValue(for: key)
             return
         }
 
-        writeData(Data(value.utf8), for: key)
+        writeData(Data(value.utf8), for: key, accessibility: accessibility)
     }
 
     // Stores raw data in Keychain; used by local message-history encryption keys.
-    static func writeData(_ value: Data, for key: String) {
+    nonisolated static func writeData(_ value: Data, for key: String) {
+        writeData(value, for: key, accessibility: nil)
+    }
+
+    // Stores raw data in Keychain with optional accessibility constraints for key material.
+    nonisolated static func writeData(_ value: Data, for key: String, accessibility: CFString?) {
         if value.isEmpty {
             deleteValue(for: key)
             return
@@ -78,12 +92,15 @@ enum SecureStore {
 
         var query = baseQuery(for: key)
         query[kSecValueData as String] = value
+        if let accessibility {
+            query[kSecAttrAccessible as String] = accessibility
+        }
 
         SecItemAdd(query as CFDictionary, nil)
     }
 
     // Convenience wrapper for small Codable payloads kept in Keychain.
-    static func readCodable<Value: Decodable>(_ type: Value.Type, for key: String) -> Value? {
+    nonisolated static func readCodable<Value: Decodable>(_ type: Value.Type, for key: String) -> Value? {
         guard let data = readData(for: key) else {
             return nil
         }
@@ -91,19 +108,19 @@ enum SecureStore {
     }
 
     // Convenience wrapper for small Codable payloads kept in Keychain.
-    static func writeCodable<Value: Encodable>(_ value: Value, for key: String) {
+    nonisolated static func writeCodable<Value: Encodable>(_ value: Value, for key: String) {
         guard let data = try? JSONEncoder().encode(value) else {
             return
         }
         writeData(data, for: key)
     }
 
-    static func deleteValue(for key: String) {
+    nonisolated static func deleteValue(for key: String) {
         let query = baseQuery(for: key)
         SecItemDelete(query as CFDictionary)
     }
 
-    private static func baseQuery(for key: String) -> [String: Any] {
+    private nonisolated static func baseQuery(for key: String) -> [String: Any] {
         [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: serviceName,
@@ -111,7 +128,7 @@ enum SecureStore {
         ]
     }
 
-    private static var serviceName: String {
+    private nonisolated static var serviceName: String {
         Bundle.main.bundleIdentifier ?? "com.codexmobile.app"
     }
 }

--- a/CodexMobile/CodexMobile/Services/Terminal/CodexService+Terminal.swift
+++ b/CodexMobile/CodexMobile/Services/Terminal/CodexService+Terminal.swift
@@ -1,0 +1,272 @@
+// FILE: CodexService+Terminal.swift
+// Purpose: Starts and controls the on-device SSH terminal session.
+// Layer: Service Extension
+// Exports: CodexService terminal APIs
+// Depends on: CodexService, RemodexNativeSSHTerminal, RemodexTerminalModels
+
+import Foundation
+
+extension CodexService {
+    static let defaultTerminalId = "term-1"
+
+    func terminalSnapshot(for terminalId: String) -> RemodexTerminalSnapshot {
+        if terminalId == Self.defaultTerminalId, terminalSnapshotsById[terminalId] == nil {
+            return terminalSnapshot
+        }
+        return terminalSnapshotsById[terminalId] ?? RemodexTerminalSnapshot.idleSnapshot(terminalId: terminalId)
+    }
+
+    func knownTerminalSnapshots() -> [RemodexTerminalSnapshot] {
+        var snapshots = terminalSnapshotsById
+        snapshots[Self.defaultTerminalId] = snapshots[Self.defaultTerminalId] ?? terminalSnapshot
+        return snapshots.values.sorted { lhs, rhs in
+            terminalSortIndex(lhs.terminalId) < terminalSortIndex(rhs.terminalId)
+        }
+    }
+
+    func openTerminal(
+        profile: RemodexTerminalProfile,
+        cols: Int,
+        rows: Int
+    ) async throws {
+        try await openTerminal(
+            terminalId: Self.defaultTerminalId,
+            profile: profile,
+            cols: cols,
+            rows: rows
+        )
+    }
+
+    func openTerminal(
+        terminalId: String,
+        profile: RemodexTerminalProfile,
+        cols: Int,
+        rows: Int
+    ) async throws {
+        let normalizedProfile = profile.normalizedForSave
+        let instanceId = UUID().uuidString
+        let terminal = nativeTerminal(for: terminalId)
+        terminalProfile = normalizedProfile
+        RemodexTerminalProfileStore.save(normalizedProfile)
+        setTerminalSnapshot(RemodexTerminalSnapshot(
+            terminalId: terminalId,
+            instanceId: instanceId,
+            status: .starting,
+            buffer: "",
+            bufferData: Data(),
+            cwd: normalizedProfile.cwd,
+            cols: cols,
+            rows: rows,
+            errorMessage: nil,
+            resizeSupported: true
+        ), for: terminalId)
+
+        let privateKey = RemodexTerminalPrivateKeyStore.loadPrivateKey()
+        let passphrase = RemodexTerminalPrivateKeyStore.loadPassphrase()
+        do {
+            try await terminal.open(
+                profile: normalizedProfile,
+                privateKey: privateKey,
+                passphrase: passphrase,
+                cols: cols,
+                rows: rows,
+                onConnected: { [weak self] _ in
+                    guard let self else { return }
+                    guard self.isCurrentTerminalInstance(instanceId, terminalId: terminalId) else { return }
+                    self.updateTerminalSnapshot(for: terminalId) { snapshot in
+                        snapshot.status = .running
+                        snapshot.errorMessage = nil
+                        snapshot.resizeSupported = true
+                    }
+                    self.applyConnectedTerminalSizeAndDirectory(
+                        instanceId: instanceId,
+                        terminalId: terminalId,
+                        cwd: normalizedProfile.cwd
+                    )
+                },
+                onOutput: { [weak self] data in
+                    guard self?.isCurrentTerminalInstance(instanceId, terminalId: terminalId) == true else { return }
+                    self?.updateTerminalSnapshot(for: terminalId) { snapshot in
+                        snapshot.appendOutput(data)
+                    }
+                },
+                onFinished: { [weak self] error in
+                    guard let self else { return }
+                    guard self.isCurrentTerminalInstance(instanceId, terminalId: terminalId) else { return }
+                    if let error {
+                        self.updateTerminalSnapshot(for: terminalId) { snapshot in
+                            snapshot.status = .error
+                            snapshot.errorMessage = self.terminalErrorText(error)
+                        }
+                    } else {
+                        self.updateTerminalSnapshot(for: terminalId) { snapshot in
+                            if snapshot.status == .running || snapshot.status == .starting {
+                                snapshot.status = .exited
+                            }
+                        }
+                    }
+                }
+            )
+        } catch {
+            if isCurrentTerminalInstance(instanceId, terminalId: terminalId) {
+                updateTerminalSnapshot(for: terminalId) { snapshot in
+                    snapshot.status = .error
+                    snapshot.errorMessage = terminalErrorText(error)
+                }
+            }
+            throw error
+        }
+    }
+
+    func writeTerminalInput(_ data: Data) async throws {
+        try await writeTerminalInput(data, terminalId: Self.defaultTerminalId)
+    }
+
+    func writeTerminalInput(_ data: Data, terminalId: String) async throws {
+        guard !data.isEmpty else { return }
+        try await nativeTerminal(for: terminalId).write(data)
+    }
+
+    func writeTerminalInput(_ text: String) async throws {
+        try await writeTerminalInput(Data(text.utf8))
+    }
+
+    func resizeTerminal(cols: Int, rows: Int) async throws {
+        try await resizeTerminal(terminalId: Self.defaultTerminalId, cols: cols, rows: rows)
+    }
+
+    func resizeTerminal(terminalId: String, cols: Int, rows: Int) async throws {
+        updateTerminalSnapshot(for: terminalId) { snapshot in
+            snapshot.cols = cols
+            snapshot.rows = rows
+        }
+        guard terminalSnapshot(for: terminalId).status == .running else { return }
+        try await nativeTerminal(for: terminalId).resize(cols: cols, rows: rows)
+    }
+
+    func clearTerminalBuffer() async throws {
+        try await clearTerminalBuffer(terminalId: Self.defaultTerminalId)
+    }
+
+    func clearTerminalBuffer(terminalId: String) async throws {
+        updateTerminalSnapshot(for: terminalId) { snapshot in
+            snapshot.buffer = ""
+            snapshot.bufferData = Data()
+        }
+    }
+
+    func changeTerminalWorkingDirectory(_ cwd: String) async throws {
+        try await changeTerminalWorkingDirectory(cwd, terminalId: Self.defaultTerminalId)
+    }
+
+    func changeTerminalWorkingDirectory(_ cwd: String, terminalId: String) async throws {
+        let trimmedCWD = cwd.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedCWD.isEmpty else { return }
+        updateTerminalSnapshot(for: terminalId) { snapshot in
+            snapshot.cwd = trimmedCWD
+        }
+        terminalProfile.cwd = trimmedCWD
+        RemodexTerminalProfileStore.save(terminalProfile)
+        guard terminalSnapshot(for: terminalId).status == .running else { return }
+        try await writeTerminalInput(
+            Data(shellChangeDirectoryCommand(for: trimmedCWD).utf8),
+            terminalId: terminalId
+        )
+    }
+
+    func closeTerminal() async throws {
+        try await closeTerminal(terminalId: Self.defaultTerminalId)
+    }
+
+    func closeTerminal(terminalId: String) async throws {
+        await nativeTerminal(for: terminalId).close()
+        updateTerminalSnapshot(for: terminalId) { snapshot in
+            snapshot.status = .closed
+            snapshot.errorMessage = nil
+        }
+    }
+
+    func refreshTerminalSnapshot() async throws {
+        // The native SSH session is already the source of truth; no bridge RPC is needed.
+    }
+
+    func handleTerminalEvent(_ paramsObject: IncomingParamsObject?) {
+        // Kept for compatibility with older bridges that might still emit terminal/event.
+    }
+
+    private func sendInitialTerminalDirectoryCommandIfNeeded(_ cwd: String, terminalId: String) async {
+        let trimmedCWD = cwd.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedCWD.isEmpty else { return }
+        try? await writeTerminalInput(
+            Data(shellChangeDirectoryCommand(for: trimmedCWD).utf8),
+            terminalId: terminalId
+        )
+    }
+
+    private func applyConnectedTerminalSizeAndDirectory(instanceId: String, terminalId: String, cwd: String) {
+        Task { @MainActor in
+            guard isCurrentTerminalInstance(instanceId, terminalId: terminalId) else { return }
+            // The surface may have measured its real grid while SSH was still connecting.
+            let snapshot = terminalSnapshot(for: terminalId)
+            try? await nativeTerminal(for: terminalId).resize(cols: snapshot.cols, rows: snapshot.rows)
+            guard isCurrentTerminalInstance(instanceId, terminalId: terminalId) else { return }
+            await sendInitialTerminalDirectoryCommandIfNeeded(cwd, terminalId: terminalId)
+        }
+    }
+
+    private func isCurrentTerminalInstance(_ instanceId: String, terminalId: String) -> Bool {
+        terminalSnapshot(for: terminalId).instanceId == instanceId
+    }
+
+    private func nativeTerminal(for terminalId: String) -> RemodexNativeSSHTerminal {
+        if terminalId == Self.defaultTerminalId {
+            return nativeSSHTerminal
+        }
+        if let terminal = nativeSSHTerminalsById[terminalId] {
+            return terminal
+        }
+        let terminal = RemodexNativeSSHTerminal()
+        nativeSSHTerminalsById[terminalId] = terminal
+        return terminal
+    }
+
+    private func setTerminalSnapshot(_ snapshot: RemodexTerminalSnapshot, for terminalId: String) {
+        terminalSnapshotsById[terminalId] = snapshot
+        if terminalId == Self.defaultTerminalId {
+            terminalSnapshot = snapshot
+        }
+    }
+
+    private func updateTerminalSnapshot(
+        for terminalId: String,
+        mutate: (inout RemodexTerminalSnapshot) -> Void
+    ) {
+        var snapshot = terminalSnapshot(for: terminalId)
+        mutate(&snapshot)
+        setTerminalSnapshot(snapshot, for: terminalId)
+    }
+
+    private func terminalSortIndex(_ terminalId: String) -> Int {
+        guard terminalId.hasPrefix("term-"),
+              let value = Int(terminalId.dropFirst(5)) else {
+            return Int.max
+        }
+        return value
+    }
+
+    private func shellChangeDirectoryCommand(for cwd: String) -> String {
+        "cd \(shellSingleQuoted(cwd))\n"
+    }
+
+    private func shellSingleQuoted(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+
+    private func terminalErrorText(_ error: Error) -> String {
+        if let localizedError = error as? LocalizedError,
+           let description = localizedError.errorDescription {
+            return description
+        }
+        return error.localizedDescription
+    }
+}

--- a/CodexMobile/CodexMobile/Services/Terminal/RemodexNativeSSHTerminal.swift
+++ b/CodexMobile/CodexMobile/Services/Terminal/RemodexNativeSSHTerminal.swift
@@ -1,0 +1,281 @@
+// FILE: RemodexNativeSSHTerminal.swift
+// Purpose: Owns the phone-side SSH client and bridges raw TTY bytes to Ghostty.
+// Layer: Service
+// Exports: RemodexNativeSSHTerminal, RemodexNativeSSHTerminalError
+// Depends on: Citadel, Crypto, Foundation, NIOCore
+
+import Citadel
+import Crypto
+import Foundation
+import NIO
+import NIOCore
+import NIOSSH
+
+enum RemodexNativeSSHTerminalError: LocalizedError {
+    case missingPrivateKey
+    case hostKeyChanged
+    case unsupportedPrivateKey(String)
+    case sessionNotRunning
+
+    var errorDescription: String? {
+        switch self {
+        case .missingPrivateKey:
+            return "Paste your SSH private key before connecting."
+        case .hostKeyChanged:
+            return "The SSH host key changed. Check the host before reconnecting."
+        case .unsupportedPrivateKey(let keyType):
+            return "This SSH key type is not supported yet: \(keyType). Use an Ed25519 or RSA private key."
+        case .sessionNotRunning:
+            return "The SSH terminal is not running."
+        }
+    }
+}
+
+@MainActor
+final class RemodexNativeSSHTerminal {
+    private var client: SSHClient?
+    private var writer: TTYStdinWriter?
+    private var sessionTask: Task<Void, Never>?
+    // Guards shared state so late callbacks from an older SSH task cannot affect a new session.
+    private var currentSessionId: UUID?
+    private var connectContinuation: CheckedContinuation<Void, Error>?
+    private var isUserClosing = false
+
+    var isRunning: Bool {
+        sessionTask != nil
+    }
+
+    func open(
+        profile: RemodexTerminalProfile,
+        privateKey: String,
+        passphrase: String,
+        cols: Int,
+        rows: Int,
+        onConnected: @escaping @MainActor (TTYStdinWriter) -> Void,
+        onOutput: @escaping @MainActor (Data) -> Void,
+        onFinished: @escaping @MainActor (Error?) -> Void
+    ) async throws {
+        let oldClient = client
+        closeLocalState(markUserClosing: true)
+        try? await oldClient?.close()
+        isUserClosing = false
+        let sessionId = UUID()
+        let authenticationMethod = try Self.authenticationMethod(
+            username: profile.username,
+            privateKey: privateKey,
+            passphrase: passphrase
+        )
+
+        try await withCheckedThrowingContinuation { continuation in
+            currentSessionId = sessionId
+            connectContinuation = continuation
+            sessionTask = Task { [weak self] in
+                var connectedClient: SSHClient?
+                do {
+                    let sshClient = try await SSHClient.connect(
+                        host: profile.host,
+                        port: profile.port,
+                        authenticationMethod: authenticationMethod,
+                        hostKeyValidator: .custom(RemodexSSHKnownHostValidator(
+                            host: profile.host,
+                            port: profile.port
+                        )),
+                        reconnect: .never
+                    )
+                    connectedClient = sshClient
+                    let shouldCloseClient = await MainActor.run { () -> Bool in
+                        guard let self, self.isCurrentSession(sessionId) else {
+                            return true
+                        }
+                        self.client = sshClient
+                        return false
+                    }
+                    if shouldCloseClient {
+                        try? await sshClient.close()
+                        return
+                    }
+
+                    try await sshClient.withPTY(
+                        .init(
+                            wantReply: true,
+                            term: "xterm-256color",
+                            terminalCharacterWidth: max(cols, 1),
+                            terminalRowHeight: max(rows, 1),
+                            terminalPixelWidth: 0,
+                            terminalPixelHeight: 0,
+                            terminalModes: .init([.ECHO: 1])
+                        )
+                    ) { inbound, outbound in
+                        try await outbound.changeSize(
+                            cols: cols,
+                            rows: rows,
+                            pixelWidth: 0,
+                            pixelHeight: 0
+                        )
+                        await MainActor.run {
+                            guard let self, self.isCurrentSession(sessionId) else { return }
+                            self.writer = outbound
+                            onConnected(outbound)
+                            self.resumeConnectContinuation(for: sessionId)
+                        }
+
+                        for try await output in inbound {
+                            switch output {
+                            case .stdout(let buffer), .stderr(let buffer):
+                                let data = Data(buffer.readableBytesView)
+                                await MainActor.run {
+                                    guard self?.isCurrentSession(sessionId) == true else { return }
+                                    onOutput(data)
+                                }
+                            }
+                        }
+                    }
+                    try? await sshClient.close()
+
+                    await MainActor.run {
+                        guard let self, self.isCurrentSession(sessionId) else { return }
+                        self.clearSessionReferences(for: sessionId)
+                        onFinished(nil)
+                    }
+                } catch {
+                    if let connectedClient {
+                        try? await connectedClient.close()
+                    }
+                    await MainActor.run {
+                        guard let self, self.isCurrentSession(sessionId) else { return }
+                        let wasUserClosing = self.isUserClosing || error is CancellationError
+                        self.resumeConnectContinuation(for: sessionId, throwing: error)
+                        self.clearSessionReferences(for: sessionId)
+                        onFinished(wasUserClosing ? nil : error)
+                    }
+                }
+            }
+        }
+    }
+
+    func write(_ data: Data) async throws {
+        guard let writer else {
+            throw RemodexNativeSSHTerminalError.sessionNotRunning
+        }
+        var buffer = ByteBufferAllocator().buffer(capacity: data.count)
+        buffer.writeBytes(data)
+        try await writer.write(buffer)
+    }
+
+    func resize(cols: Int, rows: Int) async throws {
+        guard let writer else { return }
+        try await writer.changeSize(cols: cols, rows: rows, pixelWidth: 0, pixelHeight: 0)
+    }
+
+    func close() async {
+        let client = client
+        closeLocalState(markUserClosing: true)
+        try? await client?.close()
+    }
+
+    private func closeLocalState(markUserClosing: Bool = false) {
+        isUserClosing = markUserClosing
+        sessionTask?.cancel()
+        sessionTask = nil
+        currentSessionId = nil
+        writer = nil
+        client = nil
+        if markUserClosing {
+            resumeConnectContinuation()
+        } else {
+            resumeConnectContinuation(throwing: CancellationError())
+        }
+    }
+
+    private func clearSessionReferences(for sessionId: UUID) {
+        guard isCurrentSession(sessionId) else { return }
+        sessionTask = nil
+        currentSessionId = nil
+        writer = nil
+        client = nil
+    }
+
+    private func isCurrentSession(_ sessionId: UUID) -> Bool {
+        currentSessionId == sessionId
+    }
+
+    private func resumeConnectContinuation(for sessionId: UUID) {
+        guard isCurrentSession(sessionId) else { return }
+        resumeConnectContinuation()
+    }
+
+    private func resumeConnectContinuation() {
+        connectContinuation?.resume()
+        connectContinuation = nil
+    }
+
+    private func resumeConnectContinuation(throwing error: Error) {
+        connectContinuation?.resume(throwing: error)
+        connectContinuation = nil
+    }
+
+    private func resumeConnectContinuation(for sessionId: UUID, throwing error: Error) {
+        guard isCurrentSession(sessionId) else { return }
+        resumeConnectContinuation(throwing: error)
+    }
+
+    private static func authenticationMethod(
+        username: String,
+        privateKey: String,
+        passphrase: String
+    ) throws -> SSHAuthenticationMethod {
+        let normalizedKey = privateKey
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedKey.isEmpty else {
+            throw RemodexNativeSSHTerminalError.missingPrivateKey
+        }
+
+        let decryptionKey = passphrase.isEmpty ? nil : Data(passphrase.utf8)
+        let keyType = try SSHKeyDetection.detectPrivateKeyType(from: normalizedKey)
+        switch keyType {
+        case .ed25519:
+            let key = try Curve25519.Signing.PrivateKey(
+                sshEd25519: normalizedKey,
+                decryptionKey: decryptionKey
+            )
+            return .ed25519(username: username, privateKey: key)
+        case .rsa:
+            let key = try Insecure.RSA.PrivateKey(
+                sshRsa: normalizedKey,
+                decryptionKey: decryptionKey
+            )
+            return .rsa(username: username, privateKey: key)
+        default:
+            throw RemodexNativeSSHTerminalError.unsupportedPrivateKey(keyType.description)
+        }
+    }
+}
+
+private struct RemodexSSHKnownHostValidator: NIOSSHClientServerAuthenticationDelegate, Sendable {
+    let host: String
+    let port: Int
+
+    nonisolated init(host: String, port: Int) {
+        self.host = host
+        self.port = port
+    }
+
+    nonisolated func validateHostKey(
+        hostKey: NIOSSHPublicKey,
+        validationCompletePromise: EventLoopPromise<Void>
+    ) {
+        let currentHostKey = String(openSSHPublicKey: hostKey)
+        if let storedHostKey = RemodexSSHKnownHostStore.load(host: host, port: port) {
+            if storedHostKey == currentHostKey {
+                validationCompletePromise.succeed(())
+            } else {
+                validationCompletePromise.fail(RemodexNativeSSHTerminalError.hostKeyChanged)
+            }
+            return
+        }
+
+        RemodexSSHKnownHostStore.save(currentHostKey, host: host, port: port)
+        validationCompletePromise.succeed(())
+    }
+}

--- a/CodexMobile/CodexMobile/Services/Terminal/RemodexSSHKnownHostStore.swift
+++ b/CodexMobile/CodexMobile/Services/Terminal/RemodexSSHKnownHostStore.swift
@@ -1,0 +1,28 @@
+// FILE: RemodexSSHKnownHostStore.swift
+// Purpose: Persists SSH host keys for trust-on-first-use validation.
+// Layer: Service
+// Exports: RemodexSSHKnownHostStore
+// Depends on: Foundation, SecureStore
+
+import Foundation
+
+enum RemodexSSHKnownHostStore {
+    nonisolated static func load(host: String, port: Int) -> String? {
+        SecureStore.readString(for: storageKey(host: host, port: port))
+    }
+
+    nonisolated static func save(_ hostKey: String, host: String, port: Int) {
+        SecureStore.writeString(hostKey, for: storageKey(host: host, port: port))
+    }
+
+    nonisolated static func delete(host: String, port: Int) {
+        SecureStore.deleteValue(for: storageKey(host: host, port: port))
+    }
+
+    private nonisolated static func storageKey(host: String, port: Int) -> String {
+        let normalizedHost = host
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return "\(CodexSecureKeys.terminalSSHKnownHostPrefix).\(normalizedHost):\(port)"
+    }
+}

--- a/CodexMobile/CodexMobile/Services/Terminal/RemodexTerminalModels.swift
+++ b/CodexMobile/CodexMobile/Services/Terminal/RemodexTerminalModels.swift
@@ -1,0 +1,318 @@
+// FILE: RemodexTerminalModels.swift
+// Purpose: Defines the native SSH terminal profile and runtime snapshot models.
+// Layer: Service Model
+// Exports: RemodexTerminalProfile, RemodexTerminalSnapshot, RemodexTerminalStatus
+// Depends on: Foundation, JSONValue
+
+import Foundation
+
+private let remodexTerminalMaxBufferCharacters = 200_000
+private let remodexTerminalMaxBufferBytes = 200_000
+private let remodexDefaultTerminalId = "term-1"
+
+enum RemodexTerminalStatus: String, Codable, Equatable, Sendable {
+    case idle
+    case starting
+    case running
+    case exited
+    case closed
+    case error
+
+    var isRunning: Bool {
+        self == .starting || self == .running
+    }
+
+    var displayTitle: String {
+        switch self {
+        case .idle:
+            return "Idle"
+        case .starting:
+            return "Connecting"
+        case .running:
+            return "Running"
+        case .exited:
+            return "Exited"
+        case .closed:
+            return "Closed"
+        case .error:
+            return "Error"
+        }
+    }
+}
+
+struct RemodexTerminalProfile: Codable, Equatable, Sendable {
+    var host: String
+    var username: String
+    var port: Int
+    var cwd: String
+    var nickname: String
+
+    enum CodingKeys: String, CodingKey {
+        case host
+        case username
+        case port
+        case cwd
+        case nickname
+    }
+
+    init(host: String, username: String, port: Int, cwd: String, nickname: String = "") {
+        self.host = host
+        self.username = username
+        self.port = port
+        self.cwd = cwd
+        self.nickname = nickname
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        host = try container.decodeIfPresent(String.self, forKey: .host) ?? ""
+        username = try container.decodeIfPresent(String.self, forKey: .username) ?? ""
+        port = try container.decodeIfPresent(Int.self, forKey: .port) ?? 22
+        cwd = try container.decodeIfPresent(String.self, forKey: .cwd) ?? ""
+        nickname = try container.decodeIfPresent(String.self, forKey: .nickname) ?? ""
+    }
+
+    static var empty: RemodexTerminalProfile {
+        RemodexTerminalProfile(
+            host: "",
+            username: "",
+            port: 22,
+            cwd: "",
+            nickname: ""
+        )
+    }
+
+    var connectionString: String {
+        let trimmedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedUser = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        let portSuffix = port == 22 ? "" : ":\(port)"
+        guard !trimmedUser.isEmpty else {
+            return "\(trimmedHost)\(portSuffix)"
+        }
+        return "\(trimmedUser)@\(trimmedHost)\(portSuffix)"
+    }
+
+    var displayTarget: String {
+        let trimmedNickname = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedNickname.isEmpty {
+            return trimmedNickname
+        }
+        let trimmedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedUser = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedUser.isEmpty else {
+            return trimmedHost.isEmpty ? "SSH host" : trimmedHost
+        }
+        return "\(trimmedUser)@\(trimmedHost)"
+    }
+
+    var normalizedForSave: RemodexTerminalProfile {
+        RemodexTerminalProfile(
+            host: host.trimmingCharacters(in: .whitespacesAndNewlines),
+            username: username.trimmingCharacters(in: .whitespacesAndNewlines),
+            port: max(1, min(65535, port)),
+            cwd: cwd.trimmingCharacters(in: .whitespacesAndNewlines),
+            nickname: nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+    mutating func applyPreferredWorkingDirectoryOverride(_ workingDirectory: String?) {
+        guard let workingDirectory = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !workingDirectory.isEmpty else {
+            return
+        }
+        cwd = workingDirectory
+    }
+
+    mutating func applyConnectionString(_ value: String) {
+        var rawValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if rawValue.hasPrefix("ssh ") {
+            rawValue.removeFirst(4)
+            rawValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        guard !rawValue.isEmpty else { return }
+
+        let userAndHost = rawValue.split(separator: "@", maxSplits: 1, omittingEmptySubsequences: false)
+        if userAndHost.count == 2 {
+            username = String(userAndHost[0])
+            applyHostAndPort(String(userAndHost[1]))
+        } else {
+            applyHostAndPort(rawValue)
+        }
+    }
+
+    private mutating func applyHostAndPort(_ value: String) {
+        let hostAndPort = value.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        host = String(hostAndPort.first ?? "")
+        if hostAndPort.count == 2, let parsedPort = Int(hostAndPort[1]) {
+            port = max(1, min(65535, parsedPort))
+        }
+    }
+}
+
+struct RemodexTerminalSnapshot: Equatable, Sendable {
+    var terminalId: String
+    var instanceId: String?
+    var status: RemodexTerminalStatus
+    var buffer: String
+    var bufferData: Data
+    var cwd: String
+    var cols: Int
+    var rows: Int
+    var errorMessage: String?
+    var resizeSupported: Bool
+
+    static let idle = RemodexTerminalSnapshot(
+        terminalId: remodexDefaultTerminalId,
+        instanceId: nil,
+        status: .idle,
+        buffer: "",
+        bufferData: Data(),
+        cwd: "",
+        cols: 80,
+        rows: 24,
+        errorMessage: nil,
+        resizeSupported: false
+    )
+
+    static func idleSnapshot(terminalId: String) -> RemodexTerminalSnapshot {
+        var snapshot = idle
+        snapshot.terminalId = terminalId
+        return snapshot
+    }
+
+    init(
+        terminalId: String,
+        instanceId: String?,
+        status: RemodexTerminalStatus,
+        buffer: String,
+        bufferData: Data,
+        cwd: String,
+        cols: Int,
+        rows: Int,
+        errorMessage: String?,
+        resizeSupported: Bool
+    ) {
+        self.terminalId = terminalId
+        self.instanceId = instanceId
+        self.status = status
+        self.buffer = buffer
+        self.bufferData = bufferData
+        self.cwd = cwd
+        self.cols = cols
+        self.rows = rows
+        self.errorMessage = errorMessage
+        self.resizeSupported = resizeSupported
+    }
+
+    init(resultObject: [String: JSONValue]) {
+        let rawStatus = resultObject["status"]?.stringValue ?? RemodexTerminalStatus.idle.rawValue
+        let historyText = resultObject["history"]?.stringValue ?? resultObject["buffer"]?.stringValue ?? ""
+        let historyData = Self.dataFromBase64(resultObject["historyBase64"]?.stringValue ?? resultObject["history_base64"]?.stringValue)
+            ?? Self.dataFromBase64(resultObject["dataBase64"]?.stringValue ?? resultObject["data_base64"]?.stringValue)
+            ?? Data(historyText.utf8)
+        self.init(
+            terminalId: resultObject["terminalId"]?.stringValue ?? resultObject["terminal_id"]?.stringValue ?? remodexDefaultTerminalId,
+            instanceId: Self.instanceId(in: resultObject),
+            status: RemodexTerminalStatus(rawValue: rawStatus) ?? .idle,
+            buffer: Self.trimmedBuffer(historyText.isEmpty ? String(decoding: historyData, as: UTF8.self) : historyText),
+            bufferData: Self.trimmedBufferData(historyData),
+            cwd: resultObject["cwd"]?.stringValue ?? "",
+            cols: resultObject["cols"]?.intValue ?? 80,
+            rows: resultObject["rows"]?.intValue ?? 24,
+            errorMessage: resultObject["error"]?.stringValue,
+            resizeSupported: resultObject["resizeSupported"]?.boolValue ?? false
+        )
+    }
+
+    mutating func applyTerminalEvent(_ paramsObject: [String: JSONValue]) {
+        if let incomingInstanceId = Self.instanceId(in: paramsObject) {
+            if let instanceId, instanceId != incomingInstanceId {
+                return
+            }
+            instanceId = incomingInstanceId
+        }
+        if let terminalId = paramsObject["terminalId"]?.stringValue ?? paramsObject["terminal_id"]?.stringValue {
+            self.terminalId = terminalId
+        }
+        if let rawStatus = paramsObject["status"]?.stringValue,
+           let status = RemodexTerminalStatus(rawValue: rawStatus) {
+            self.status = status
+        }
+        if let history = paramsObject["history"]?.stringValue {
+            buffer = Self.trimmedBuffer(history)
+            bufferData = Self.trimmedBufferData(Self.dataFromBase64(
+                paramsObject["historyBase64"]?.stringValue ?? paramsObject["history_base64"]?.stringValue
+            ) ?? Data(history.utf8))
+        } else if let historyBase64 = paramsObject["historyBase64"]?.stringValue ?? paramsObject["history_base64"]?.stringValue,
+                  let historyData = Self.dataFromBase64(historyBase64) {
+            bufferData = Self.trimmedBufferData(historyData)
+            buffer = Self.trimmedBuffer(String(decoding: historyData, as: UTF8.self))
+        } else if let dataBase64 = paramsObject["dataBase64"]?.stringValue ?? paramsObject["data_base64"]?.stringValue,
+                  let data = Self.dataFromBase64(dataBase64) {
+            bufferData = Self.appendingBufferData(bufferData, data)
+            let text = paramsObject["data"]?.stringValue ?? String(decoding: data, as: UTF8.self)
+            buffer = Self.trimmedBuffer(buffer + text)
+        } else if let data = paramsObject["data"]?.stringValue {
+            buffer = Self.trimmedBuffer(buffer + data)
+            bufferData = Self.appendingBufferData(bufferData, Data(data.utf8))
+        }
+        if let cwd = paramsObject["cwd"]?.stringValue {
+            self.cwd = cwd
+        }
+        if let cols = paramsObject["cols"]?.intValue {
+            self.cols = cols
+        }
+        if let rows = paramsObject["rows"]?.intValue {
+            self.rows = rows
+        }
+        if let errorValue = paramsObject["error"] {
+            errorMessage = errorValue.stringValue
+        }
+        if let resizeSupported = paramsObject["resizeSupported"]?.boolValue {
+            self.resizeSupported = resizeSupported
+        }
+    }
+
+    mutating func appendOutput(_ data: Data) {
+        guard !data.isEmpty else { return }
+        bufferData = Self.appendingBufferData(bufferData, data)
+        buffer = Self.trimmedBuffer(buffer + String(decoding: data, as: UTF8.self))
+    }
+
+    static func instanceId(in object: [String: JSONValue]) -> String? {
+        object["instanceId"]?.stringValue
+            ?? object["instance_id"]?.stringValue
+            ?? object["sessionId"]?.stringValue
+            ?? object["session_id"]?.stringValue
+    }
+
+    private static func trimmedBuffer(_ value: String) -> String {
+        guard value.count > remodexTerminalMaxBufferCharacters else {
+            return value
+        }
+        return String(value.suffix(remodexTerminalMaxBufferCharacters))
+    }
+
+    private static func trimmedBufferData(_ value: Data) -> Data {
+        guard value.count > remodexTerminalMaxBufferBytes else {
+            return value
+        }
+        return Data(value.suffix(remodexTerminalMaxBufferBytes))
+    }
+
+    private static func dataFromBase64(_ value: String?) -> Data? {
+        guard let value else {
+            return nil
+        }
+        guard !value.isEmpty else {
+            return Data()
+        }
+        return Data(base64Encoded: value)
+    }
+
+    private static func appendingBufferData(_ lhs: Data, _ rhs: Data) -> Data {
+        var result = lhs
+        result.append(rhs)
+        return trimmedBufferData(result)
+    }
+}

--- a/CodexMobile/CodexMobile/Services/Terminal/RemodexTerminalPrivateKeyStore.swift
+++ b/CodexMobile/CodexMobile/Services/Terminal/RemodexTerminalPrivateKeyStore.swift
@@ -1,0 +1,45 @@
+// FILE: RemodexTerminalPrivateKeyStore.swift
+// Purpose: Stores the phone-side SSH private key material used by the native terminal.
+// Layer: Service
+// Exports: RemodexTerminalPrivateKeyStore
+// Depends on: Foundation, SecureStore
+
+import Foundation
+import Security
+
+enum RemodexTerminalPrivateKeyStore {
+    static func loadPrivateKey() -> String {
+        SecureStore.readString(for: CodexSecureKeys.terminalSSHPrivateKey) ?? ""
+    }
+
+    static func savePrivateKey(_ value: String) {
+        SecureStore.writeString(
+            normalizedPrivateKey(value),
+            for: CodexSecureKeys.terminalSSHPrivateKey,
+            accessibility: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        )
+    }
+
+    static func loadPassphrase() -> String {
+        SecureStore.readString(for: CodexSecureKeys.terminalSSHPrivateKeyPassphrase) ?? ""
+    }
+
+    static func savePassphrase(_ value: String) {
+        SecureStore.writeString(
+            value,
+            for: CodexSecureKeys.terminalSSHPrivateKeyPassphrase,
+            accessibility: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        )
+    }
+
+    static func hasPrivateKey(_ value: String? = nil) -> Bool {
+        let key = normalizedPrivateKey(value ?? loadPrivateKey())
+        return key.contains("PRIVATE KEY")
+    }
+
+    private static func normalizedPrivateKey(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/CodexMobile/CodexMobile/Services/Terminal/RemodexTerminalProfileStore.swift
+++ b/CodexMobile/CodexMobile/Services/Terminal/RemodexTerminalProfileStore.swift
@@ -1,0 +1,19 @@
+// FILE: RemodexTerminalProfileStore.swift
+// Purpose: Persists the SSH terminal profile in Keychain-backed app storage.
+// Layer: Service
+// Exports: RemodexTerminalProfileStore
+// Depends on: SecureStore, RemodexTerminalProfile
+
+import Foundation
+
+enum RemodexTerminalProfileStore {
+    // Keeps host/key-path configuration with the same Keychain protection as pairing metadata.
+    static func load() -> RemodexTerminalProfile {
+        SecureStore.readCodable(RemodexTerminalProfile.self, for: CodexSecureKeys.terminalSSHProfile)
+            ?? .empty
+    }
+
+    static func save(_ profile: RemodexTerminalProfile) {
+        SecureStore.writeCodable(profile.normalizedForSave, for: CodexSecureKeys.terminalSSHProfile)
+    }
+}

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/Info.plist
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AvailableLibraries</key>
+	<array>
+		<dict>
+			<key>BinaryPath</key>
+			<string>libghostty-fat.a</string>
+			<key>HeadersPath</key>
+			<string>Headers</string>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64</string>
+			<key>LibraryPath</key>
+			<string>libghostty-fat.a</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+		</dict>
+		<dict>
+			<key>BinaryPath</key>
+			<string>libghostty-fat.a</string>
+			<key>HeadersPath</key>
+			<string>Headers</string>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64-simulator</string>
+			<key>LibraryPath</key>
+			<string>libghostty-fat.a</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+			<key>SupportedPlatformVariant</key>
+			<string>simulator</string>
+		</dict>
+	</array>
+	<key>CFBundlePackageType</key>
+	<string>XFWK</string>
+	<key>XCFrameworkFormatVersion</key>
+	<string>1.0</string>
+</dict>
+</plist>

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty.h
@@ -1,0 +1,1218 @@
+// Ghostty embedding API. The documentation for the embedding API is
+// only within the Zig source files that define the implementations. This
+// isn't meant to be a general purpose embedding API (yet) so there hasn't
+// been documentation or example work beyond that.
+//
+// The only consumer of this API is the macOS app, but the API is built to
+// be more general purpose.
+#ifndef GHOSTTY_H
+#define GHOSTTY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#else
+#include <sys/types.h>
+#endif
+
+//-------------------------------------------------------------------
+// Macros
+
+#define GHOSTTY_SUCCESS 0
+
+// Symbol visibility for shared library builds. On Windows, functions
+// are exported from the DLL when building and imported when consuming.
+// On other platforms with GCC/Clang, functions are marked with default
+// visibility so they remain accessible when the library is built with
+// -fvisibility=hidden. For static library builds, define GHOSTTY_STATIC
+// before including this header to make this a no-op.
+#ifndef GHOSTTY_API
+#if defined(GHOSTTY_STATIC)
+  #define GHOSTTY_API
+#elif defined(_WIN32) || defined(_WIN64)
+  #ifdef GHOSTTY_BUILD_SHARED
+    #define GHOSTTY_API __declspec(dllexport)
+  #else
+    #define GHOSTTY_API __declspec(dllimport)
+  #endif
+#elif defined(__GNUC__) && __GNUC__ >= 4
+  #define GHOSTTY_API __attribute__((visibility("default")))
+#else
+  #define GHOSTTY_API
+#endif
+#endif
+
+//-------------------------------------------------------------------
+// Types
+
+// Opaque types
+typedef void* ghostty_app_t;
+typedef void* ghostty_config_t;
+typedef void* ghostty_surface_t;
+typedef void* ghostty_inspector_t;
+
+// All the types below are fully defined and must be kept in sync with
+// their Zig counterparts. Any changes to these types MUST have an associated
+// Zig change.
+typedef enum {
+  GHOSTTY_PLATFORM_INVALID,
+  GHOSTTY_PLATFORM_MACOS,
+  GHOSTTY_PLATFORM_IOS,
+} ghostty_platform_e;
+
+// Callback for custom I/O write handler.
+typedef void (*ghostty_surface_write_fn)(void* userdata,
+                                         const uint8_t* data,
+                                         size_t len);
+
+typedef enum {
+  GHOSTTY_CLIPBOARD_STANDARD,
+  GHOSTTY_CLIPBOARD_SELECTION,
+} ghostty_clipboard_e;
+
+typedef struct {
+  const char *mime;
+  const char *data;
+} ghostty_clipboard_content_s;
+
+typedef enum {
+  GHOSTTY_CLIPBOARD_REQUEST_PASTE,
+  GHOSTTY_CLIPBOARD_REQUEST_OSC_52_READ,
+  GHOSTTY_CLIPBOARD_REQUEST_OSC_52_WRITE,
+} ghostty_clipboard_request_e;
+
+typedef enum {
+  GHOSTTY_MOUSE_RELEASE,
+  GHOSTTY_MOUSE_PRESS,
+} ghostty_input_mouse_state_e;
+
+typedef enum {
+  GHOSTTY_MOUSE_UNKNOWN,
+  GHOSTTY_MOUSE_LEFT,
+  GHOSTTY_MOUSE_RIGHT,
+  GHOSTTY_MOUSE_MIDDLE,
+  GHOSTTY_MOUSE_FOUR,
+  GHOSTTY_MOUSE_FIVE,
+  GHOSTTY_MOUSE_SIX,
+  GHOSTTY_MOUSE_SEVEN,
+  GHOSTTY_MOUSE_EIGHT,
+  GHOSTTY_MOUSE_NINE,
+  GHOSTTY_MOUSE_TEN,
+  GHOSTTY_MOUSE_ELEVEN,
+} ghostty_input_mouse_button_e;
+
+typedef enum {
+  GHOSTTY_MOUSE_MOMENTUM_NONE,
+  GHOSTTY_MOUSE_MOMENTUM_BEGAN,
+  GHOSTTY_MOUSE_MOMENTUM_STATIONARY,
+  GHOSTTY_MOUSE_MOMENTUM_CHANGED,
+  GHOSTTY_MOUSE_MOMENTUM_ENDED,
+  GHOSTTY_MOUSE_MOMENTUM_CANCELLED,
+  GHOSTTY_MOUSE_MOMENTUM_MAY_BEGIN,
+} ghostty_input_mouse_momentum_e;
+
+typedef enum {
+  GHOSTTY_COLOR_SCHEME_LIGHT = 0,
+  GHOSTTY_COLOR_SCHEME_DARK = 1,
+} ghostty_color_scheme_e;
+
+// This is a packed struct (see src/input/mouse.zig) but the C standard
+// afaik doesn't let us reliably define packed structs so we build it up
+// from scratch.
+typedef int ghostty_input_scroll_mods_t;
+
+typedef enum {
+  GHOSTTY_MODS_NONE = 0,
+  GHOSTTY_MODS_SHIFT = 1 << 0,
+  GHOSTTY_MODS_CTRL = 1 << 1,
+  GHOSTTY_MODS_ALT = 1 << 2,
+  GHOSTTY_MODS_SUPER = 1 << 3,
+  GHOSTTY_MODS_CAPS = 1 << 4,
+  GHOSTTY_MODS_NUM = 1 << 5,
+  GHOSTTY_MODS_SHIFT_RIGHT = 1 << 6,
+  GHOSTTY_MODS_CTRL_RIGHT = 1 << 7,
+  GHOSTTY_MODS_ALT_RIGHT = 1 << 8,
+  GHOSTTY_MODS_SUPER_RIGHT = 1 << 9,
+} ghostty_input_mods_e;
+
+typedef enum {
+  GHOSTTY_BINDING_FLAGS_CONSUMED = 1 << 0,
+  GHOSTTY_BINDING_FLAGS_ALL = 1 << 1,
+  GHOSTTY_BINDING_FLAGS_GLOBAL = 1 << 2,
+  GHOSTTY_BINDING_FLAGS_PERFORMABLE = 1 << 3,
+} ghostty_binding_flags_e;
+
+typedef enum {
+  GHOSTTY_ACTION_RELEASE,
+  GHOSTTY_ACTION_PRESS,
+  GHOSTTY_ACTION_REPEAT,
+} ghostty_input_action_e;
+
+// Based on: https://www.w3.org/TR/uievents-code/
+typedef enum {
+  GHOSTTY_KEY_UNIDENTIFIED,
+
+  // "Writing System Keys" § 3.1.1
+  GHOSTTY_KEY_BACKQUOTE,
+  GHOSTTY_KEY_BACKSLASH,
+  GHOSTTY_KEY_BRACKET_LEFT,
+  GHOSTTY_KEY_BRACKET_RIGHT,
+  GHOSTTY_KEY_COMMA,
+  GHOSTTY_KEY_DIGIT_0,
+  GHOSTTY_KEY_DIGIT_1,
+  GHOSTTY_KEY_DIGIT_2,
+  GHOSTTY_KEY_DIGIT_3,
+  GHOSTTY_KEY_DIGIT_4,
+  GHOSTTY_KEY_DIGIT_5,
+  GHOSTTY_KEY_DIGIT_6,
+  GHOSTTY_KEY_DIGIT_7,
+  GHOSTTY_KEY_DIGIT_8,
+  GHOSTTY_KEY_DIGIT_9,
+  GHOSTTY_KEY_EQUAL,
+  GHOSTTY_KEY_INTL_BACKSLASH,
+  GHOSTTY_KEY_INTL_RO,
+  GHOSTTY_KEY_INTL_YEN,
+  GHOSTTY_KEY_A,
+  GHOSTTY_KEY_B,
+  GHOSTTY_KEY_C,
+  GHOSTTY_KEY_D,
+  GHOSTTY_KEY_E,
+  GHOSTTY_KEY_F,
+  GHOSTTY_KEY_G,
+  GHOSTTY_KEY_H,
+  GHOSTTY_KEY_I,
+  GHOSTTY_KEY_J,
+  GHOSTTY_KEY_K,
+  GHOSTTY_KEY_L,
+  GHOSTTY_KEY_M,
+  GHOSTTY_KEY_N,
+  GHOSTTY_KEY_O,
+  GHOSTTY_KEY_P,
+  GHOSTTY_KEY_Q,
+  GHOSTTY_KEY_R,
+  GHOSTTY_KEY_S,
+  GHOSTTY_KEY_T,
+  GHOSTTY_KEY_U,
+  GHOSTTY_KEY_V,
+  GHOSTTY_KEY_W,
+  GHOSTTY_KEY_X,
+  GHOSTTY_KEY_Y,
+  GHOSTTY_KEY_Z,
+  GHOSTTY_KEY_MINUS,
+  GHOSTTY_KEY_PERIOD,
+  GHOSTTY_KEY_QUOTE,
+  GHOSTTY_KEY_SEMICOLON,
+  GHOSTTY_KEY_SLASH,
+
+  // "Functional Keys" § 3.1.2
+  GHOSTTY_KEY_ALT_LEFT,
+  GHOSTTY_KEY_ALT_RIGHT,
+  GHOSTTY_KEY_BACKSPACE,
+  GHOSTTY_KEY_CAPS_LOCK,
+  GHOSTTY_KEY_CONTEXT_MENU,
+  GHOSTTY_KEY_CONTROL_LEFT,
+  GHOSTTY_KEY_CONTROL_RIGHT,
+  GHOSTTY_KEY_ENTER,
+  GHOSTTY_KEY_META_LEFT,
+  GHOSTTY_KEY_META_RIGHT,
+  GHOSTTY_KEY_SHIFT_LEFT,
+  GHOSTTY_KEY_SHIFT_RIGHT,
+  GHOSTTY_KEY_SPACE,
+  GHOSTTY_KEY_TAB,
+  GHOSTTY_KEY_CONVERT,
+  GHOSTTY_KEY_KANA_MODE,
+  GHOSTTY_KEY_NON_CONVERT,
+
+  // "Control Pad Section" § 3.2
+  GHOSTTY_KEY_DELETE,
+  GHOSTTY_KEY_END,
+  GHOSTTY_KEY_HELP,
+  GHOSTTY_KEY_HOME,
+  GHOSTTY_KEY_INSERT,
+  GHOSTTY_KEY_PAGE_DOWN,
+  GHOSTTY_KEY_PAGE_UP,
+
+  // "Arrow Pad Section" § 3.3
+  GHOSTTY_KEY_ARROW_DOWN,
+  GHOSTTY_KEY_ARROW_LEFT,
+  GHOSTTY_KEY_ARROW_RIGHT,
+  GHOSTTY_KEY_ARROW_UP,
+
+  // "Numpad Section" § 3.4
+  GHOSTTY_KEY_NUM_LOCK,
+  GHOSTTY_KEY_NUMPAD_0,
+  GHOSTTY_KEY_NUMPAD_1,
+  GHOSTTY_KEY_NUMPAD_2,
+  GHOSTTY_KEY_NUMPAD_3,
+  GHOSTTY_KEY_NUMPAD_4,
+  GHOSTTY_KEY_NUMPAD_5,
+  GHOSTTY_KEY_NUMPAD_6,
+  GHOSTTY_KEY_NUMPAD_7,
+  GHOSTTY_KEY_NUMPAD_8,
+  GHOSTTY_KEY_NUMPAD_9,
+  GHOSTTY_KEY_NUMPAD_ADD,
+  GHOSTTY_KEY_NUMPAD_BACKSPACE,
+  GHOSTTY_KEY_NUMPAD_CLEAR,
+  GHOSTTY_KEY_NUMPAD_CLEAR_ENTRY,
+  GHOSTTY_KEY_NUMPAD_COMMA,
+  GHOSTTY_KEY_NUMPAD_DECIMAL,
+  GHOSTTY_KEY_NUMPAD_DIVIDE,
+  GHOSTTY_KEY_NUMPAD_ENTER,
+  GHOSTTY_KEY_NUMPAD_EQUAL,
+  GHOSTTY_KEY_NUMPAD_MEMORY_ADD,
+  GHOSTTY_KEY_NUMPAD_MEMORY_CLEAR,
+  GHOSTTY_KEY_NUMPAD_MEMORY_RECALL,
+  GHOSTTY_KEY_NUMPAD_MEMORY_STORE,
+  GHOSTTY_KEY_NUMPAD_MEMORY_SUBTRACT,
+  GHOSTTY_KEY_NUMPAD_MULTIPLY,
+  GHOSTTY_KEY_NUMPAD_PAREN_LEFT,
+  GHOSTTY_KEY_NUMPAD_PAREN_RIGHT,
+  GHOSTTY_KEY_NUMPAD_SUBTRACT,
+  GHOSTTY_KEY_NUMPAD_SEPARATOR,
+  GHOSTTY_KEY_NUMPAD_UP,
+  GHOSTTY_KEY_NUMPAD_DOWN,
+  GHOSTTY_KEY_NUMPAD_RIGHT,
+  GHOSTTY_KEY_NUMPAD_LEFT,
+  GHOSTTY_KEY_NUMPAD_BEGIN,
+  GHOSTTY_KEY_NUMPAD_HOME,
+  GHOSTTY_KEY_NUMPAD_END,
+  GHOSTTY_KEY_NUMPAD_INSERT,
+  GHOSTTY_KEY_NUMPAD_DELETE,
+  GHOSTTY_KEY_NUMPAD_PAGE_UP,
+  GHOSTTY_KEY_NUMPAD_PAGE_DOWN,
+
+  // "Function Section" § 3.5
+  GHOSTTY_KEY_ESCAPE,
+  GHOSTTY_KEY_F1,
+  GHOSTTY_KEY_F2,
+  GHOSTTY_KEY_F3,
+  GHOSTTY_KEY_F4,
+  GHOSTTY_KEY_F5,
+  GHOSTTY_KEY_F6,
+  GHOSTTY_KEY_F7,
+  GHOSTTY_KEY_F8,
+  GHOSTTY_KEY_F9,
+  GHOSTTY_KEY_F10,
+  GHOSTTY_KEY_F11,
+  GHOSTTY_KEY_F12,
+  GHOSTTY_KEY_F13,
+  GHOSTTY_KEY_F14,
+  GHOSTTY_KEY_F15,
+  GHOSTTY_KEY_F16,
+  GHOSTTY_KEY_F17,
+  GHOSTTY_KEY_F18,
+  GHOSTTY_KEY_F19,
+  GHOSTTY_KEY_F20,
+  GHOSTTY_KEY_F21,
+  GHOSTTY_KEY_F22,
+  GHOSTTY_KEY_F23,
+  GHOSTTY_KEY_F24,
+  GHOSTTY_KEY_F25,
+  GHOSTTY_KEY_FN,
+  GHOSTTY_KEY_FN_LOCK,
+  GHOSTTY_KEY_PRINT_SCREEN,
+  GHOSTTY_KEY_SCROLL_LOCK,
+  GHOSTTY_KEY_PAUSE,
+
+  // "Media Keys" § 3.6
+  GHOSTTY_KEY_BROWSER_BACK,
+  GHOSTTY_KEY_BROWSER_FAVORITES,
+  GHOSTTY_KEY_BROWSER_FORWARD,
+  GHOSTTY_KEY_BROWSER_HOME,
+  GHOSTTY_KEY_BROWSER_REFRESH,
+  GHOSTTY_KEY_BROWSER_SEARCH,
+  GHOSTTY_KEY_BROWSER_STOP,
+  GHOSTTY_KEY_EJECT,
+  GHOSTTY_KEY_LAUNCH_APP_1,
+  GHOSTTY_KEY_LAUNCH_APP_2,
+  GHOSTTY_KEY_LAUNCH_MAIL,
+  GHOSTTY_KEY_MEDIA_PLAY_PAUSE,
+  GHOSTTY_KEY_MEDIA_SELECT,
+  GHOSTTY_KEY_MEDIA_STOP,
+  GHOSTTY_KEY_MEDIA_TRACK_NEXT,
+  GHOSTTY_KEY_MEDIA_TRACK_PREVIOUS,
+  GHOSTTY_KEY_POWER,
+  GHOSTTY_KEY_SLEEP,
+  GHOSTTY_KEY_AUDIO_VOLUME_DOWN,
+  GHOSTTY_KEY_AUDIO_VOLUME_MUTE,
+  GHOSTTY_KEY_AUDIO_VOLUME_UP,
+  GHOSTTY_KEY_WAKE_UP,
+
+  // "Legacy, Non-standard, and Special Keys" § 3.7
+  GHOSTTY_KEY_COPY,
+  GHOSTTY_KEY_CUT,
+  GHOSTTY_KEY_PASTE,
+} ghostty_input_key_e;
+
+typedef struct {
+  ghostty_input_action_e action;
+  ghostty_input_mods_e mods;
+  ghostty_input_mods_e consumed_mods;
+  uint32_t keycode;
+  const char* text;
+  uint32_t unshifted_codepoint;
+  bool composing;
+} ghostty_input_key_s;
+
+typedef enum {
+  GHOSTTY_TRIGGER_PHYSICAL,
+  GHOSTTY_TRIGGER_UNICODE,
+  GHOSTTY_TRIGGER_CATCH_ALL,
+} ghostty_input_trigger_tag_e;
+
+typedef union {
+  ghostty_input_key_e translated;
+  ghostty_input_key_e physical;
+  uint32_t unicode;
+  // catch_all has no payload
+} ghostty_input_trigger_key_u;
+
+typedef struct {
+  ghostty_input_trigger_tag_e tag;
+  ghostty_input_trigger_key_u key;
+  ghostty_input_mods_e mods;
+} ghostty_input_trigger_s;
+
+typedef struct {
+  const char* action_key;
+  const char* action;
+  const char* title;
+  const char* description;
+} ghostty_command_s;
+
+typedef enum {
+  GHOSTTY_BUILD_MODE_DEBUG,
+  GHOSTTY_BUILD_MODE_RELEASE_SAFE,
+  GHOSTTY_BUILD_MODE_RELEASE_FAST,
+  GHOSTTY_BUILD_MODE_RELEASE_SMALL,
+} ghostty_build_mode_e;
+
+typedef struct {
+  ghostty_build_mode_e build_mode;
+  const char* version;
+  uintptr_t version_len;
+} ghostty_info_s;
+
+typedef struct {
+  const char* message;
+} ghostty_diagnostic_s;
+
+typedef struct {
+  const char* ptr;
+  uintptr_t len;
+  bool sentinel;
+} ghostty_string_s;
+
+typedef struct {
+  double tl_px_x;
+  double tl_px_y;
+  uint32_t offset_start;
+  uint32_t offset_len;
+  const char* text;
+  uintptr_t text_len;
+} ghostty_text_s;
+
+typedef enum {
+  GHOSTTY_POINT_ACTIVE,
+  GHOSTTY_POINT_VIEWPORT,
+  GHOSTTY_POINT_SCREEN,
+  GHOSTTY_POINT_SURFACE,
+} ghostty_point_tag_e;
+
+typedef enum {
+  GHOSTTY_POINT_COORD_EXACT,
+  GHOSTTY_POINT_COORD_TOP_LEFT,
+  GHOSTTY_POINT_COORD_BOTTOM_RIGHT,
+} ghostty_point_coord_e;
+
+typedef struct {
+  ghostty_point_tag_e tag;
+  ghostty_point_coord_e coord;
+  uint32_t x;
+  uint32_t y;
+} ghostty_point_s;
+
+typedef struct {
+  ghostty_point_s top_left;
+  ghostty_point_s bottom_right;
+  bool rectangle;
+} ghostty_selection_s;
+
+typedef struct {
+  const char* key;
+  const char* value;
+} ghostty_env_var_s;
+
+typedef struct {
+  void* nsview;
+} ghostty_platform_macos_s;
+
+typedef struct {
+  void* uiview;
+} ghostty_platform_ios_s;
+
+typedef union {
+  ghostty_platform_macos_s macos;
+  ghostty_platform_ios_s ios;
+} ghostty_platform_u;
+
+typedef enum {
+  GHOSTTY_SURFACE_CONTEXT_WINDOW = 0,
+  GHOSTTY_SURFACE_CONTEXT_TAB = 1,
+  GHOSTTY_SURFACE_CONTEXT_SPLIT = 2,
+} ghostty_surface_context_e;
+
+typedef struct {
+  ghostty_platform_e platform_tag;
+  ghostty_platform_u platform;
+  void* userdata;
+  double scale_factor;
+  float font_size;
+  const char* working_directory;
+  const char* command;
+  ghostty_env_var_s* env_vars;
+  size_t env_var_count;
+  const char* initial_input;
+  bool wait_after_command;
+  ghostty_surface_context_e context;
+  bool use_custom_io;
+} ghostty_surface_config_s;
+
+typedef struct {
+  uint16_t columns;
+  uint16_t rows;
+  uint32_t width_px;
+  uint32_t height_px;
+  uint32_t cell_width_px;
+  uint32_t cell_height_px;
+} ghostty_surface_size_s;
+
+// Config types
+
+// config.Path
+typedef struct {
+  const char* path;
+  bool optional;
+} ghostty_config_path_s;
+
+// config.Color
+typedef struct {
+  uint8_t r;
+  uint8_t g;
+  uint8_t b;
+} ghostty_config_color_s;
+
+// config.ColorList
+typedef struct {
+  const ghostty_config_color_s* colors;
+  size_t len;
+} ghostty_config_color_list_s;
+
+// config.RepeatableCommand
+typedef struct {
+  const ghostty_command_s* commands;
+  size_t len;
+} ghostty_config_command_list_s;
+
+// config.Palette
+typedef struct {
+  ghostty_config_color_s colors[256];
+} ghostty_config_palette_s;
+
+// config.QuickTerminalSize
+typedef enum {
+  GHOSTTY_QUICK_TERMINAL_SIZE_NONE,
+  GHOSTTY_QUICK_TERMINAL_SIZE_PERCENTAGE,
+  GHOSTTY_QUICK_TERMINAL_SIZE_PIXELS,
+} ghostty_quick_terminal_size_tag_e;
+
+typedef union {
+  float percentage;
+  uint32_t pixels;
+} ghostty_quick_terminal_size_value_u;
+
+typedef struct {
+  ghostty_quick_terminal_size_tag_e tag;
+  ghostty_quick_terminal_size_value_u value;
+} ghostty_quick_terminal_size_s;
+
+typedef struct {
+  ghostty_quick_terminal_size_s primary;
+  ghostty_quick_terminal_size_s secondary;
+} ghostty_config_quick_terminal_size_s;
+
+// config.Fullscreen
+typedef enum {
+  GHOSTTY_CONFIG_FULLSCREEN_FALSE,
+  GHOSTTY_CONFIG_FULLSCREEN_TRUE,
+  GHOSTTY_CONFIG_FULLSCREEN_NON_NATIVE,
+  GHOSTTY_CONFIG_FULLSCREEN_NON_NATIVE_VISIBLE_MENU,
+  GHOSTTY_CONFIG_FULLSCREEN_NON_NATIVE_PADDED_NOTCH,
+} ghostty_config_fullscreen_e;
+
+// apprt.Target.Key
+typedef enum {
+  GHOSTTY_TARGET_APP,
+  GHOSTTY_TARGET_SURFACE,
+} ghostty_target_tag_e;
+
+typedef union {
+  ghostty_surface_t surface;
+} ghostty_target_u;
+
+typedef struct {
+  ghostty_target_tag_e tag;
+  ghostty_target_u target;
+} ghostty_target_s;
+
+// apprt.action.SplitDirection
+typedef enum {
+  GHOSTTY_SPLIT_DIRECTION_RIGHT,
+  GHOSTTY_SPLIT_DIRECTION_DOWN,
+  GHOSTTY_SPLIT_DIRECTION_LEFT,
+  GHOSTTY_SPLIT_DIRECTION_UP,
+} ghostty_action_split_direction_e;
+
+// apprt.action.GotoSplit
+typedef enum {
+  GHOSTTY_GOTO_SPLIT_PREVIOUS,
+  GHOSTTY_GOTO_SPLIT_NEXT,
+  GHOSTTY_GOTO_SPLIT_UP,
+  GHOSTTY_GOTO_SPLIT_LEFT,
+  GHOSTTY_GOTO_SPLIT_DOWN,
+  GHOSTTY_GOTO_SPLIT_RIGHT,
+} ghostty_action_goto_split_e;
+
+// apprt.action.GotoWindow
+typedef enum {
+  GHOSTTY_GOTO_WINDOW_PREVIOUS,
+  GHOSTTY_GOTO_WINDOW_NEXT,
+} ghostty_action_goto_window_e;
+
+// apprt.action.ResizeSplit.Direction
+typedef enum {
+  GHOSTTY_RESIZE_SPLIT_UP,
+  GHOSTTY_RESIZE_SPLIT_DOWN,
+  GHOSTTY_RESIZE_SPLIT_LEFT,
+  GHOSTTY_RESIZE_SPLIT_RIGHT,
+} ghostty_action_resize_split_direction_e;
+
+// apprt.action.ResizeSplit
+typedef struct {
+  uint16_t amount;
+  ghostty_action_resize_split_direction_e direction;
+} ghostty_action_resize_split_s;
+
+// apprt.action.MoveTab
+typedef struct {
+  ssize_t amount;
+} ghostty_action_move_tab_s;
+
+// apprt.action.GotoTab
+typedef enum {
+  GHOSTTY_GOTO_TAB_PREVIOUS = -1,
+  GHOSTTY_GOTO_TAB_NEXT = -2,
+  GHOSTTY_GOTO_TAB_LAST = -3,
+} ghostty_action_goto_tab_e;
+
+// apprt.action.Fullscreen
+typedef enum {
+  GHOSTTY_FULLSCREEN_NATIVE,
+  GHOSTTY_FULLSCREEN_MACOS_NON_NATIVE,
+  GHOSTTY_FULLSCREEN_MACOS_NON_NATIVE_VISIBLE_MENU,
+  GHOSTTY_FULLSCREEN_MACOS_NON_NATIVE_PADDED_NOTCH,
+} ghostty_action_fullscreen_e;
+
+// apprt.action.FloatWindow
+typedef enum {
+  GHOSTTY_FLOAT_WINDOW_ON,
+  GHOSTTY_FLOAT_WINDOW_OFF,
+  GHOSTTY_FLOAT_WINDOW_TOGGLE,
+} ghostty_action_float_window_e;
+
+// apprt.action.SecureInput
+typedef enum {
+  GHOSTTY_SECURE_INPUT_ON,
+  GHOSTTY_SECURE_INPUT_OFF,
+  GHOSTTY_SECURE_INPUT_TOGGLE,
+} ghostty_action_secure_input_e;
+
+// apprt.action.Inspector
+typedef enum {
+  GHOSTTY_INSPECTOR_TOGGLE,
+  GHOSTTY_INSPECTOR_SHOW,
+  GHOSTTY_INSPECTOR_HIDE,
+} ghostty_action_inspector_e;
+
+// apprt.action.QuitTimer
+typedef enum {
+  GHOSTTY_QUIT_TIMER_START,
+  GHOSTTY_QUIT_TIMER_STOP,
+} ghostty_action_quit_timer_e;
+
+// apprt.action.Readonly
+typedef enum {
+  GHOSTTY_READONLY_OFF,
+  GHOSTTY_READONLY_ON,
+} ghostty_action_readonly_e;
+
+// apprt.action.DesktopNotification.C
+typedef struct {
+  const char* title;
+  const char* body;
+} ghostty_action_desktop_notification_s;
+
+// apprt.action.SetTitle.C
+typedef struct {
+  const char* title;
+} ghostty_action_set_title_s;
+
+// apprt.action.PromptTitle
+typedef enum {
+  GHOSTTY_PROMPT_TITLE_SURFACE,
+  GHOSTTY_PROMPT_TITLE_TAB,
+} ghostty_action_prompt_title_e;
+
+// apprt.action.Pwd.C
+typedef struct {
+  const char* pwd;
+} ghostty_action_pwd_s;
+
+// terminal.MouseShape
+typedef enum {
+  GHOSTTY_MOUSE_SHAPE_DEFAULT,
+  GHOSTTY_MOUSE_SHAPE_CONTEXT_MENU,
+  GHOSTTY_MOUSE_SHAPE_HELP,
+  GHOSTTY_MOUSE_SHAPE_POINTER,
+  GHOSTTY_MOUSE_SHAPE_PROGRESS,
+  GHOSTTY_MOUSE_SHAPE_WAIT,
+  GHOSTTY_MOUSE_SHAPE_CELL,
+  GHOSTTY_MOUSE_SHAPE_CROSSHAIR,
+  GHOSTTY_MOUSE_SHAPE_TEXT,
+  GHOSTTY_MOUSE_SHAPE_VERTICAL_TEXT,
+  GHOSTTY_MOUSE_SHAPE_ALIAS,
+  GHOSTTY_MOUSE_SHAPE_COPY,
+  GHOSTTY_MOUSE_SHAPE_MOVE,
+  GHOSTTY_MOUSE_SHAPE_NO_DROP,
+  GHOSTTY_MOUSE_SHAPE_NOT_ALLOWED,
+  GHOSTTY_MOUSE_SHAPE_GRAB,
+  GHOSTTY_MOUSE_SHAPE_GRABBING,
+  GHOSTTY_MOUSE_SHAPE_ALL_SCROLL,
+  GHOSTTY_MOUSE_SHAPE_COL_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_ROW_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_N_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_E_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_S_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_W_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_NE_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_NW_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_SE_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_SW_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_EW_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_NS_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_NESW_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_NWSE_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_ZOOM_IN,
+  GHOSTTY_MOUSE_SHAPE_ZOOM_OUT,
+} ghostty_action_mouse_shape_e;
+
+// apprt.action.MouseVisibility
+typedef enum {
+  GHOSTTY_MOUSE_VISIBLE,
+  GHOSTTY_MOUSE_HIDDEN,
+} ghostty_action_mouse_visibility_e;
+
+// apprt.action.MouseOverLink
+typedef struct {
+  const char* url;
+  size_t len;
+} ghostty_action_mouse_over_link_s;
+
+// apprt.action.SizeLimit
+typedef struct {
+  uint32_t min_width;
+  uint32_t min_height;
+  uint32_t max_width;
+  uint32_t max_height;
+} ghostty_action_size_limit_s;
+
+// apprt.action.InitialSize
+typedef struct {
+  uint32_t width;
+  uint32_t height;
+} ghostty_action_initial_size_s;
+
+// apprt.action.CellSize
+typedef struct {
+  uint32_t width;
+  uint32_t height;
+} ghostty_action_cell_size_s;
+
+// renderer.Health
+typedef enum {
+  GHOSTTY_RENDERER_HEALTH_HEALTHY,
+  GHOSTTY_RENDERER_HEALTH_UNHEALTHY,
+} ghostty_action_renderer_health_e;
+
+// apprt.action.KeySequence
+typedef struct {
+  bool active;
+  ghostty_input_trigger_s trigger;
+} ghostty_action_key_sequence_s;
+
+// apprt.action.KeyTable.Tag
+typedef enum {
+  GHOSTTY_KEY_TABLE_ACTIVATE,
+  GHOSTTY_KEY_TABLE_DEACTIVATE,
+  GHOSTTY_KEY_TABLE_DEACTIVATE_ALL,
+} ghostty_action_key_table_tag_e;
+
+// apprt.action.KeyTable.CValue
+typedef union {
+  struct {
+    const char *name;
+    size_t len;
+  } activate;
+} ghostty_action_key_table_u;
+
+// apprt.action.KeyTable.C
+typedef struct {
+  ghostty_action_key_table_tag_e tag;
+  ghostty_action_key_table_u value;
+} ghostty_action_key_table_s;
+
+// apprt.action.ColorKind
+typedef enum {
+  GHOSTTY_ACTION_COLOR_KIND_FOREGROUND = -1,
+  GHOSTTY_ACTION_COLOR_KIND_BACKGROUND = -2,
+  GHOSTTY_ACTION_COLOR_KIND_CURSOR = -3,
+} ghostty_action_color_kind_e;
+
+// apprt.action.ColorChange
+typedef struct {
+  ghostty_action_color_kind_e kind;
+  uint8_t r;
+  uint8_t g;
+  uint8_t b;
+} ghostty_action_color_change_s;
+
+// apprt.action.ConfigChange
+typedef struct {
+  ghostty_config_t config;
+} ghostty_action_config_change_s;
+
+// apprt.action.ReloadConfig
+typedef struct {
+  bool soft;
+} ghostty_action_reload_config_s;
+
+// apprt.action.OpenUrlKind
+typedef enum {
+  GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN,
+  GHOSTTY_ACTION_OPEN_URL_KIND_TEXT,
+  GHOSTTY_ACTION_OPEN_URL_KIND_HTML,
+} ghostty_action_open_url_kind_e;
+
+// apprt.action.OpenUrl.C
+typedef struct {
+  ghostty_action_open_url_kind_e kind;
+  const char* url;
+  uintptr_t len;
+} ghostty_action_open_url_s;
+
+// apprt.action.CloseTabMode
+typedef enum {
+  GHOSTTY_ACTION_CLOSE_TAB_MODE_THIS,
+  GHOSTTY_ACTION_CLOSE_TAB_MODE_OTHER,
+  GHOSTTY_ACTION_CLOSE_TAB_MODE_RIGHT,
+} ghostty_action_close_tab_mode_e;
+
+// apprt.surface.Message.ChildExited
+typedef struct {
+  uint32_t exit_code;
+  uint64_t timetime_ms;
+} ghostty_surface_message_childexited_s;
+
+// terminal.osc.Command.ProgressReport.State
+typedef enum {
+  GHOSTTY_PROGRESS_STATE_REMOVE,
+  GHOSTTY_PROGRESS_STATE_SET,
+  GHOSTTY_PROGRESS_STATE_ERROR,
+  GHOSTTY_PROGRESS_STATE_INDETERMINATE,
+  GHOSTTY_PROGRESS_STATE_PAUSE,
+} ghostty_action_progress_report_state_e;
+
+// terminal.osc.Command.ProgressReport.C
+typedef struct {
+  ghostty_action_progress_report_state_e state;
+  // -1 if no progress was reported, otherwise 0-100 indicating percent
+  // completeness.
+  int8_t progress;
+} ghostty_action_progress_report_s;
+
+// apprt.action.CommandFinished.C
+typedef struct {
+  // -1 if no exit code was reported, otherwise 0-255
+  int16_t exit_code;
+  // number of nanoseconds that command was running for
+  uint64_t duration;
+} ghostty_action_command_finished_s;
+
+// apprt.action.StartSearch.C
+typedef struct {
+  const char* needle;
+} ghostty_action_start_search_s;
+
+// apprt.action.SearchTotal
+typedef struct {
+  ssize_t total;
+} ghostty_action_search_total_s;
+
+// apprt.action.SearchSelected
+typedef struct {
+  ssize_t selected;
+} ghostty_action_search_selected_s;
+
+// terminal.Scrollbar
+typedef struct {
+  uint64_t total;
+  uint64_t offset;
+  uint64_t len;
+} ghostty_action_scrollbar_s;
+
+// apprt.Action.Key
+typedef enum {
+  GHOSTTY_ACTION_QUIT,
+  GHOSTTY_ACTION_NEW_WINDOW,
+  GHOSTTY_ACTION_NEW_TAB,
+  GHOSTTY_ACTION_CLOSE_TAB,
+  GHOSTTY_ACTION_NEW_SPLIT,
+  GHOSTTY_ACTION_CLOSE_ALL_WINDOWS,
+  GHOSTTY_ACTION_TOGGLE_MAXIMIZE,
+  GHOSTTY_ACTION_TOGGLE_FULLSCREEN,
+  GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW,
+  GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS,
+  GHOSTTY_ACTION_TOGGLE_QUICK_TERMINAL,
+  GHOSTTY_ACTION_TOGGLE_COMMAND_PALETTE,
+  GHOSTTY_ACTION_TOGGLE_VISIBILITY,
+  GHOSTTY_ACTION_TOGGLE_BACKGROUND_OPACITY,
+  GHOSTTY_ACTION_MOVE_TAB,
+  GHOSTTY_ACTION_GOTO_TAB,
+  GHOSTTY_ACTION_GOTO_SPLIT,
+  GHOSTTY_ACTION_GOTO_WINDOW,
+  GHOSTTY_ACTION_RESIZE_SPLIT,
+  GHOSTTY_ACTION_EQUALIZE_SPLITS,
+  GHOSTTY_ACTION_TOGGLE_SPLIT_ZOOM,
+  GHOSTTY_ACTION_PRESENT_TERMINAL,
+  GHOSTTY_ACTION_SIZE_LIMIT,
+  GHOSTTY_ACTION_RESET_WINDOW_SIZE,
+  GHOSTTY_ACTION_INITIAL_SIZE,
+  GHOSTTY_ACTION_CELL_SIZE,
+  GHOSTTY_ACTION_SCROLLBAR,
+  GHOSTTY_ACTION_RENDER,
+  GHOSTTY_ACTION_INSPECTOR,
+  GHOSTTY_ACTION_SHOW_GTK_INSPECTOR,
+  GHOSTTY_ACTION_RENDER_INSPECTOR,
+  GHOSTTY_ACTION_DESKTOP_NOTIFICATION,
+  GHOSTTY_ACTION_SET_TITLE,
+  GHOSTTY_ACTION_SET_TAB_TITLE,
+  GHOSTTY_ACTION_PROMPT_TITLE,
+  GHOSTTY_ACTION_PWD,
+  GHOSTTY_ACTION_MOUSE_SHAPE,
+  GHOSTTY_ACTION_MOUSE_VISIBILITY,
+  GHOSTTY_ACTION_MOUSE_OVER_LINK,
+  GHOSTTY_ACTION_RENDERER_HEALTH,
+  GHOSTTY_ACTION_OPEN_CONFIG,
+  GHOSTTY_ACTION_QUIT_TIMER,
+  GHOSTTY_ACTION_FLOAT_WINDOW,
+  GHOSTTY_ACTION_SECURE_INPUT,
+  GHOSTTY_ACTION_KEY_SEQUENCE,
+  GHOSTTY_ACTION_KEY_TABLE,
+  GHOSTTY_ACTION_COLOR_CHANGE,
+  GHOSTTY_ACTION_RELOAD_CONFIG,
+  GHOSTTY_ACTION_CONFIG_CHANGE,
+  GHOSTTY_ACTION_CLOSE_WINDOW,
+  GHOSTTY_ACTION_RING_BELL,
+  GHOSTTY_ACTION_UNDO,
+  GHOSTTY_ACTION_REDO,
+  GHOSTTY_ACTION_CHECK_FOR_UPDATES,
+  GHOSTTY_ACTION_OPEN_URL,
+  GHOSTTY_ACTION_SHOW_CHILD_EXITED,
+  GHOSTTY_ACTION_PROGRESS_REPORT,
+  GHOSTTY_ACTION_SHOW_ON_SCREEN_KEYBOARD,
+  GHOSTTY_ACTION_COMMAND_FINISHED,
+  GHOSTTY_ACTION_START_SEARCH,
+  GHOSTTY_ACTION_END_SEARCH,
+  GHOSTTY_ACTION_SEARCH_TOTAL,
+  GHOSTTY_ACTION_SEARCH_SELECTED,
+  GHOSTTY_ACTION_READONLY,
+  GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD,
+} ghostty_action_tag_e;
+
+typedef union {
+  ghostty_action_split_direction_e new_split;
+  ghostty_action_fullscreen_e toggle_fullscreen;
+  ghostty_action_move_tab_s move_tab;
+  ghostty_action_goto_tab_e goto_tab;
+  ghostty_action_goto_split_e goto_split;
+  ghostty_action_goto_window_e goto_window;
+  ghostty_action_resize_split_s resize_split;
+  ghostty_action_size_limit_s size_limit;
+  ghostty_action_initial_size_s initial_size;
+  ghostty_action_cell_size_s cell_size;
+  ghostty_action_scrollbar_s scrollbar;
+  ghostty_action_inspector_e inspector;
+  ghostty_action_desktop_notification_s desktop_notification;
+  ghostty_action_set_title_s set_title;
+  ghostty_action_set_title_s set_tab_title;
+  ghostty_action_prompt_title_e prompt_title;
+  ghostty_action_pwd_s pwd;
+  ghostty_action_mouse_shape_e mouse_shape;
+  ghostty_action_mouse_visibility_e mouse_visibility;
+  ghostty_action_mouse_over_link_s mouse_over_link;
+  ghostty_action_renderer_health_e renderer_health;
+  ghostty_action_quit_timer_e quit_timer;
+  ghostty_action_float_window_e float_window;
+  ghostty_action_secure_input_e secure_input;
+  ghostty_action_key_sequence_s key_sequence;
+  ghostty_action_key_table_s key_table;
+  ghostty_action_color_change_s color_change;
+  ghostty_action_reload_config_s reload_config;
+  ghostty_action_config_change_s config_change;
+  ghostty_action_open_url_s open_url;
+  ghostty_action_close_tab_mode_e close_tab_mode;
+  ghostty_surface_message_childexited_s child_exited;
+  ghostty_action_progress_report_s progress_report;
+  ghostty_action_command_finished_s command_finished;
+  ghostty_action_start_search_s start_search;
+  ghostty_action_search_total_s search_total;
+  ghostty_action_search_selected_s search_selected;
+  ghostty_action_readonly_e readonly;
+} ghostty_action_u;
+
+typedef struct {
+  ghostty_action_tag_e tag;
+  ghostty_action_u action;
+} ghostty_action_s;
+
+typedef void (*ghostty_runtime_wakeup_cb)(void*);
+typedef bool (*ghostty_runtime_read_clipboard_cb)(void*,
+                                                  ghostty_clipboard_e,
+                                                  void*);
+typedef void (*ghostty_runtime_confirm_read_clipboard_cb)(
+    void*,
+    const char*,
+    void*,
+    ghostty_clipboard_request_e);
+typedef void (*ghostty_runtime_write_clipboard_cb)(void*,
+                                                   ghostty_clipboard_e,
+                                                   const ghostty_clipboard_content_s*,
+                                                   size_t,
+                                                   bool);
+typedef void (*ghostty_runtime_close_surface_cb)(void*, bool);
+typedef bool (*ghostty_runtime_action_cb)(ghostty_app_t,
+                                          ghostty_target_s,
+                                          ghostty_action_s);
+
+typedef struct {
+  void* userdata;
+  bool supports_selection_clipboard;
+  ghostty_runtime_wakeup_cb wakeup_cb;
+  ghostty_runtime_action_cb action_cb;
+  ghostty_runtime_read_clipboard_cb read_clipboard_cb;
+  ghostty_runtime_confirm_read_clipboard_cb confirm_read_clipboard_cb;
+  ghostty_runtime_write_clipboard_cb write_clipboard_cb;
+  ghostty_runtime_close_surface_cb close_surface_cb;
+} ghostty_runtime_config_s;
+
+// apprt.ipc.Target.Key
+typedef enum {
+  GHOSTTY_IPC_TARGET_CLASS,
+  GHOSTTY_IPC_TARGET_DETECT,
+} ghostty_ipc_target_tag_e;
+
+typedef union {
+  char *klass;
+} ghostty_ipc_target_u;
+
+typedef struct {
+  ghostty_ipc_target_tag_e tag;
+  ghostty_ipc_target_u target;
+} chostty_ipc_target_s;
+
+// apprt.ipc.Action.NewWindow
+typedef struct {
+  // This should be a null terminated list of strings.
+  const char **arguments;
+} ghostty_ipc_action_new_window_s;
+
+typedef union {
+  ghostty_ipc_action_new_window_s new_window;
+} ghostty_ipc_action_u;
+
+// apprt.ipc.Action.Key
+typedef enum {
+  GHOSTTY_IPC_ACTION_NEW_WINDOW,
+} ghostty_ipc_action_tag_e;
+
+//-------------------------------------------------------------------
+// Published API
+
+GHOSTTY_API int ghostty_init(uintptr_t, char**);
+GHOSTTY_API void ghostty_cli_try_action(void);
+GHOSTTY_API ghostty_info_s ghostty_info(void);
+GHOSTTY_API const char* ghostty_translate(const char*);
+GHOSTTY_API void ghostty_string_free(ghostty_string_s);
+
+GHOSTTY_API ghostty_config_t ghostty_config_new();
+GHOSTTY_API void ghostty_config_free(ghostty_config_t);
+GHOSTTY_API ghostty_config_t ghostty_config_clone(ghostty_config_t);
+GHOSTTY_API void ghostty_config_load_cli_args(ghostty_config_t);
+GHOSTTY_API void ghostty_config_load_file(ghostty_config_t, const char*);
+GHOSTTY_API void ghostty_config_load_default_files(ghostty_config_t);
+GHOSTTY_API void ghostty_config_load_recursive_files(ghostty_config_t);
+GHOSTTY_API void ghostty_config_finalize(ghostty_config_t);
+GHOSTTY_API bool ghostty_config_get(ghostty_config_t, void*, const char*, uintptr_t);
+GHOSTTY_API ghostty_input_trigger_s ghostty_config_trigger(ghostty_config_t,
+                                                              const char*,
+                                                              uintptr_t);
+GHOSTTY_API uint32_t ghostty_config_diagnostics_count(ghostty_config_t);
+GHOSTTY_API ghostty_diagnostic_s ghostty_config_get_diagnostic(ghostty_config_t, uint32_t);
+GHOSTTY_API ghostty_string_s ghostty_config_open_path(void);
+
+GHOSTTY_API ghostty_app_t ghostty_app_new(const ghostty_runtime_config_s*,
+                                             ghostty_config_t);
+GHOSTTY_API void ghostty_app_free(ghostty_app_t);
+GHOSTTY_API void ghostty_app_tick(ghostty_app_t);
+GHOSTTY_API void* ghostty_app_userdata(ghostty_app_t);
+GHOSTTY_API void ghostty_app_set_focus(ghostty_app_t, bool);
+GHOSTTY_API bool ghostty_app_key(ghostty_app_t, ghostty_input_key_s);
+GHOSTTY_API bool ghostty_app_key_is_binding(ghostty_app_t, ghostty_input_key_s);
+GHOSTTY_API void ghostty_app_keyboard_changed(ghostty_app_t);
+GHOSTTY_API void ghostty_app_open_config(ghostty_app_t);
+GHOSTTY_API void ghostty_app_update_config(ghostty_app_t, ghostty_config_t);
+GHOSTTY_API bool ghostty_app_needs_confirm_quit(ghostty_app_t);
+GHOSTTY_API bool ghostty_app_has_global_keybinds(ghostty_app_t);
+GHOSTTY_API void ghostty_app_set_color_scheme(ghostty_app_t, ghostty_color_scheme_e);
+
+GHOSTTY_API ghostty_surface_config_s ghostty_surface_config_new();
+
+GHOSTTY_API ghostty_surface_t ghostty_surface_new(ghostty_app_t,
+                                                     const ghostty_surface_config_s*);
+GHOSTTY_API void ghostty_surface_free(ghostty_surface_t);
+GHOSTTY_API void* ghostty_surface_userdata(ghostty_surface_t);
+GHOSTTY_API ghostty_app_t ghostty_surface_app(ghostty_surface_t);
+GHOSTTY_API ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t, ghostty_surface_context_e);
+GHOSTTY_API void ghostty_surface_update_config(ghostty_surface_t, ghostty_config_t);
+GHOSTTY_API bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_process_exited(ghostty_surface_t);
+GHOSTTY_API void ghostty_surface_refresh(ghostty_surface_t);
+GHOSTTY_API void ghostty_surface_draw(ghostty_surface_t);
+GHOSTTY_API void ghostty_surface_feed_data(ghostty_surface_t, const uint8_t*, size_t);
+GHOSTTY_API void ghostty_surface_set_write_callback(ghostty_surface_t,
+                                                       ghostty_surface_write_fn,
+                                                       void*);
+GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
+GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
+GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
+GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
+GHOSTTY_API ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
+GHOSTTY_API uint64_t ghostty_surface_foreground_pid(ghostty_surface_t);
+GHOSTTY_API ghostty_string_s ghostty_surface_tty_name(ghostty_surface_t);
+GHOSTTY_API void ghostty_surface_set_color_scheme(ghostty_surface_t,
+                                                     ghostty_color_scheme_e);
+GHOSTTY_API ghostty_input_mods_e ghostty_surface_key_translation_mods(ghostty_surface_t,
+                                                                         ghostty_input_mods_e);
+GHOSTTY_API bool ghostty_surface_key(ghostty_surface_t, ghostty_input_key_s);
+GHOSTTY_API bool ghostty_surface_key_is_binding(ghostty_surface_t,
+                                                   ghostty_input_key_s,
+                                                   ghostty_binding_flags_e*);
+GHOSTTY_API void ghostty_surface_text(ghostty_surface_t, const char*, uintptr_t);
+GHOSTTY_API void ghostty_surface_preedit(ghostty_surface_t, const char*, uintptr_t);
+GHOSTTY_API bool ghostty_surface_mouse_captured(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_mouse_button(ghostty_surface_t,
+                                                 ghostty_input_mouse_state_e,
+                                                 ghostty_input_mouse_button_e,
+                                                 ghostty_input_mods_e);
+GHOSTTY_API void ghostty_surface_mouse_pos(ghostty_surface_t,
+                                              double,
+                                              double,
+                                              ghostty_input_mods_e);
+GHOSTTY_API void ghostty_surface_mouse_scroll(ghostty_surface_t,
+                                                 double,
+                                                 double,
+                                                 ghostty_input_scroll_mods_t);
+GHOSTTY_API void ghostty_surface_mouse_pressure(ghostty_surface_t, uint32_t, double);
+GHOSTTY_API void ghostty_surface_ime_point(ghostty_surface_t, double*, double*, double*, double*);
+GHOSTTY_API void ghostty_surface_request_close(ghostty_surface_t);
+GHOSTTY_API void ghostty_surface_split(ghostty_surface_t, ghostty_action_split_direction_e);
+GHOSTTY_API void ghostty_surface_split_focus(ghostty_surface_t,
+                                                ghostty_action_goto_split_e);
+GHOSTTY_API void ghostty_surface_split_resize(ghostty_surface_t,
+                                                 ghostty_action_resize_split_direction_e,
+                                                 uint16_t);
+GHOSTTY_API void ghostty_surface_split_equalize(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_binding_action(ghostty_surface_t, const char*, uintptr_t);
+GHOSTTY_API void ghostty_surface_complete_clipboard_request(ghostty_surface_t,
+                                                               const char*,
+                                                               void*,
+                                                               bool);
+GHOSTTY_API bool ghostty_surface_has_selection(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
+GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,
+                                              ghostty_selection_s,
+                                              ghostty_text_s*);
+GHOSTTY_API void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
+
+#ifdef __APPLE__
+GHOSTTY_API void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);
+GHOSTTY_API void* ghostty_surface_quicklook_font(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_quicklook_word(ghostty_surface_t, ghostty_text_s*);
+#endif
+
+GHOSTTY_API ghostty_inspector_t ghostty_surface_inspector(ghostty_surface_t);
+GHOSTTY_API void ghostty_inspector_free(ghostty_surface_t);
+GHOSTTY_API void ghostty_inspector_set_focus(ghostty_inspector_t, bool);
+GHOSTTY_API void ghostty_inspector_set_content_scale(ghostty_inspector_t, double, double);
+GHOSTTY_API void ghostty_inspector_set_size(ghostty_inspector_t, uint32_t, uint32_t);
+GHOSTTY_API void ghostty_inspector_mouse_button(ghostty_inspector_t,
+                                                   ghostty_input_mouse_state_e,
+                                                   ghostty_input_mouse_button_e,
+                                                   ghostty_input_mods_e);
+GHOSTTY_API void ghostty_inspector_mouse_pos(ghostty_inspector_t, double, double);
+GHOSTTY_API void ghostty_inspector_mouse_scroll(ghostty_inspector_t,
+                                                   double,
+                                                   double,
+                                                   ghostty_input_scroll_mods_t);
+GHOSTTY_API void ghostty_inspector_key(ghostty_inspector_t,
+                                          ghostty_input_action_e,
+                                          ghostty_input_key_e,
+                                          ghostty_input_mods_e);
+GHOSTTY_API void ghostty_inspector_text(ghostty_inspector_t, const char*);
+
+#ifdef __APPLE__
+GHOSTTY_API bool ghostty_inspector_metal_init(ghostty_inspector_t, void*);
+GHOSTTY_API void ghostty_inspector_metal_render(ghostty_inspector_t, void*, void*);
+GHOSTTY_API bool ghostty_inspector_metal_shutdown(ghostty_inspector_t);
+#endif
+
+// APIs I'd like to get rid of eventually but are still needed for now.
+// Don't use these unless you know what you're doing.
+GHOSTTY_API void ghostty_set_window_background_blur(ghostty_app_t, void*);
+
+// Benchmark API, if available.
+GHOSTTY_API bool ghostty_benchmark_cli(const char*, const char*);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GHOSTTY_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt.h
@@ -1,0 +1,87 @@
+/**
+ * @file vt.h
+ *
+ * libghostty-vt - Virtual terminal emulator library
+ * 
+ * This library provides functionality for parsing and handling terminal
+ * escape sequences as well as maintaining terminal state such as styles,
+ * cursor position, screen, scrollback, and more.
+ *
+ * WARNING: This is an incomplete, work-in-progress API. It is not yet
+ * stable and is definitely going to change. 
+ */
+
+/**
+ * @mainpage libghostty-vt - Virtual Terminal Emulator Library
+ *
+ * libghostty-vt is a C library which implements a modern terminal emulator,
+ * extracted from the [Ghostty](https://ghostty.org) terminal emulator.
+ *
+ * libghostty-vt contains the logic for handling the core parts of a terminal
+ * emulator: parsing terminal escape sequences, maintaining terminal state,
+ * encoding input events, etc. It can handle scrollback, line wrapping, 
+ * reflow on resize, and more.
+ *
+ * @warning This library is currently in development and the API is not yet stable.
+ * Breaking changes are expected in future versions. Use with caution in production code.
+ *
+ * @section groups_sec API Reference
+ *
+ * The API is organized into the following groups:
+ * - @ref key "Key Encoding" - Encode key events into terminal sequences
+ * - @ref osc "OSC Parser" - Parse OSC (Operating System Command) sequences
+ * - @ref sgr "SGR Parser" - Parse SGR (Select Graphic Rendition) sequences
+ * - @ref paste "Paste Utilities" - Validate paste data safety
+ * - @ref allocator "Memory Management" - Memory management and custom allocators
+ * - @ref wasm "WebAssembly Utilities" - WebAssembly convenience functions
+ *
+ * @section examples_sec Examples
+ *
+ * Complete working examples:
+ * - @ref c-vt/src/main.c - OSC parser example
+ * - @ref c-vt-key-encode/src/main.c - Key encoding example
+ * - @ref c-vt-paste/src/main.c - Paste safety check example
+ * - @ref c-vt-sgr/src/main.c - SGR parser example
+ *
+ */
+
+/** @example c-vt/src/main.c
+ * This example demonstrates how to use the OSC parser to parse an OSC sequence,
+ * extract command information, and retrieve command-specific data like window titles.
+ */
+
+/** @example c-vt-key-encode/src/main.c
+ * This example demonstrates how to use the key encoder to convert key events
+ * into terminal escape sequences using the Kitty keyboard protocol.
+ */
+
+/** @example c-vt-paste/src/main.c
+ * This example demonstrates how to use the paste utilities to check if
+ * paste data is safe before sending it to the terminal.
+ */
+
+/** @example c-vt-sgr/src/main.c
+ * This example demonstrates how to use the SGR parser to parse terminal
+ * styling sequences and extract text attributes like colors and underline styles.
+ */
+
+#ifndef GHOSTTY_VT_H
+#define GHOSTTY_VT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <ghostty/vt/result.h>
+#include <ghostty/vt/allocator.h>
+#include <ghostty/vt/osc.h>
+#include <ghostty/vt/sgr.h>
+#include <ghostty/vt/key.h>
+#include <ghostty/vt/paste.h>
+#include <ghostty/vt/wasm.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GHOSTTY_VT_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/allocator.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/allocator.h
@@ -1,0 +1,196 @@
+/**
+ * @file allocator.h
+ *
+ * Memory management interface for libghostty-vt.
+ */
+
+#ifndef GHOSTTY_VT_ALLOCATOR_H
+#define GHOSTTY_VT_ALLOCATOR_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/** @defgroup allocator Memory Management
+ *
+ * libghostty-vt does require memory allocation for various operations,
+ * but is resilient to allocation failures and will gracefully handle
+ * out-of-memory situations by returning error codes.
+ *
+ * The exact memory management semantics are documented in the relevant
+ * functions and data structures.
+ *
+ * libghostty-vt uses explicit memory allocation via an allocator
+ * interface provided by GhosttyAllocator. The interface is based on the
+ * [Zig](https://ziglang.org) allocator interface, since this has been
+ * shown to be a flexible and powerful interface in practice and enables
+ * a wide variety of allocation strategies.
+ *
+ * **For the common case, you can pass NULL as the allocator for any
+ * function that accepts one,** and libghostty will use a default allocator.
+ * The default allocator will be libc malloc/free if libc is linked. 
+ * Otherwise, a custom allocator is used (currently Zig's SMP allocator)
+ * that doesn't require any external dependencies.
+ *
+ * ## Basic Usage
+ *
+ * For simple use cases, you can ignore this interface entirely by passing NULL
+ * as the allocator parameter to functions that accept one. This will use the
+ * default allocator (typically libc malloc/free, if libc is linked, but
+ * we provide our own default allocator if libc isn't linked).
+ *
+ * To use a custom allocator:
+ * 1. Implement the GhosttyAllocatorVtable function pointers
+ * 2. Create a GhosttyAllocator struct with your vtable and context
+ * 3. Pass the allocator to functions that accept one
+ *
+ * @{
+ */
+
+/**
+ * Function table for custom memory allocator operations.
+ * 
+ * This vtable defines the interface for a custom memory allocator. All
+ * function pointers must be valid and non-NULL.
+ *
+ * @ingroup allocator
+ *
+ * If you're not going to use a custom allocator, you can ignore all of
+ * this. All functions that take an allocator pointer allow NULL to use a
+ * default allocator.
+ *
+ * The interface is based on the Zig allocator interface. I'll say up front
+ * that it is easy to look at this interface and think "wow, this is really
+ * overcomplicated". The reason for this complexity is well thought out by
+ * the Zig folks, and it enables a diverse set of allocation strategies
+ * as shown by the Zig ecosystem. As a consolation, please note that many
+ * of the arguments are only needed for advanced use cases and can be
+ * safely ignored in simple implementations. For example, if you look at 
+ * the Zig implementation of the libc allocator in `lib/std/heap.zig`
+ * (search for CAllocator), you'll see it is very simple.
+ *
+ * We chose to align with the Zig allocator interface because:
+ *
+ *   1. It is a proven interface that serves a wide variety of use cases
+ *      in the real world via the Zig ecosystem. It's shown to work.
+ *
+ *   2. Our core implementation itself is Zig, and this lets us very
+ *      cheaply and easily convert between C and Zig allocators.
+ *
+ * NOTE(mitchellh): In the future, we can have default implementations of
+ * resize/remap and allow those to be null.
+ */
+typedef struct {
+    /**
+     * Return a pointer to `len` bytes with specified `alignment`, or return
+     * `NULL` indicating the allocation failed.
+     *
+     * @param ctx The allocator context
+     * @param len Number of bytes to allocate
+     * @param alignment Required alignment for the allocation. Guaranteed to
+     *   be a power of two between 1 and 16 inclusive.
+     * @param ret_addr First return address of the allocation call stack (0 if not provided)
+     * @return Pointer to allocated memory, or NULL if allocation failed
+     */
+    void* (*alloc)(void *ctx, size_t len, uint8_t alignment, uintptr_t ret_addr);
+    
+    /**
+     * Attempt to expand or shrink memory in place.
+     *
+     * `memory_len` must equal the length requested from the most recent
+     * successful call to `alloc`, `resize`, or `remap`. `alignment` must
+     * equal the same value that was passed as the `alignment` parameter to
+     * the original `alloc` call.
+     *
+     * `new_len` must be greater than zero.
+     *
+     * @param ctx The allocator context
+     * @param memory Pointer to the memory block to resize
+     * @param memory_len Current size of the memory block
+     * @param alignment Alignment (must match original allocation)
+     * @param new_len New requested size
+     * @param ret_addr First return address of the allocation call stack (0 if not provided)
+     * @return true if resize was successful in-place, false if relocation would be required
+     */
+    bool (*resize)(void *ctx, void *memory, size_t memory_len, uint8_t alignment, size_t new_len, uintptr_t ret_addr);
+    
+    /**
+     * Attempt to expand or shrink memory, allowing relocation.
+     *
+     * `memory_len` must equal the length requested from the most recent
+     * successful call to `alloc`, `resize`, or `remap`. `alignment` must
+     * equal the same value that was passed as the `alignment` parameter to
+     * the original `alloc` call.
+     *
+     * A non-`NULL` return value indicates the resize was successful. The
+     * allocation may have same address, or may have been relocated. In either
+     * case, the allocation now has size of `new_len`. A `NULL` return value
+     * indicates that the resize would be equivalent to allocating new memory,
+     * copying the bytes from the old memory, and then freeing the old memory.
+     * In such case, it is more efficient for the caller to perform the copy.
+     *
+     * `new_len` must be greater than zero.
+     *
+     * @param ctx The allocator context
+     * @param memory Pointer to the memory block to remap
+     * @param memory_len Current size of the memory block
+     * @param alignment Alignment (must match original allocation)
+     * @param new_len New requested size
+     * @param ret_addr First return address of the allocation call stack (0 if not provided)
+     * @return Pointer to resized memory (may be relocated), or NULL if manual copy is needed
+     */
+    void* (*remap)(void *ctx, void *memory, size_t memory_len, uint8_t alignment, size_t new_len, uintptr_t ret_addr);
+    
+    /**
+     * Free and invalidate a region of memory.
+     *
+     * `memory_len` must equal the length requested from the most recent
+     * successful call to `alloc`, `resize`, or `remap`. `alignment` must
+     * equal the same value that was passed as the `alignment` parameter to
+     * the original `alloc` call.
+     *
+     * @param ctx The allocator context
+     * @param memory Pointer to the memory block to free
+     * @param memory_len Size of the memory block
+     * @param alignment Alignment (must match original allocation)
+     * @param ret_addr First return address of the allocation call stack (0 if not provided)
+     */
+    void (*free)(void *ctx, void *memory, size_t memory_len, uint8_t alignment, uintptr_t ret_addr);
+} GhosttyAllocatorVtable;
+
+/**
+ * Custom memory allocator.
+ *
+ * For functions that take an allocator pointer, a NULL pointer indicates
+ * that the default allocator should be used. The default allocator will 
+ * be libc malloc/free if we're linking to libc. If libc isn't linked,
+ * a custom allocator is used (currently Zig's SMP allocator).
+ *
+ * @ingroup allocator
+ *
+ * Usage example:
+ * @code
+ * GhosttyAllocator allocator = {
+ *     .vtable = &my_allocator_vtable,
+ *     .ctx = my_allocator_state
+ * };
+ * @endcode
+ */
+typedef struct GhosttyAllocator {
+    /**
+     * Opaque context pointer passed to all vtable functions.
+     * This allows the allocator implementation to maintain state
+     * or reference external resources needed for memory management.
+     */
+    void *ctx;
+
+    /**
+     * Pointer to the allocator's vtable containing function pointers
+     * for memory operations (alloc, resize, remap, free).
+     */
+    const GhosttyAllocatorVtable *vtable;
+} GhosttyAllocator;
+
+/** @} */
+
+#endif /* GHOSTTY_VT_ALLOCATOR_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/color.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/color.h
@@ -1,0 +1,96 @@
+/**
+ * @file color.h
+ *
+ * Color types and utilities.
+ */
+
+#ifndef GHOSTTY_VT_COLOR_H
+#define GHOSTTY_VT_COLOR_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * RGB color value.
+ *
+ * @ingroup sgr
+ */
+typedef struct {
+  uint8_t r; /**< Red component (0-255) */
+  uint8_t g; /**< Green component (0-255) */
+  uint8_t b; /**< Blue component (0-255) */
+} GhosttyColorRgb;
+
+/**
+ * Palette color index (0-255).
+ *
+ * @ingroup sgr
+ */
+typedef uint8_t GhosttyColorPaletteIndex;
+
+/** @addtogroup sgr
+ * @{
+ */
+
+/** Black color (0) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BLACK 0
+/** Red color (1) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_RED 1
+/** Green color (2) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_GREEN 2
+/** Yellow color (3) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_YELLOW 3
+/** Blue color (4) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BLUE 4
+/** Magenta color (5) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_MAGENTA 5
+/** Cyan color (6) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_CYAN 6
+/** White color (7) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_WHITE 7
+/** Bright black color (8) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BRIGHT_BLACK 8
+/** Bright red color (9) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BRIGHT_RED 9
+/** Bright green color (10) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BRIGHT_GREEN 10
+/** Bright yellow color (11) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BRIGHT_YELLOW 11
+/** Bright blue color (12) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BRIGHT_BLUE 12
+/** Bright magenta color (13) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BRIGHT_MAGENTA 13
+/** Bright cyan color (14) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BRIGHT_CYAN 14
+/** Bright white color (15) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BRIGHT_WHITE 15
+
+/** @} */
+
+/**
+ * Get the RGB color components.
+ *
+ * This function extracts the individual red, green, and blue components
+ * from a GhosttyColorRgb value. Primarily useful in WebAssembly environments
+ * where accessing struct fields directly is difficult.
+ *
+ * @param color The RGB color value
+ * @param r Pointer to store the red component (0-255)
+ * @param g Pointer to store the green component (0-255)
+ * @param b Pointer to store the blue component (0-255)
+ *
+ * @ingroup sgr
+ */
+void ghostty_color_rgb_get(GhosttyColorRgb color,
+                           uint8_t* r,
+                           uint8_t* g,
+                           uint8_t* b);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GHOSTTY_VT_COLOR_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/key.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/key.h
@@ -1,0 +1,80 @@
+/**
+ * @file key.h
+ *
+ * Key encoding module - encode key events into terminal escape sequences.
+ */
+
+#ifndef GHOSTTY_VT_KEY_H
+#define GHOSTTY_VT_KEY_H
+
+/** @defgroup key Key Encoding
+ *
+ * Utilities for encoding key events into terminal escape sequences,
+ * supporting both legacy encoding as well as Kitty Keyboard Protocol.
+ *
+ * ## Basic Usage
+ *
+ * 1. Create an encoder instance with ghostty_key_encoder_new()
+ * 2. Configure encoder options with ghostty_key_encoder_setopt().
+ * 3. For each key event:
+ *    - Create a key event with ghostty_key_event_new()
+ *    - Set event properties (action, key, modifiers, etc.)
+ *    - Encode with ghostty_key_encoder_encode()
+ *    - Free the event with ghostty_key_event_free()
+ *    - Note: You can also reuse the same key event multiple times by
+ *      changing its properties.
+ * 4. Free the encoder with ghostty_key_encoder_free() when done
+ *
+ * ## Example
+ *
+ * @code{.c}
+ * #include <assert.h>
+ * #include <stdio.h>
+ * #include <ghostty/vt.h>
+ * 
+ * int main() {
+ *   // Create encoder
+ *   GhosttyKeyEncoder encoder;
+ *   GhosttyResult result = ghostty_key_encoder_new(NULL, &encoder);
+ *   assert(result == GHOSTTY_SUCCESS);
+ * 
+ *   // Enable Kitty keyboard protocol with all features
+ *   ghostty_key_encoder_setopt(encoder, GHOSTTY_KEY_ENCODER_OPT_KITTY_FLAGS, 
+ *                              &(uint8_t){GHOSTTY_KITTY_KEY_ALL});
+ * 
+ *   // Create and configure key event for Ctrl+C press
+ *   GhosttyKeyEvent event;
+ *   result = ghostty_key_event_new(NULL, &event);
+ *   assert(result == GHOSTTY_SUCCESS);
+ *   ghostty_key_event_set_action(event, GHOSTTY_KEY_ACTION_PRESS);
+ *   ghostty_key_event_set_key(event, GHOSTTY_KEY_C);
+ *   ghostty_key_event_set_mods(event, GHOSTTY_MODS_CTRL);
+ * 
+ *   // Encode the key event
+ *   char buf[128];
+ *   size_t written = 0;
+ *   result = ghostty_key_encoder_encode(encoder, event, buf, sizeof(buf), &written);
+ *   assert(result == GHOSTTY_SUCCESS);
+ * 
+ *   // Use the encoded sequence (e.g., write to terminal)
+ *   fwrite(buf, 1, written, stdout);
+ * 
+ *   // Cleanup
+ *   ghostty_key_event_free(event);
+ *   ghostty_key_encoder_free(encoder);
+ *   return 0;
+ * }
+ * @endcode
+ *
+ * For a complete working example, see example/c-vt-key-encode in the
+ * repository.
+ *
+ * @{
+ */
+
+#include <ghostty/vt/key/event.h>
+#include <ghostty/vt/key/encoder.h>
+
+/** @} */
+
+#endif /* GHOSTTY_VT_KEY_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/key/encoder.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/key/encoder.h
@@ -1,0 +1,221 @@
+/**
+ * @file encoder.h
+ *
+ * Key event encoding to terminal escape sequences.
+ */
+
+#ifndef GHOSTTY_VT_KEY_ENCODER_H
+#define GHOSTTY_VT_KEY_ENCODER_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <ghostty/vt/result.h>
+#include <ghostty/vt/allocator.h>
+#include <ghostty/vt/key/event.h>
+
+/**
+ * Opaque handle to a key encoder instance.
+ *
+ * This handle represents a key encoder that converts key events into terminal
+ * escape sequences.
+ *
+ * @ingroup key
+ */
+typedef struct GhosttyKeyEncoder *GhosttyKeyEncoder;
+
+/**
+ * Kitty keyboard protocol flags.
+ *
+ * Bitflags representing the various modes of the Kitty keyboard protocol.
+ * These can be combined using bitwise OR operations. Valid values all
+ * start with `GHOSTTY_KITTY_KEY_`.
+ *
+ * @ingroup key
+ */
+typedef uint8_t GhosttyKittyKeyFlags;
+
+/** Kitty keyboard protocol disabled (all flags off) */
+#define GHOSTTY_KITTY_KEY_DISABLED 0
+
+/** Disambiguate escape codes */
+#define GHOSTTY_KITTY_KEY_DISAMBIGUATE (1 << 0)
+
+/** Report key press and release events */
+#define GHOSTTY_KITTY_KEY_REPORT_EVENTS (1 << 1)
+
+/** Report alternate key codes */
+#define GHOSTTY_KITTY_KEY_REPORT_ALTERNATES (1 << 2)
+
+/** Report all key events including those normally handled by the terminal */
+#define GHOSTTY_KITTY_KEY_REPORT_ALL (1 << 3)
+
+/** Report associated text with key events */
+#define GHOSTTY_KITTY_KEY_REPORT_ASSOCIATED (1 << 4)
+
+/** All Kitty keyboard protocol flags enabled */
+#define GHOSTTY_KITTY_KEY_ALL (GHOSTTY_KITTY_KEY_DISAMBIGUATE | GHOSTTY_KITTY_KEY_REPORT_EVENTS | GHOSTTY_KITTY_KEY_REPORT_ALTERNATES | GHOSTTY_KITTY_KEY_REPORT_ALL | GHOSTTY_KITTY_KEY_REPORT_ASSOCIATED)
+
+/**
+ * macOS option key behavior.
+ *
+ * Determines whether the "option" key on macOS is treated as "alt" or not.
+ * See the Ghostty `macos-option-as-alt` configuration option for more details.
+ *
+ * @ingroup key
+ */
+typedef enum {
+    /** Option key is not treated as alt */
+    GHOSTTY_OPTION_AS_ALT_FALSE = 0,
+    /** Option key is treated as alt */
+    GHOSTTY_OPTION_AS_ALT_TRUE = 1,
+    /** Only left option key is treated as alt */
+    GHOSTTY_OPTION_AS_ALT_LEFT = 2,
+    /** Only right option key is treated as alt */
+    GHOSTTY_OPTION_AS_ALT_RIGHT = 3,
+} GhosttyOptionAsAlt;
+
+/**
+ * Key encoder option identifiers.
+ *
+ * These values are used with ghostty_key_encoder_setopt() to configure
+ * the behavior of the key encoder.
+ *
+ * @ingroup key
+ */
+typedef enum {
+    /** Terminal DEC mode 1: cursor key application mode (value: bool) */
+    GHOSTTY_KEY_ENCODER_OPT_CURSOR_KEY_APPLICATION = 0,
+    
+    /** Terminal DEC mode 66: keypad key application mode (value: bool) */
+    GHOSTTY_KEY_ENCODER_OPT_KEYPAD_KEY_APPLICATION = 1,
+    
+    /** Terminal DEC mode 1035: ignore keypad with numlock (value: bool) */
+    GHOSTTY_KEY_ENCODER_OPT_IGNORE_KEYPAD_WITH_NUMLOCK = 2,
+    
+    /** Terminal DEC mode 1036: alt sends escape prefix (value: bool) */
+    GHOSTTY_KEY_ENCODER_OPT_ALT_ESC_PREFIX = 3,
+    
+    /** xterm modifyOtherKeys mode 2 (value: bool) */
+    GHOSTTY_KEY_ENCODER_OPT_MODIFY_OTHER_KEYS_STATE_2 = 4,
+    
+    /** Kitty keyboard protocol flags (value: GhosttyKittyKeyFlags bitmask) */
+    GHOSTTY_KEY_ENCODER_OPT_KITTY_FLAGS = 5,
+    
+    /** macOS option-as-alt setting (value: GhosttyOptionAsAlt) */
+    GHOSTTY_KEY_ENCODER_OPT_MACOS_OPTION_AS_ALT = 6,
+} GhosttyKeyEncoderOption;
+
+/**
+ * Create a new key encoder instance.
+ *
+ * Creates a new key encoder with default options. The encoder can be configured
+ * using ghostty_key_encoder_setopt() and must be freed using
+ * ghostty_key_encoder_free() when no longer needed.
+ *
+ * @param allocator Pointer to the allocator to use for memory management, or NULL to use the default allocator
+ * @param encoder Pointer to store the created encoder handle
+ * @return GHOSTTY_SUCCESS on success, or an error code on failure
+ *
+ * @ingroup key
+ */
+GhosttyResult ghostty_key_encoder_new(const GhosttyAllocator *allocator, GhosttyKeyEncoder *encoder);
+
+/**
+ * Free a key encoder instance.
+ *
+ * Releases all resources associated with the key encoder. After this call,
+ * the encoder handle becomes invalid and must not be used.
+ *
+ * @param encoder The encoder handle to free (may be NULL)
+ *
+ * @ingroup key
+ */
+void ghostty_key_encoder_free(GhosttyKeyEncoder encoder);
+
+/**
+ * Set an option on the key encoder.
+ *
+ * Configures the behavior of the key encoder. Options control various aspects
+ * of encoding such as terminal modes (cursor key application mode, keypad mode),
+ * protocol selection (Kitty keyboard protocol flags), and platform-specific
+ * behaviors (macOS option-as-alt).
+ *
+ * A null pointer value does nothing. It does not reset the value to the
+ * default. The setopt call will do nothing.
+ *
+ * @param encoder The encoder handle, must not be NULL
+ * @param option The option to set
+ * @param value Pointer to the value to set (type depends on the option)
+ *
+ * @ingroup key
+ */
+void ghostty_key_encoder_setopt(GhosttyKeyEncoder encoder, GhosttyKeyEncoderOption option, const void *value);
+
+/**
+ * Encode a key event into a terminal escape sequence.
+ *
+ * Converts a key event into the appropriate terminal escape sequence based on
+ * the encoder's current options. The sequence is written to the provided buffer.
+ *
+ * Not all key events produce output. For example, unmodified modifier keys
+ * typically don't generate escape sequences. Check the out_len parameter to
+ * determine if any data was written.
+ *
+ * If the output buffer is too small, this function returns GHOSTTY_OUT_OF_MEMORY
+ * and out_len will contain the required buffer size. The caller can then
+ * allocate a larger buffer and call the function again.
+ *
+ * @param encoder The encoder handle, must not be NULL
+ * @param event The key event to encode, must not be NULL
+ * @param out_buf Buffer to write the encoded sequence to
+ * @param out_buf_size Size of the output buffer in bytes
+ * @param out_len Pointer to store the number of bytes written (may be NULL)
+ * @return GHOSTTY_SUCCESS on success, GHOSTTY_OUT_OF_MEMORY if buffer too small, or other error code
+ *
+ * ## Example: Calculate required buffer size
+ *
+ * @code{.c}
+ * // Query the required size with a NULL buffer (always returns OUT_OF_MEMORY)
+ * size_t required = 0;
+ * GhosttyResult result = ghostty_key_encoder_encode(encoder, event, NULL, 0, &required);
+ * assert(result == GHOSTTY_OUT_OF_MEMORY);
+ * 
+ * // Allocate buffer of required size
+ * char *buf = malloc(required);
+ * 
+ * // Encode with properly sized buffer
+ * size_t written = 0;
+ * result = ghostty_key_encoder_encode(encoder, event, buf, required, &written);
+ * assert(result == GHOSTTY_SUCCESS);
+ * 
+ * // Use the encoded sequence...
+ * 
+ * free(buf);
+ * @endcode
+ *
+ * ## Example: Direct encoding with static buffer
+ *
+ * @code{.c}
+ * // Most escape sequences are short, so a static buffer often suffices
+ * char buf[128];
+ * size_t written = 0;
+ * GhosttyResult result = ghostty_key_encoder_encode(encoder, event, buf, sizeof(buf), &written);
+ * 
+ * if (result == GHOSTTY_SUCCESS) {
+ *   // Write the encoded sequence to the terminal
+ *   write(pty_fd, buf, written);
+ * } else if (result == GHOSTTY_OUT_OF_MEMORY) {
+ *   // Buffer too small, written contains required size
+ *   char *dynamic_buf = malloc(written);
+ *   result = ghostty_key_encoder_encode(encoder, event, dynamic_buf, written, &written);
+ *   assert(result == GHOSTTY_SUCCESS);
+ *   write(pty_fd, dynamic_buf, written);
+ *   free(dynamic_buf);
+ * }
+ * @endcode
+ *
+ * @ingroup key
+ */
+GhosttyResult ghostty_key_encoder_encode(GhosttyKeyEncoder encoder, GhosttyKeyEvent event, char *out_buf, size_t out_buf_size, size_t *out_len);
+
+#endif /* GHOSTTY_VT_KEY_ENCODER_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/key/event.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/key/event.h
@@ -1,0 +1,474 @@
+/**
+ * @file event.h
+ *
+ * Key event representation and manipulation.
+ */
+
+#ifndef GHOSTTY_VT_KEY_EVENT_H
+#define GHOSTTY_VT_KEY_EVENT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <ghostty/vt/result.h>
+#include <ghostty/vt/allocator.h>
+
+/**
+ * Opaque handle to a key event.
+ * 
+ * This handle represents a keyboard input event containing information about
+ * the physical key pressed, modifiers, and generated text.
+ *
+ * @ingroup key
+ */
+typedef struct GhosttyKeyEvent *GhosttyKeyEvent;
+
+/**
+ * Keyboard input event types.
+ *
+ * @ingroup key
+ */
+typedef enum {
+    /** Key was released */
+    GHOSTTY_KEY_ACTION_RELEASE = 0,
+    /** Key was pressed */
+    GHOSTTY_KEY_ACTION_PRESS = 1,
+    /** Key is being repeated (held down) */
+    GHOSTTY_KEY_ACTION_REPEAT = 2,
+} GhosttyKeyAction;
+
+/**
+ * Keyboard modifier keys bitmask.
+ *
+ * A bitmask representing all keyboard modifiers. This tracks which modifier keys 
+ * are pressed and, where supported by the platform, which side (left or right) 
+ * of each modifier is active.
+ *
+ * Use the GHOSTTY_MODS_* constants to test and set individual modifiers.
+ *
+ * Modifier side bits are only meaningful when the corresponding modifier bit is set.
+ * Not all platforms support distinguishing between left and right modifier 
+ * keys and Ghostty is built to expect that some platforms may not provide this
+ * information.
+ *
+ * @ingroup key
+ */
+typedef uint16_t GhosttyMods;
+
+/** Shift key is pressed */
+#define GHOSTTY_MODS_SHIFT (1 << 0)
+/** Control key is pressed */
+#define GHOSTTY_MODS_CTRL (1 << 1)
+/** Alt/Option key is pressed */
+#define GHOSTTY_MODS_ALT (1 << 2)
+/** Super/Command/Windows key is pressed */
+#define GHOSTTY_MODS_SUPER (1 << 3)
+/** Caps Lock is active */
+#define GHOSTTY_MODS_CAPS_LOCK (1 << 4)
+/** Num Lock is active */
+#define GHOSTTY_MODS_NUM_LOCK (1 << 5)
+
+/**
+ * Right shift is pressed (0 = left, 1 = right).
+ * Only meaningful when GHOSTTY_MODS_SHIFT is set.
+ */
+#define GHOSTTY_MODS_SHIFT_SIDE (1 << 6)
+/**
+ * Right ctrl is pressed (0 = left, 1 = right).
+ * Only meaningful when GHOSTTY_MODS_CTRL is set.
+ */
+#define GHOSTTY_MODS_CTRL_SIDE (1 << 7)
+/**
+ * Right alt is pressed (0 = left, 1 = right).
+ * Only meaningful when GHOSTTY_MODS_ALT is set.
+ */
+#define GHOSTTY_MODS_ALT_SIDE (1 << 8)
+/**
+ * Right super is pressed (0 = left, 1 = right).
+ * Only meaningful when GHOSTTY_MODS_SUPER is set.
+ */
+#define GHOSTTY_MODS_SUPER_SIDE (1 << 9)
+
+/**
+ * Physical key codes.
+ *
+ * The set of key codes that Ghostty is aware of. These represent physical keys 
+ * on the keyboard and are layout-independent. For example, the "a" key on a US 
+ * keyboard is the same as the "ф" key on a Russian keyboard, but both will 
+ * report the same key_a value.
+ *
+ * Layout-dependent strings are provided separately as UTF-8 text and are produced 
+ * by the platform. These values are based on the W3C UI Events KeyboardEvent code 
+ * standard. See: https://www.w3.org/TR/uievents-code
+ *
+ * @ingroup key
+ */
+typedef enum {
+    GHOSTTY_KEY_UNIDENTIFIED = 0,
+
+    // Writing System Keys (W3C § 3.1.1)
+    GHOSTTY_KEY_BACKQUOTE,
+    GHOSTTY_KEY_BACKSLASH,
+    GHOSTTY_KEY_BRACKET_LEFT,
+    GHOSTTY_KEY_BRACKET_RIGHT,
+    GHOSTTY_KEY_COMMA,
+    GHOSTTY_KEY_DIGIT_0,
+    GHOSTTY_KEY_DIGIT_1,
+    GHOSTTY_KEY_DIGIT_2,
+    GHOSTTY_KEY_DIGIT_3,
+    GHOSTTY_KEY_DIGIT_4,
+    GHOSTTY_KEY_DIGIT_5,
+    GHOSTTY_KEY_DIGIT_6,
+    GHOSTTY_KEY_DIGIT_7,
+    GHOSTTY_KEY_DIGIT_8,
+    GHOSTTY_KEY_DIGIT_9,
+    GHOSTTY_KEY_EQUAL,
+    GHOSTTY_KEY_INTL_BACKSLASH,
+    GHOSTTY_KEY_INTL_RO,
+    GHOSTTY_KEY_INTL_YEN,
+    GHOSTTY_KEY_A,
+    GHOSTTY_KEY_B,
+    GHOSTTY_KEY_C,
+    GHOSTTY_KEY_D,
+    GHOSTTY_KEY_E,
+    GHOSTTY_KEY_F,
+    GHOSTTY_KEY_G,
+    GHOSTTY_KEY_H,
+    GHOSTTY_KEY_I,
+    GHOSTTY_KEY_J,
+    GHOSTTY_KEY_K,
+    GHOSTTY_KEY_L,
+    GHOSTTY_KEY_M,
+    GHOSTTY_KEY_N,
+    GHOSTTY_KEY_O,
+    GHOSTTY_KEY_P,
+    GHOSTTY_KEY_Q,
+    GHOSTTY_KEY_R,
+    GHOSTTY_KEY_S,
+    GHOSTTY_KEY_T,
+    GHOSTTY_KEY_U,
+    GHOSTTY_KEY_V,
+    GHOSTTY_KEY_W,
+    GHOSTTY_KEY_X,
+    GHOSTTY_KEY_Y,
+    GHOSTTY_KEY_Z,
+    GHOSTTY_KEY_MINUS,
+    GHOSTTY_KEY_PERIOD,
+    GHOSTTY_KEY_QUOTE,
+    GHOSTTY_KEY_SEMICOLON,
+    GHOSTTY_KEY_SLASH,
+
+    // Functional Keys (W3C § 3.1.2)
+    GHOSTTY_KEY_ALT_LEFT,
+    GHOSTTY_KEY_ALT_RIGHT,
+    GHOSTTY_KEY_BACKSPACE,
+    GHOSTTY_KEY_CAPS_LOCK,
+    GHOSTTY_KEY_CONTEXT_MENU,
+    GHOSTTY_KEY_CONTROL_LEFT,
+    GHOSTTY_KEY_CONTROL_RIGHT,
+    GHOSTTY_KEY_ENTER,
+    GHOSTTY_KEY_META_LEFT,
+    GHOSTTY_KEY_META_RIGHT,
+    GHOSTTY_KEY_SHIFT_LEFT,
+    GHOSTTY_KEY_SHIFT_RIGHT,
+    GHOSTTY_KEY_SPACE,
+    GHOSTTY_KEY_TAB,
+    GHOSTTY_KEY_CONVERT,
+    GHOSTTY_KEY_KANA_MODE,
+    GHOSTTY_KEY_NON_CONVERT,
+
+    // Control Pad Section (W3C § 3.2)
+    GHOSTTY_KEY_DELETE,
+    GHOSTTY_KEY_END,
+    GHOSTTY_KEY_HELP,
+    GHOSTTY_KEY_HOME,
+    GHOSTTY_KEY_INSERT,
+    GHOSTTY_KEY_PAGE_DOWN,
+    GHOSTTY_KEY_PAGE_UP,
+
+    // Arrow Pad Section (W3C § 3.3)
+    GHOSTTY_KEY_ARROW_DOWN,
+    GHOSTTY_KEY_ARROW_LEFT,
+    GHOSTTY_KEY_ARROW_RIGHT,
+    GHOSTTY_KEY_ARROW_UP,
+
+    // Numpad Section (W3C § 3.4)
+    GHOSTTY_KEY_NUM_LOCK,
+    GHOSTTY_KEY_NUMPAD_0,
+    GHOSTTY_KEY_NUMPAD_1,
+    GHOSTTY_KEY_NUMPAD_2,
+    GHOSTTY_KEY_NUMPAD_3,
+    GHOSTTY_KEY_NUMPAD_4,
+    GHOSTTY_KEY_NUMPAD_5,
+    GHOSTTY_KEY_NUMPAD_6,
+    GHOSTTY_KEY_NUMPAD_7,
+    GHOSTTY_KEY_NUMPAD_8,
+    GHOSTTY_KEY_NUMPAD_9,
+    GHOSTTY_KEY_NUMPAD_ADD,
+    GHOSTTY_KEY_NUMPAD_BACKSPACE,
+    GHOSTTY_KEY_NUMPAD_CLEAR,
+    GHOSTTY_KEY_NUMPAD_CLEAR_ENTRY,
+    GHOSTTY_KEY_NUMPAD_COMMA,
+    GHOSTTY_KEY_NUMPAD_DECIMAL,
+    GHOSTTY_KEY_NUMPAD_DIVIDE,
+    GHOSTTY_KEY_NUMPAD_ENTER,
+    GHOSTTY_KEY_NUMPAD_EQUAL,
+    GHOSTTY_KEY_NUMPAD_MEMORY_ADD,
+    GHOSTTY_KEY_NUMPAD_MEMORY_CLEAR,
+    GHOSTTY_KEY_NUMPAD_MEMORY_RECALL,
+    GHOSTTY_KEY_NUMPAD_MEMORY_STORE,
+    GHOSTTY_KEY_NUMPAD_MEMORY_SUBTRACT,
+    GHOSTTY_KEY_NUMPAD_MULTIPLY,
+    GHOSTTY_KEY_NUMPAD_PAREN_LEFT,
+    GHOSTTY_KEY_NUMPAD_PAREN_RIGHT,
+    GHOSTTY_KEY_NUMPAD_SUBTRACT,
+    GHOSTTY_KEY_NUMPAD_SEPARATOR,
+    GHOSTTY_KEY_NUMPAD_UP,
+    GHOSTTY_KEY_NUMPAD_DOWN,
+    GHOSTTY_KEY_NUMPAD_RIGHT,
+    GHOSTTY_KEY_NUMPAD_LEFT,
+    GHOSTTY_KEY_NUMPAD_BEGIN,
+    GHOSTTY_KEY_NUMPAD_HOME,
+    GHOSTTY_KEY_NUMPAD_END,
+    GHOSTTY_KEY_NUMPAD_INSERT,
+    GHOSTTY_KEY_NUMPAD_DELETE,
+    GHOSTTY_KEY_NUMPAD_PAGE_UP,
+    GHOSTTY_KEY_NUMPAD_PAGE_DOWN,
+
+    // Function Section (W3C § 3.5)
+    GHOSTTY_KEY_ESCAPE,
+    GHOSTTY_KEY_F1,
+    GHOSTTY_KEY_F2,
+    GHOSTTY_KEY_F3,
+    GHOSTTY_KEY_F4,
+    GHOSTTY_KEY_F5,
+    GHOSTTY_KEY_F6,
+    GHOSTTY_KEY_F7,
+    GHOSTTY_KEY_F8,
+    GHOSTTY_KEY_F9,
+    GHOSTTY_KEY_F10,
+    GHOSTTY_KEY_F11,
+    GHOSTTY_KEY_F12,
+    GHOSTTY_KEY_F13,
+    GHOSTTY_KEY_F14,
+    GHOSTTY_KEY_F15,
+    GHOSTTY_KEY_F16,
+    GHOSTTY_KEY_F17,
+    GHOSTTY_KEY_F18,
+    GHOSTTY_KEY_F19,
+    GHOSTTY_KEY_F20,
+    GHOSTTY_KEY_F21,
+    GHOSTTY_KEY_F22,
+    GHOSTTY_KEY_F23,
+    GHOSTTY_KEY_F24,
+    GHOSTTY_KEY_F25,
+    GHOSTTY_KEY_FN,
+    GHOSTTY_KEY_FN_LOCK,
+    GHOSTTY_KEY_PRINT_SCREEN,
+    GHOSTTY_KEY_SCROLL_LOCK,
+    GHOSTTY_KEY_PAUSE,
+
+    // Media Keys (W3C § 3.6)
+    GHOSTTY_KEY_BROWSER_BACK,
+    GHOSTTY_KEY_BROWSER_FAVORITES,
+    GHOSTTY_KEY_BROWSER_FORWARD,
+    GHOSTTY_KEY_BROWSER_HOME,
+    GHOSTTY_KEY_BROWSER_REFRESH,
+    GHOSTTY_KEY_BROWSER_SEARCH,
+    GHOSTTY_KEY_BROWSER_STOP,
+    GHOSTTY_KEY_EJECT,
+    GHOSTTY_KEY_LAUNCH_APP_1,
+    GHOSTTY_KEY_LAUNCH_APP_2,
+    GHOSTTY_KEY_LAUNCH_MAIL,
+    GHOSTTY_KEY_MEDIA_PLAY_PAUSE,
+    GHOSTTY_KEY_MEDIA_SELECT,
+    GHOSTTY_KEY_MEDIA_STOP,
+    GHOSTTY_KEY_MEDIA_TRACK_NEXT,
+    GHOSTTY_KEY_MEDIA_TRACK_PREVIOUS,
+    GHOSTTY_KEY_POWER,
+    GHOSTTY_KEY_SLEEP,
+    GHOSTTY_KEY_AUDIO_VOLUME_DOWN,
+    GHOSTTY_KEY_AUDIO_VOLUME_MUTE,
+    GHOSTTY_KEY_AUDIO_VOLUME_UP,
+    GHOSTTY_KEY_WAKE_UP,
+
+    // Legacy, Non-standard, and Special Keys (W3C § 3.7)
+    GHOSTTY_KEY_COPY,
+    GHOSTTY_KEY_CUT,
+    GHOSTTY_KEY_PASTE,
+} GhosttyKey;
+
+/**
+ * Create a new key event instance.
+ * 
+ * Creates a new key event with default values. The event must be freed using
+ * ghostty_key_event_free() when no longer needed.
+ * 
+ * @param allocator Pointer to the allocator to use for memory management, or NULL to use the default allocator
+ * @param event Pointer to store the created key event handle
+ * @return GHOSTTY_SUCCESS on success, or an error code on failure
+ * 
+ * @ingroup key
+ */
+GhosttyResult ghostty_key_event_new(const GhosttyAllocator *allocator, GhosttyKeyEvent *event);
+
+/**
+ * Free a key event instance.
+ * 
+ * Releases all resources associated with the key event. After this call,
+ * the event handle becomes invalid and must not be used.
+ * 
+ * @param event The key event handle to free (may be NULL)
+ * 
+ * @ingroup key
+ */
+void ghostty_key_event_free(GhosttyKeyEvent event);
+
+/**
+ * Set the key action (press, release, repeat).
+ *
+ * @param event The key event handle, must not be NULL
+ * @param action The action to set
+ *
+ * @ingroup key
+ */
+void ghostty_key_event_set_action(GhosttyKeyEvent event, GhosttyKeyAction action);
+
+/**
+ * Get the key action (press, release, repeat).
+ *
+ * @param event The key event handle, must not be NULL
+ * @return The key action
+ *
+ * @ingroup key
+ */
+GhosttyKeyAction ghostty_key_event_get_action(GhosttyKeyEvent event);
+
+/**
+ * Set the physical key code.
+ *
+ * @param event The key event handle, must not be NULL
+ * @param key The physical key code to set
+ *
+ * @ingroup key
+ */
+void ghostty_key_event_set_key(GhosttyKeyEvent event, GhosttyKey key);
+
+/**
+ * Get the physical key code.
+ *
+ * @param event The key event handle, must not be NULL
+ * @return The physical key code
+ *
+ * @ingroup key
+ */
+GhosttyKey ghostty_key_event_get_key(GhosttyKeyEvent event);
+
+/**
+ * Set the modifier keys bitmask.
+ *
+ * @param event The key event handle, must not be NULL
+ * @param mods The modifier keys bitmask to set
+ *
+ * @ingroup key
+ */
+void ghostty_key_event_set_mods(GhosttyKeyEvent event, GhosttyMods mods);
+
+/**
+ * Get the modifier keys bitmask.
+ *
+ * @param event The key event handle, must not be NULL
+ * @return The modifier keys bitmask
+ *
+ * @ingroup key
+ */
+GhosttyMods ghostty_key_event_get_mods(GhosttyKeyEvent event);
+
+/**
+ * Set the consumed modifiers bitmask.
+ *
+ * @param event The key event handle, must not be NULL
+ * @param consumed_mods The consumed modifiers bitmask to set
+ *
+ * @ingroup key
+ */
+void ghostty_key_event_set_consumed_mods(GhosttyKeyEvent event, GhosttyMods consumed_mods);
+
+/**
+ * Get the consumed modifiers bitmask.
+ *
+ * @param event The key event handle, must not be NULL
+ * @return The consumed modifiers bitmask
+ *
+ * @ingroup key
+ */
+GhosttyMods ghostty_key_event_get_consumed_mods(GhosttyKeyEvent event);
+
+/**
+ * Set whether the key event is part of a composition sequence.
+ *
+ * @param event The key event handle, must not be NULL
+ * @param composing Whether the key event is part of a composition sequence
+ *
+ * @ingroup key
+ */
+void ghostty_key_event_set_composing(GhosttyKeyEvent event, bool composing);
+
+/**
+ * Get whether the key event is part of a composition sequence.
+ *
+ * @param event The key event handle, must not be NULL
+ * @return Whether the key event is part of a composition sequence
+ *
+ * @ingroup key
+ */
+bool ghostty_key_event_get_composing(GhosttyKeyEvent event);
+
+/**
+ * Set the UTF-8 text generated by the key event.
+ *
+ * The key event does NOT take ownership of the text pointer. The caller
+ * must ensure the string remains valid for the lifetime needed by the event.
+ *
+ * @param event The key event handle, must not be NULL
+ * @param utf8 The UTF-8 text to set (or NULL for empty)
+ * @param len Length of the UTF-8 text in bytes
+ *
+ * @ingroup key
+ */
+void ghostty_key_event_set_utf8(GhosttyKeyEvent event, const char *utf8, size_t len);
+
+/**
+ * Get the UTF-8 text generated by the key event.
+ *
+ * The returned pointer is valid until the event is freed or the UTF-8 text is modified.
+ *
+ * @param event The key event handle, must not be NULL
+ * @param len Pointer to store the length of the UTF-8 text in bytes (may be NULL)
+ * @return The UTF-8 text (or NULL for empty)
+ *
+ * @ingroup key
+ */
+const char *ghostty_key_event_get_utf8(GhosttyKeyEvent event, size_t *len);
+
+/**
+ * Set the unshifted Unicode codepoint.
+ *
+ * @param event The key event handle, must not be NULL
+ * @param codepoint The unshifted Unicode codepoint to set
+ *
+ * @ingroup key
+ */
+void ghostty_key_event_set_unshifted_codepoint(GhosttyKeyEvent event, uint32_t codepoint);
+
+/**
+ * Get the unshifted Unicode codepoint.
+ *
+ * @param event The key event handle, must not be NULL
+ * @return The unshifted Unicode codepoint
+ *
+ * @ingroup key
+ */
+uint32_t ghostty_key_event_get_unshifted_codepoint(GhosttyKeyEvent event);
+
+#endif /* GHOSTTY_VT_KEY_EVENT_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/osc.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/osc.h
@@ -1,0 +1,233 @@
+/**
+ * @file osc.h
+ *
+ * OSC (Operating System Command) sequence parser and command handling.
+ */
+
+#ifndef GHOSTTY_VT_OSC_H
+#define GHOSTTY_VT_OSC_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <ghostty/vt/result.h>
+#include <ghostty/vt/allocator.h>
+
+/**
+ * Opaque handle to an OSC parser instance.
+ * 
+ * This handle represents an OSC (Operating System Command) parser that can
+ * be used to parse the contents of OSC sequences.
+ *
+ * @ingroup osc
+ */
+typedef struct GhosttyOscParser *GhosttyOscParser;
+
+/**
+ * Opaque handle to a single OSC command.
+ * 
+ * This handle represents a parsed OSC (Operating System Command) command.
+ * The command can be queried for its type and associated data.
+ *
+ * @ingroup osc
+ */
+typedef struct GhosttyOscCommand *GhosttyOscCommand;
+
+/** @defgroup osc OSC Parser
+ *
+ * OSC (Operating System Command) sequence parser and command handling.
+ *
+ * The parser operates in a streaming fashion, processing input byte-by-byte
+ * to handle OSC sequences that may arrive in fragments across multiple reads.
+ * This interface makes it easy to integrate into most environments and avoids
+ * over-allocating buffers.
+ *
+ * ## Basic Usage
+ *
+ * 1. Create a parser instance with ghostty_osc_new()
+ * 2. Feed bytes to the parser using ghostty_osc_next() 
+ * 3. Finalize parsing with ghostty_osc_end() to get the command
+ * 4. Query command type and extract data using ghostty_osc_command_type()
+ *    and ghostty_osc_command_data()
+ * 5. Free the parser with ghostty_osc_free() when done
+ *
+ * @{
+ */
+
+/**
+ * OSC command types.
+ *
+ * @ingroup osc
+ */
+typedef enum {
+  GHOSTTY_OSC_COMMAND_INVALID = 0,
+  GHOSTTY_OSC_COMMAND_CHANGE_WINDOW_TITLE = 1,
+  GHOSTTY_OSC_COMMAND_CHANGE_WINDOW_ICON = 2,
+  GHOSTTY_OSC_COMMAND_SEMANTIC_PROMPT = 3,
+  GHOSTTY_OSC_COMMAND_CLIPBOARD_CONTENTS = 4,
+  GHOSTTY_OSC_COMMAND_REPORT_PWD = 5,
+  GHOSTTY_OSC_COMMAND_MOUSE_SHAPE = 6,
+  GHOSTTY_OSC_COMMAND_COLOR_OPERATION = 7,
+  GHOSTTY_OSC_COMMAND_KITTY_COLOR_PROTOCOL = 8,
+  GHOSTTY_OSC_COMMAND_SHOW_DESKTOP_NOTIFICATION = 9,
+  GHOSTTY_OSC_COMMAND_HYPERLINK_START = 10,
+  GHOSTTY_OSC_COMMAND_HYPERLINK_END = 11,
+  GHOSTTY_OSC_COMMAND_CONEMU_SLEEP = 12,
+  GHOSTTY_OSC_COMMAND_CONEMU_SHOW_MESSAGE_BOX = 13,
+  GHOSTTY_OSC_COMMAND_CONEMU_CHANGE_TAB_TITLE = 14,
+  GHOSTTY_OSC_COMMAND_CONEMU_PROGRESS_REPORT = 15,
+  GHOSTTY_OSC_COMMAND_CONEMU_WAIT_INPUT = 16,
+  GHOSTTY_OSC_COMMAND_CONEMU_GUIMACRO = 17,
+  GHOSTTY_OSC_COMMAND_CONEMU_RUN_PROCESS = 18,
+  GHOSTTY_OSC_COMMAND_CONEMU_OUTPUT_ENVIRONMENT_VARIABLE = 19,
+  GHOSTTY_OSC_COMMAND_CONEMU_XTERM_EMULATION = 20,
+  GHOSTTY_OSC_COMMAND_CONEMU_COMMENT = 21,
+  GHOSTTY_OSC_COMMAND_KITTY_TEXT_SIZING = 22,
+} GhosttyOscCommandType;
+
+/**
+ * OSC command data types.
+ * 
+ * These values specify what type of data to extract from an OSC command
+ * using `ghostty_osc_command_data`.
+ *
+ * @ingroup osc
+ */
+typedef enum {
+  /** Invalid data type. Never results in any data extraction. */
+  GHOSTTY_OSC_DATA_INVALID = 0,
+  
+  /** 
+   * Window title string data.
+   *
+   * Valid for: GHOSTTY_OSC_COMMAND_CHANGE_WINDOW_TITLE
+   *
+   * Output type: const char ** (pointer to null-terminated string)
+   *
+   * Lifetime: Valid until the next call to any ghostty_osc_* function with 
+   * the same parser instance. Memory is owned by the parser.
+   */
+  GHOSTTY_OSC_DATA_CHANGE_WINDOW_TITLE_STR = 1,
+} GhosttyOscCommandData;
+
+/**
+ * Create a new OSC parser instance.
+ * 
+ * Creates a new OSC (Operating System Command) parser using the provided
+ * allocator. The parser must be freed using ghostty_vt_osc_free() when
+ * no longer needed.
+ * 
+ * @param allocator Pointer to the allocator to use for memory management, or NULL to use the default allocator
+ * @param parser Pointer to store the created parser handle
+ * @return GHOSTTY_SUCCESS on success, or an error code on failure
+ * 
+ * @ingroup osc
+ */
+GhosttyResult ghostty_osc_new(const GhosttyAllocator *allocator, GhosttyOscParser *parser);
+
+/**
+ * Free an OSC parser instance.
+ * 
+ * Releases all resources associated with the OSC parser. After this call,
+ * the parser handle becomes invalid and must not be used.
+ * 
+ * @param parser The parser handle to free (may be NULL)
+ * 
+ * @ingroup osc
+ */
+void ghostty_osc_free(GhosttyOscParser parser);
+
+/**
+ * Reset an OSC parser instance to its initial state.
+ * 
+ * Resets the parser state, clearing any partially parsed OSC sequences
+ * and returning the parser to its initial state. This is useful for
+ * reusing a parser instance or recovering from parse errors.
+ * 
+ * @param parser The parser handle to reset, must not be null.
+ * 
+ * @ingroup osc
+ */
+void ghostty_osc_reset(GhosttyOscParser parser);
+
+/**
+ * Parse the next byte in an OSC sequence.
+ * 
+ * Processes a single byte as part of an OSC sequence. The parser maintains
+ * internal state to track the progress through the sequence. Call this
+ * function for each byte in the sequence data.
+ *
+ * When finished pumping the parser with bytes, call ghostty_osc_end
+ * to get the final result.
+ * 
+ * @param parser The parser handle, must not be null.
+ * @param byte The next byte to parse
+ * 
+ * @ingroup osc
+ */
+void ghostty_osc_next(GhosttyOscParser parser, uint8_t byte);
+
+/**
+ * Finalize OSC parsing and retrieve the parsed command.
+ * 
+ * Call this function after feeding all bytes of an OSC sequence to the parser
+ * using ghostty_osc_next() with the exception of the terminating character
+ * (ESC or ST). This function finalizes the parsing process and returns the 
+ * parsed OSC command.
+ *
+ * The return value is never NULL. Invalid commands will return a command
+ * with type GHOSTTY_OSC_COMMAND_INVALID.
+ * 
+ * The terminator parameter specifies the byte that terminated the OSC sequence
+ * (typically 0x07 for BEL or 0x5C for ST after ESC). This information is
+ * preserved in the parsed command so that responses can use the same terminator
+ * format for better compatibility with the calling program. For commands that
+ * do not require a response, this parameter is ignored and the resulting
+ * command will not retain the terminator information.
+ * 
+ * The returned command handle is valid until the next call to any 
+ * `ghostty_osc_*` function with the same parser instance with the exception
+ * of command introspection functions such as `ghostty_osc_command_type`.
+ * 
+ * @param parser The parser handle, must not be null.
+ * @param terminator The terminating byte of the OSC sequence (0x07 for BEL, 0x5C for ST)
+ * @return Handle to the parsed OSC command
+ * 
+ * @ingroup osc
+ */
+GhosttyOscCommand ghostty_osc_end(GhosttyOscParser parser, uint8_t terminator);
+
+/**
+ * Get the type of an OSC command.
+ * 
+ * Returns the type identifier for the given OSC command. This can be used
+ * to determine what kind of command was parsed and what data might be
+ * available from it.
+ * 
+ * @param command The OSC command handle to query (may be NULL)
+ * @return The command type, or GHOSTTY_OSC_COMMAND_INVALID if command is NULL
+ * 
+ * @ingroup osc
+ */
+GhosttyOscCommandType ghostty_osc_command_type(GhosttyOscCommand command);
+
+/**
+ * Extract data from an OSC command.
+ * 
+ * Extracts typed data from the given OSC command based on the specified
+ * data type. The output pointer must be of the appropriate type for the
+ * requested data kind. Valid command types, output types, and memory
+ * safety information are documented in the `GhosttyOscCommandData` enum.
+ *
+ * @param command The OSC command handle to query (may be NULL)
+ * @param data The type of data to extract
+ * @param out Pointer to store the extracted data (type depends on data parameter)
+ * @return true if data extraction was successful, false otherwise
+ * 
+ * @ingroup osc
+ */
+bool ghostty_osc_command_data(GhosttyOscCommand command, GhosttyOscCommandData data, void *out);
+
+/** @} */
+
+#endif /* GHOSTTY_VT_OSC_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/paste.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/paste.h
@@ -1,0 +1,75 @@
+/**
+ * @file paste.h
+ *
+ * Paste utilities - validate and encode paste data for terminal input.
+ */
+
+#ifndef GHOSTTY_VT_PASTE_H
+#define GHOSTTY_VT_PASTE_H
+
+/** @defgroup paste Paste Utilities
+ *
+ * Utilities for validating paste data safety.
+ *
+ * ## Basic Usage
+ *
+ * Use ghostty_paste_is_safe() to check if paste data contains potentially
+ * dangerous sequences before sending it to the terminal.
+ *
+ * ## Example
+ *
+ * @code{.c}
+ * #include <stdio.h>
+ * #include <string.h>
+ * #include <ghostty/vt.h>
+ * 
+ * int main() {
+ *   const char* safe_data = "hello world";
+ *   const char* unsafe_data = "rm -rf /\n";
+ * 
+ *   if (ghostty_paste_is_safe(safe_data, strlen(safe_data))) {
+ *     printf("Safe to paste\n");
+ *   }
+ * 
+ *   if (!ghostty_paste_is_safe(unsafe_data, strlen(unsafe_data))) {
+ *     printf("Unsafe! Contains newline\n");
+ *   }
+ * 
+ *   return 0;
+ * }
+ * @endcode
+ *
+ * @{
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Check if paste data is safe to paste into the terminal.
+ *
+ * Data is considered unsafe if it contains:
+ * - Newlines (`\n`) which can inject commands
+ * - The bracketed paste end sequence (`\x1b[201~`) which can be used
+ *   to exit bracketed paste mode and inject commands
+ *
+ * This check is conservative and considers data unsafe regardless of
+ * current terminal state.
+ *
+ * @param data The paste data to check (must not be NULL)
+ * @param len The length of the data in bytes
+ * @return true if the data is safe to paste, false otherwise
+ */
+bool ghostty_paste_is_safe(const char* data, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* GHOSTTY_VT_PASTE_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/result.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/result.h
@@ -1,0 +1,22 @@
+/**
+ * @file result.h
+ *
+ * Result codes for libghostty-vt operations.
+ */
+
+#ifndef GHOSTTY_VT_RESULT_H
+#define GHOSTTY_VT_RESULT_H
+
+/**
+ * Result codes for libghostty-vt operations.
+ */
+typedef enum {
+    /** Operation completed successfully */
+    GHOSTTY_SUCCESS = 0,
+    /** Operation failed due to failed allocation */
+    GHOSTTY_OUT_OF_MEMORY = -1,
+    /** Operation failed due to invalid value */
+    GHOSTTY_INVALID_VALUE = -2,
+} GhosttyResult;
+
+#endif /* GHOSTTY_VT_RESULT_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/sgr.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/sgr.h
@@ -1,0 +1,394 @@
+/**
+ * @file sgr.h
+ *
+ * SGR (Select Graphic Rendition) attribute parsing and handling.
+ */
+
+#ifndef GHOSTTY_VT_SGR_H
+#define GHOSTTY_VT_SGR_H
+
+/** @defgroup sgr SGR Parser
+ *
+ * SGR (Select Graphic Rendition) attribute parser.
+ *
+ * SGR sequences are the syntax used to set styling attributes such as
+ * bold, italic, underline, and colors for text in terminal emulators.
+ * For example, you may be familiar with sequences like `ESC[1;31m`. The
+ * `1;31` is the SGR attribute list.
+ *
+ * The parser processes SGR parameters from CSI sequences (e.g., `ESC[1;31m`)
+ * and returns individual text attributes like bold, italic, colors, etc.
+ * It supports both semicolon (`;`) and colon (`:`) separators, possibly mixed,
+ * and handles various color formats including 8-color, 16-color, 256-color,
+ * X11 named colors, and RGB in multiple formats.
+ *
+ * ## Basic Usage
+ *
+ * 1. Create a parser instance with ghostty_sgr_new()
+ * 2. Set SGR parameters with ghostty_sgr_set_params()
+ * 3. Iterate through attributes using ghostty_sgr_next()
+ * 4. Free the parser with ghostty_sgr_free() when done
+ *
+ * ## Example
+ *
+ * @code{.c}
+ * #include <assert.h>
+ * #include <stdio.h>
+ * #include <ghostty/vt.h>
+ *
+ * int main() {
+ *   // Create parser
+ *   GhosttySgrParser parser;
+ *   GhosttyResult result = ghostty_sgr_new(NULL, &parser);
+ *   assert(result == GHOSTTY_SUCCESS);
+ *
+ *   // Parse "bold, red foreground" sequence: ESC[1;31m
+ *   uint16_t params[] = {1, 31};
+ *   result = ghostty_sgr_set_params(parser, params, NULL, 2);
+ *   assert(result == GHOSTTY_SUCCESS);
+ *
+ *   // Iterate through attributes
+ *   GhosttySgrAttribute attr;
+ *   while (ghostty_sgr_next(parser, &attr)) {
+ *     switch (attr.tag) {
+ *       case GHOSTTY_SGR_ATTR_BOLD:
+ *         printf("Bold enabled\n");
+ *         break;
+ *       case GHOSTTY_SGR_ATTR_FG_8:
+ *         printf("Foreground color: %d\n", attr.value.fg_8);
+ *         break;
+ *       default:
+ *         break;
+ *     }
+ *   }
+ *
+ *   // Cleanup
+ *   ghostty_sgr_free(parser);
+ *   return 0;
+ * }
+ * @endcode
+ *
+ * @{
+ */
+
+#include <ghostty/vt/allocator.h>
+#include <ghostty/vt/color.h>
+#include <ghostty/vt/result.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Opaque handle to an SGR parser instance.
+ *
+ * This handle represents an SGR (Select Graphic Rendition) parser that can
+ * be used to parse SGR sequences and extract individual text attributes.
+ *
+ * @ingroup sgr
+ */
+typedef struct GhosttySgrParser* GhosttySgrParser;
+
+/**
+ * SGR attribute tags.
+ *
+ * These values identify the type of an SGR attribute in a tagged union.
+ * Use the tag to determine which field in the attribute value union to access.
+ *
+ * @ingroup sgr
+ */
+typedef enum {
+  GHOSTTY_SGR_ATTR_UNSET = 0,
+  GHOSTTY_SGR_ATTR_UNKNOWN = 1,
+  GHOSTTY_SGR_ATTR_BOLD = 2,
+  GHOSTTY_SGR_ATTR_RESET_BOLD = 3,
+  GHOSTTY_SGR_ATTR_ITALIC = 4,
+  GHOSTTY_SGR_ATTR_RESET_ITALIC = 5,
+  GHOSTTY_SGR_ATTR_FAINT = 6,
+  GHOSTTY_SGR_ATTR_UNDERLINE = 7,
+  GHOSTTY_SGR_ATTR_RESET_UNDERLINE = 8,
+  GHOSTTY_SGR_ATTR_UNDERLINE_COLOR = 9,
+  GHOSTTY_SGR_ATTR_UNDERLINE_COLOR_256 = 10,
+  GHOSTTY_SGR_ATTR_RESET_UNDERLINE_COLOR = 11,
+  GHOSTTY_SGR_ATTR_OVERLINE = 12,
+  GHOSTTY_SGR_ATTR_RESET_OVERLINE = 13,
+  GHOSTTY_SGR_ATTR_BLINK = 14,
+  GHOSTTY_SGR_ATTR_RESET_BLINK = 15,
+  GHOSTTY_SGR_ATTR_INVERSE = 16,
+  GHOSTTY_SGR_ATTR_RESET_INVERSE = 17,
+  GHOSTTY_SGR_ATTR_INVISIBLE = 18,
+  GHOSTTY_SGR_ATTR_RESET_INVISIBLE = 19,
+  GHOSTTY_SGR_ATTR_STRIKETHROUGH = 20,
+  GHOSTTY_SGR_ATTR_RESET_STRIKETHROUGH = 21,
+  GHOSTTY_SGR_ATTR_DIRECT_COLOR_FG = 22,
+  GHOSTTY_SGR_ATTR_DIRECT_COLOR_BG = 23,
+  GHOSTTY_SGR_ATTR_BG_8 = 24,
+  GHOSTTY_SGR_ATTR_FG_8 = 25,
+  GHOSTTY_SGR_ATTR_RESET_FG = 26,
+  GHOSTTY_SGR_ATTR_RESET_BG = 27,
+  GHOSTTY_SGR_ATTR_BRIGHT_BG_8 = 28,
+  GHOSTTY_SGR_ATTR_BRIGHT_FG_8 = 29,
+  GHOSTTY_SGR_ATTR_BG_256 = 30,
+  GHOSTTY_SGR_ATTR_FG_256 = 31,
+} GhosttySgrAttributeTag;
+
+/**
+ * Underline style types.
+ *
+ * @ingroup sgr
+ */
+typedef enum {
+  GHOSTTY_SGR_UNDERLINE_NONE = 0,
+  GHOSTTY_SGR_UNDERLINE_SINGLE = 1,
+  GHOSTTY_SGR_UNDERLINE_DOUBLE = 2,
+  GHOSTTY_SGR_UNDERLINE_CURLY = 3,
+  GHOSTTY_SGR_UNDERLINE_DOTTED = 4,
+  GHOSTTY_SGR_UNDERLINE_DASHED = 5,
+} GhosttySgrUnderline;
+
+/**
+ * Unknown SGR attribute data.
+ *
+ * Contains the full parameter list and the partial list where parsing
+ * encountered an unknown or invalid sequence.
+ *
+ * @ingroup sgr
+ */
+typedef struct {
+  const uint16_t* full_ptr;
+  size_t full_len;
+  const uint16_t* partial_ptr;
+  size_t partial_len;
+} GhosttySgrUnknown;
+
+/**
+ * SGR attribute value union.
+ *
+ * This union contains all possible attribute values. Use the tag field
+ * to determine which union member is active. Attributes without associated
+ * data (like bold, italic) don't use the union value.
+ *
+ * @ingroup sgr
+ */
+typedef union {
+  GhosttySgrUnknown unknown;
+  GhosttySgrUnderline underline;
+  GhosttyColorRgb underline_color;
+  GhosttyColorPaletteIndex underline_color_256;
+  GhosttyColorRgb direct_color_fg;
+  GhosttyColorRgb direct_color_bg;
+  GhosttyColorPaletteIndex bg_8;
+  GhosttyColorPaletteIndex fg_8;
+  GhosttyColorPaletteIndex bright_bg_8;
+  GhosttyColorPaletteIndex bright_fg_8;
+  GhosttyColorPaletteIndex bg_256;
+  GhosttyColorPaletteIndex fg_256;
+  uint64_t _padding[8];
+} GhosttySgrAttributeValue;
+
+/**
+ * SGR attribute (tagged union).
+ *
+ * A complete SGR attribute with both its type tag and associated value.
+ * Always check the tag field to determine which value union member is valid.
+ *
+ * Attributes without associated data (e.g., GHOSTTY_SGR_ATTR_BOLD) can be
+ * identified by tag alone; the value union is not used for these and
+ * the memory in the value field is undefined.
+ *
+ * @ingroup sgr
+ */
+typedef struct {
+  GhosttySgrAttributeTag tag;
+  GhosttySgrAttributeValue value;
+} GhosttySgrAttribute;
+
+/**
+ * Create a new SGR parser instance.
+ *
+ * Creates a new SGR (Select Graphic Rendition) parser using the provided
+ * allocator. The parser must be freed using ghostty_sgr_free() when
+ * no longer needed.
+ *
+ * @param allocator Pointer to the allocator to use for memory management, or
+ * NULL to use the default allocator
+ * @param parser Pointer to store the created parser handle
+ * @return GHOSTTY_SUCCESS on success, or an error code on failure
+ *
+ * @ingroup sgr
+ */
+GhosttyResult ghostty_sgr_new(const GhosttyAllocator* allocator,
+                              GhosttySgrParser* parser);
+
+/**
+ * Free an SGR parser instance.
+ *
+ * Releases all resources associated with the SGR parser. After this call,
+ * the parser handle becomes invalid and must not be used. This includes
+ * any attributes previously returned by ghostty_sgr_next().
+ *
+ * @param parser The parser handle to free (may be NULL)
+ *
+ * @ingroup sgr
+ */
+void ghostty_sgr_free(GhosttySgrParser parser);
+
+/**
+ * Reset an SGR parser instance to the beginning of the parameter list.
+ *
+ * Resets the parser's iteration state without clearing the parameters.
+ * After calling this, ghostty_sgr_next() will start from the beginning
+ * of the parameter list again.
+ *
+ * @param parser The parser handle to reset, must not be NULL
+ *
+ * @ingroup sgr
+ */
+void ghostty_sgr_reset(GhosttySgrParser parser);
+
+/**
+ * Set SGR parameters for parsing.
+ *
+ * Sets the SGR parameter list to parse. Parameters are the numeric values
+ * from a CSI SGR sequence (e.g., for `ESC[1;31m`, params would be {1, 31}).
+ *
+ * The separators array optionally specifies the separator type for each
+ * parameter position. Each byte should be either ';' for semicolon or ':'
+ * for colon. This is needed for certain color formats that use colon
+ * separators (e.g., `ESC[4:3m` for curly underline). Any invalid separator
+ * values are treated as semicolons. The separators array must have the same
+ * length as the params array, if it is not NULL.
+ *
+ * If separators is NULL, all parameters are assumed to be semicolon-separated.
+ *
+ * This function makes an internal copy of the parameter and separator data,
+ * so the caller can safely free or modify the input arrays after this call.
+ *
+ * After calling this function, the parser is automatically reset and ready
+ * to iterate from the beginning.
+ *
+ * @param parser The parser handle, must not be NULL
+ * @param params Array of SGR parameter values
+ * @param separators Optional array of separator characters (';' or ':'), or
+ * NULL
+ * @param len Number of parameters (and separators if provided)
+ * @return GHOSTTY_SUCCESS on success, or an error code on failure
+ *
+ * @ingroup sgr
+ */
+GhosttyResult ghostty_sgr_set_params(GhosttySgrParser parser,
+                                     const uint16_t* params,
+                                     const char* separators,
+                                     size_t len);
+
+/**
+ * Get the next SGR attribute.
+ *
+ * Parses and returns the next attribute from the parameter list.
+ * Call this function repeatedly until it returns false to process
+ * all attributes in the sequence.
+ *
+ * @param parser The parser handle, must not be NULL
+ * @param attr Pointer to store the next attribute
+ * @return true if an attribute was returned, false if no more attributes
+ *
+ * @ingroup sgr
+ */
+bool ghostty_sgr_next(GhosttySgrParser parser, GhosttySgrAttribute* attr);
+
+/**
+ * Get the full parameter list from an unknown SGR attribute.
+ *
+ * This function retrieves the full parameter list that was provided to the
+ * parser when an unknown attribute was encountered. Primarily useful in
+ * WebAssembly environments where accessing struct fields directly is difficult.
+ *
+ * @param unknown The unknown attribute data
+ * @param ptr Pointer to store the pointer to the parameter array (may be NULL)
+ * @return The length of the full parameter array
+ *
+ * @ingroup sgr
+ */
+size_t ghostty_sgr_unknown_full(GhosttySgrUnknown unknown,
+                                const uint16_t** ptr);
+
+/**
+ * Get the partial parameter list from an unknown SGR attribute.
+ *
+ * This function retrieves the partial parameter list where parsing stopped
+ * when an unknown attribute was encountered. Primarily useful in WebAssembly
+ * environments where accessing struct fields directly is difficult.
+ *
+ * @param unknown The unknown attribute data
+ * @param ptr Pointer to store the pointer to the parameter array (may be NULL)
+ * @return The length of the partial parameter array
+ *
+ * @ingroup sgr
+ */
+size_t ghostty_sgr_unknown_partial(GhosttySgrUnknown unknown,
+                                   const uint16_t** ptr);
+
+/**
+ * Get the tag from an SGR attribute.
+ *
+ * This function extracts the tag that identifies which type of attribute
+ * this is. Primarily useful in WebAssembly environments where accessing
+ * struct fields directly is difficult.
+ *
+ * @param attr The SGR attribute
+ * @return The attribute tag
+ *
+ * @ingroup sgr
+ */
+GhosttySgrAttributeTag ghostty_sgr_attribute_tag(GhosttySgrAttribute attr);
+
+/**
+ * Get the value from an SGR attribute.
+ *
+ * This function returns a pointer to the value union from an SGR attribute. Use
+ * the tag to determine which field of the union is valid. Primarily useful in
+ * WebAssembly environments where accessing struct fields directly is difficult.
+ *
+ * @param attr Pointer to the SGR attribute
+ * @return Pointer to the attribute value union
+ *
+ * @ingroup sgr
+ */
+GhosttySgrAttributeValue* ghostty_sgr_attribute_value(
+    GhosttySgrAttribute* attr);
+
+#ifdef __wasm__
+/**
+ * Allocate memory for an SGR attribute (WebAssembly only).
+ *
+ * This is a convenience function for WebAssembly environments to allocate
+ * memory for an SGR attribute structure that can be passed to ghostty_sgr_next.
+ *
+ * @return Pointer to the allocated attribute structure
+ *
+ * @ingroup wasm
+ */
+GhosttySgrAttribute* ghostty_wasm_alloc_sgr_attribute(void);
+
+/**
+ * Free memory for an SGR attribute (WebAssembly only).
+ *
+ * Frees memory allocated by ghostty_wasm_alloc_sgr_attribute.
+ *
+ * @param attr Pointer to the attribute structure to free
+ *
+ * @ingroup wasm
+ */
+void ghostty_wasm_free_sgr_attribute(GhosttySgrAttribute* attr);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* GHOSTTY_VT_SGR_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/wasm.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/ghostty/vt/wasm.h
@@ -1,0 +1,159 @@
+/**
+ * @file wasm.h
+ *
+ * WebAssembly utility functions for libghostty-vt.
+ */
+
+#ifndef GHOSTTY_VT_WASM_H
+#define GHOSTTY_VT_WASM_H
+
+#ifdef __wasm__
+
+#include <stddef.h>
+#include <stdint.h>
+
+/** @defgroup wasm WebAssembly Utilities
+ *
+ * Convenience functions for allocating various types in WebAssembly builds.
+ * **These are only available the libghostty-vt wasm module.**
+ *
+ * Ghostty relies on pointers to various types for ABI compatibility, and
+ * creating those pointers in Wasm can be tedious. These functions provide
+ * a purely additive set of utilities that simplify memory management in
+ * Wasm environments without changing the core C library API.
+ *
+ * @note These functions always use the default allocator. If you need
+ * custom allocation strategies, you should allocate types manually using
+ * your custom allocator. This is a very rare use case in the WebAssembly
+ * world so these are optimized for simplicity.
+ *
+ * ## Example Usage
+ *
+ * Here's a simple example of using the Wasm utilities with the key encoder:
+ *
+ * @code
+ * const { exports } = wasmInstance;
+ * const view = new DataView(wasmMemory.buffer);
+ *
+ * // Create key encoder
+ * const encoderPtr = exports.ghostty_wasm_alloc_opaque();
+ * exports.ghostty_key_encoder_new(null, encoderPtr);
+ * const encoder = view.getUint32(encoder, true);
+ *
+ * // Configure encoder with Kitty protocol flags
+ * const flagsPtr = exports.ghostty_wasm_alloc_u8();
+ * view.setUint8(flagsPtr, 0x1F);
+ * exports.ghostty_key_encoder_setopt(encoder, 5, flagsPtr);
+ *
+ * // Allocate output buffer and size pointer
+ * const bufferSize = 32;
+ * const bufPtr = exports.ghostty_wasm_alloc_u8_array(bufferSize);
+ * const writtenPtr = exports.ghostty_wasm_alloc_usize();
+ *
+ * // Encode the key event
+ * exports.ghostty_key_encoder_encode(
+ *     encoder, eventPtr, bufPtr, bufferSize, writtenPtr
+ * );
+ *
+ * // Read encoded output
+ * const bytesWritten = view.getUint32(writtenPtr, true);
+ * const encoded = new Uint8Array(wasmMemory.buffer, bufPtr, bytesWritten);
+ * @endcode
+ *
+ * @remark The code above is pretty ugly! This is the lowest level interface
+ * to the libghostty-vt Wasm module. In practice, this should be wrapped
+ * in a higher-level API that abstracts away all this.
+ *
+ * @{
+ */
+
+/**
+ * Allocate an opaque pointer. This can be used for any opaque pointer
+ * types such as GhosttyKeyEncoder, GhosttyKeyEvent, etc.
+ *
+ * @return Pointer to allocated opaque pointer, or NULL if allocation failed
+ * @ingroup wasm
+ */
+void** ghostty_wasm_alloc_opaque(void);
+
+/**
+ * Free an opaque pointer allocated by ghostty_wasm_alloc_opaque().
+ *
+ * @param ptr Pointer to free, or NULL (NULL is safely ignored)
+ * @ingroup wasm
+ */
+void ghostty_wasm_free_opaque(void **ptr);
+
+/**
+ * Allocate an array of uint8_t values.
+ *
+ * @param len Number of uint8_t elements to allocate
+ * @return Pointer to allocated array, or NULL if allocation failed
+ * @ingroup wasm
+ */
+uint8_t* ghostty_wasm_alloc_u8_array(size_t len);
+
+/**
+ * Free an array allocated by ghostty_wasm_alloc_u8_array().
+ *
+ * @param ptr Pointer to the array to free, or NULL (NULL is safely ignored)
+ * @param len Length of the array (must match the length passed to alloc)
+ * @ingroup wasm
+ */
+void ghostty_wasm_free_u8_array(uint8_t *ptr, size_t len);
+
+/**
+ * Allocate an array of uint16_t values.
+ *
+ * @param len Number of uint16_t elements to allocate
+ * @return Pointer to allocated array, or NULL if allocation failed
+ * @ingroup wasm
+ */
+uint16_t* ghostty_wasm_alloc_u16_array(size_t len);
+
+/**
+ * Free an array allocated by ghostty_wasm_alloc_u16_array().
+ *
+ * @param ptr Pointer to the array to free, or NULL (NULL is safely ignored)
+ * @param len Length of the array (must match the length passed to alloc)
+ * @ingroup wasm
+ */
+void ghostty_wasm_free_u16_array(uint16_t *ptr, size_t len);
+
+/**
+ * Allocate a single uint8_t value.
+ *
+ * @return Pointer to allocated uint8_t, or NULL if allocation failed
+ * @ingroup wasm
+ */
+uint8_t* ghostty_wasm_alloc_u8(void);
+
+/**
+ * Free a uint8_t allocated by ghostty_wasm_alloc_u8().
+ *
+ * @param ptr Pointer to free, or NULL (NULL is safely ignored)
+ * @ingroup wasm
+ */
+void ghostty_wasm_free_u8(uint8_t *ptr);
+
+/**
+ * Allocate a single size_t value.
+ *
+ * @return Pointer to allocated size_t, or NULL if allocation failed
+ * @ingroup wasm
+ */
+size_t* ghostty_wasm_alloc_usize(void);
+
+/**
+ * Free a size_t allocated by ghostty_wasm_alloc_usize().
+ *
+ * @param ptr Pointer to free, or NULL (NULL is safely ignored)
+ * @ingroup wasm
+ */
+void ghostty_wasm_free_usize(size_t *ptr);
+
+/** @} */
+
+#endif /* __wasm__ */
+
+#endif /* GHOSTTY_VT_WASM_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/module.modulemap
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64-simulator/Headers/module.modulemap
@@ -1,0 +1,7 @@
+// This makes Ghostty available to the XCode build for the macOS app.
+// We append "Kit" to it not to be cute, but because targets have to have
+// unique names and we use Ghostty for other things.
+module GhosttyKit {
+    umbrella header "ghostty.h"
+    export *
+}

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty.h
@@ -1,0 +1,1218 @@
+// Ghostty embedding API. The documentation for the embedding API is
+// only within the Zig source files that define the implementations. This
+// isn't meant to be a general purpose embedding API (yet) so there hasn't
+// been documentation or example work beyond that.
+//
+// The only consumer of this API is the macOS app, but the API is built to
+// be more general purpose.
+#ifndef GHOSTTY_H
+#define GHOSTTY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#else
+#include <sys/types.h>
+#endif
+
+//-------------------------------------------------------------------
+// Macros
+
+#define GHOSTTY_SUCCESS 0
+
+// Symbol visibility for shared library builds. On Windows, functions
+// are exported from the DLL when building and imported when consuming.
+// On other platforms with GCC/Clang, functions are marked with default
+// visibility so they remain accessible when the library is built with
+// -fvisibility=hidden. For static library builds, define GHOSTTY_STATIC
+// before including this header to make this a no-op.
+#ifndef GHOSTTY_API
+#if defined(GHOSTTY_STATIC)
+  #define GHOSTTY_API
+#elif defined(_WIN32) || defined(_WIN64)
+  #ifdef GHOSTTY_BUILD_SHARED
+    #define GHOSTTY_API __declspec(dllexport)
+  #else
+    #define GHOSTTY_API __declspec(dllimport)
+  #endif
+#elif defined(__GNUC__) && __GNUC__ >= 4
+  #define GHOSTTY_API __attribute__((visibility("default")))
+#else
+  #define GHOSTTY_API
+#endif
+#endif
+
+//-------------------------------------------------------------------
+// Types
+
+// Opaque types
+typedef void* ghostty_app_t;
+typedef void* ghostty_config_t;
+typedef void* ghostty_surface_t;
+typedef void* ghostty_inspector_t;
+
+// All the types below are fully defined and must be kept in sync with
+// their Zig counterparts. Any changes to these types MUST have an associated
+// Zig change.
+typedef enum {
+  GHOSTTY_PLATFORM_INVALID,
+  GHOSTTY_PLATFORM_MACOS,
+  GHOSTTY_PLATFORM_IOS,
+} ghostty_platform_e;
+
+// Callback for custom I/O write handler.
+typedef void (*ghostty_surface_write_fn)(void* userdata,
+                                         const uint8_t* data,
+                                         size_t len);
+
+typedef enum {
+  GHOSTTY_CLIPBOARD_STANDARD,
+  GHOSTTY_CLIPBOARD_SELECTION,
+} ghostty_clipboard_e;
+
+typedef struct {
+  const char *mime;
+  const char *data;
+} ghostty_clipboard_content_s;
+
+typedef enum {
+  GHOSTTY_CLIPBOARD_REQUEST_PASTE,
+  GHOSTTY_CLIPBOARD_REQUEST_OSC_52_READ,
+  GHOSTTY_CLIPBOARD_REQUEST_OSC_52_WRITE,
+} ghostty_clipboard_request_e;
+
+typedef enum {
+  GHOSTTY_MOUSE_RELEASE,
+  GHOSTTY_MOUSE_PRESS,
+} ghostty_input_mouse_state_e;
+
+typedef enum {
+  GHOSTTY_MOUSE_UNKNOWN,
+  GHOSTTY_MOUSE_LEFT,
+  GHOSTTY_MOUSE_RIGHT,
+  GHOSTTY_MOUSE_MIDDLE,
+  GHOSTTY_MOUSE_FOUR,
+  GHOSTTY_MOUSE_FIVE,
+  GHOSTTY_MOUSE_SIX,
+  GHOSTTY_MOUSE_SEVEN,
+  GHOSTTY_MOUSE_EIGHT,
+  GHOSTTY_MOUSE_NINE,
+  GHOSTTY_MOUSE_TEN,
+  GHOSTTY_MOUSE_ELEVEN,
+} ghostty_input_mouse_button_e;
+
+typedef enum {
+  GHOSTTY_MOUSE_MOMENTUM_NONE,
+  GHOSTTY_MOUSE_MOMENTUM_BEGAN,
+  GHOSTTY_MOUSE_MOMENTUM_STATIONARY,
+  GHOSTTY_MOUSE_MOMENTUM_CHANGED,
+  GHOSTTY_MOUSE_MOMENTUM_ENDED,
+  GHOSTTY_MOUSE_MOMENTUM_CANCELLED,
+  GHOSTTY_MOUSE_MOMENTUM_MAY_BEGIN,
+} ghostty_input_mouse_momentum_e;
+
+typedef enum {
+  GHOSTTY_COLOR_SCHEME_LIGHT = 0,
+  GHOSTTY_COLOR_SCHEME_DARK = 1,
+} ghostty_color_scheme_e;
+
+// This is a packed struct (see src/input/mouse.zig) but the C standard
+// afaik doesn't let us reliably define packed structs so we build it up
+// from scratch.
+typedef int ghostty_input_scroll_mods_t;
+
+typedef enum {
+  GHOSTTY_MODS_NONE = 0,
+  GHOSTTY_MODS_SHIFT = 1 << 0,
+  GHOSTTY_MODS_CTRL = 1 << 1,
+  GHOSTTY_MODS_ALT = 1 << 2,
+  GHOSTTY_MODS_SUPER = 1 << 3,
+  GHOSTTY_MODS_CAPS = 1 << 4,
+  GHOSTTY_MODS_NUM = 1 << 5,
+  GHOSTTY_MODS_SHIFT_RIGHT = 1 << 6,
+  GHOSTTY_MODS_CTRL_RIGHT = 1 << 7,
+  GHOSTTY_MODS_ALT_RIGHT = 1 << 8,
+  GHOSTTY_MODS_SUPER_RIGHT = 1 << 9,
+} ghostty_input_mods_e;
+
+typedef enum {
+  GHOSTTY_BINDING_FLAGS_CONSUMED = 1 << 0,
+  GHOSTTY_BINDING_FLAGS_ALL = 1 << 1,
+  GHOSTTY_BINDING_FLAGS_GLOBAL = 1 << 2,
+  GHOSTTY_BINDING_FLAGS_PERFORMABLE = 1 << 3,
+} ghostty_binding_flags_e;
+
+typedef enum {
+  GHOSTTY_ACTION_RELEASE,
+  GHOSTTY_ACTION_PRESS,
+  GHOSTTY_ACTION_REPEAT,
+} ghostty_input_action_e;
+
+// Based on: https://www.w3.org/TR/uievents-code/
+typedef enum {
+  GHOSTTY_KEY_UNIDENTIFIED,
+
+  // "Writing System Keys" § 3.1.1
+  GHOSTTY_KEY_BACKQUOTE,
+  GHOSTTY_KEY_BACKSLASH,
+  GHOSTTY_KEY_BRACKET_LEFT,
+  GHOSTTY_KEY_BRACKET_RIGHT,
+  GHOSTTY_KEY_COMMA,
+  GHOSTTY_KEY_DIGIT_0,
+  GHOSTTY_KEY_DIGIT_1,
+  GHOSTTY_KEY_DIGIT_2,
+  GHOSTTY_KEY_DIGIT_3,
+  GHOSTTY_KEY_DIGIT_4,
+  GHOSTTY_KEY_DIGIT_5,
+  GHOSTTY_KEY_DIGIT_6,
+  GHOSTTY_KEY_DIGIT_7,
+  GHOSTTY_KEY_DIGIT_8,
+  GHOSTTY_KEY_DIGIT_9,
+  GHOSTTY_KEY_EQUAL,
+  GHOSTTY_KEY_INTL_BACKSLASH,
+  GHOSTTY_KEY_INTL_RO,
+  GHOSTTY_KEY_INTL_YEN,
+  GHOSTTY_KEY_A,
+  GHOSTTY_KEY_B,
+  GHOSTTY_KEY_C,
+  GHOSTTY_KEY_D,
+  GHOSTTY_KEY_E,
+  GHOSTTY_KEY_F,
+  GHOSTTY_KEY_G,
+  GHOSTTY_KEY_H,
+  GHOSTTY_KEY_I,
+  GHOSTTY_KEY_J,
+  GHOSTTY_KEY_K,
+  GHOSTTY_KEY_L,
+  GHOSTTY_KEY_M,
+  GHOSTTY_KEY_N,
+  GHOSTTY_KEY_O,
+  GHOSTTY_KEY_P,
+  GHOSTTY_KEY_Q,
+  GHOSTTY_KEY_R,
+  GHOSTTY_KEY_S,
+  GHOSTTY_KEY_T,
+  GHOSTTY_KEY_U,
+  GHOSTTY_KEY_V,
+  GHOSTTY_KEY_W,
+  GHOSTTY_KEY_X,
+  GHOSTTY_KEY_Y,
+  GHOSTTY_KEY_Z,
+  GHOSTTY_KEY_MINUS,
+  GHOSTTY_KEY_PERIOD,
+  GHOSTTY_KEY_QUOTE,
+  GHOSTTY_KEY_SEMICOLON,
+  GHOSTTY_KEY_SLASH,
+
+  // "Functional Keys" § 3.1.2
+  GHOSTTY_KEY_ALT_LEFT,
+  GHOSTTY_KEY_ALT_RIGHT,
+  GHOSTTY_KEY_BACKSPACE,
+  GHOSTTY_KEY_CAPS_LOCK,
+  GHOSTTY_KEY_CONTEXT_MENU,
+  GHOSTTY_KEY_CONTROL_LEFT,
+  GHOSTTY_KEY_CONTROL_RIGHT,
+  GHOSTTY_KEY_ENTER,
+  GHOSTTY_KEY_META_LEFT,
+  GHOSTTY_KEY_META_RIGHT,
+  GHOSTTY_KEY_SHIFT_LEFT,
+  GHOSTTY_KEY_SHIFT_RIGHT,
+  GHOSTTY_KEY_SPACE,
+  GHOSTTY_KEY_TAB,
+  GHOSTTY_KEY_CONVERT,
+  GHOSTTY_KEY_KANA_MODE,
+  GHOSTTY_KEY_NON_CONVERT,
+
+  // "Control Pad Section" § 3.2
+  GHOSTTY_KEY_DELETE,
+  GHOSTTY_KEY_END,
+  GHOSTTY_KEY_HELP,
+  GHOSTTY_KEY_HOME,
+  GHOSTTY_KEY_INSERT,
+  GHOSTTY_KEY_PAGE_DOWN,
+  GHOSTTY_KEY_PAGE_UP,
+
+  // "Arrow Pad Section" § 3.3
+  GHOSTTY_KEY_ARROW_DOWN,
+  GHOSTTY_KEY_ARROW_LEFT,
+  GHOSTTY_KEY_ARROW_RIGHT,
+  GHOSTTY_KEY_ARROW_UP,
+
+  // "Numpad Section" § 3.4
+  GHOSTTY_KEY_NUM_LOCK,
+  GHOSTTY_KEY_NUMPAD_0,
+  GHOSTTY_KEY_NUMPAD_1,
+  GHOSTTY_KEY_NUMPAD_2,
+  GHOSTTY_KEY_NUMPAD_3,
+  GHOSTTY_KEY_NUMPAD_4,
+  GHOSTTY_KEY_NUMPAD_5,
+  GHOSTTY_KEY_NUMPAD_6,
+  GHOSTTY_KEY_NUMPAD_7,
+  GHOSTTY_KEY_NUMPAD_8,
+  GHOSTTY_KEY_NUMPAD_9,
+  GHOSTTY_KEY_NUMPAD_ADD,
+  GHOSTTY_KEY_NUMPAD_BACKSPACE,
+  GHOSTTY_KEY_NUMPAD_CLEAR,
+  GHOSTTY_KEY_NUMPAD_CLEAR_ENTRY,
+  GHOSTTY_KEY_NUMPAD_COMMA,
+  GHOSTTY_KEY_NUMPAD_DECIMAL,
+  GHOSTTY_KEY_NUMPAD_DIVIDE,
+  GHOSTTY_KEY_NUMPAD_ENTER,
+  GHOSTTY_KEY_NUMPAD_EQUAL,
+  GHOSTTY_KEY_NUMPAD_MEMORY_ADD,
+  GHOSTTY_KEY_NUMPAD_MEMORY_CLEAR,
+  GHOSTTY_KEY_NUMPAD_MEMORY_RECALL,
+  GHOSTTY_KEY_NUMPAD_MEMORY_STORE,
+  GHOSTTY_KEY_NUMPAD_MEMORY_SUBTRACT,
+  GHOSTTY_KEY_NUMPAD_MULTIPLY,
+  GHOSTTY_KEY_NUMPAD_PAREN_LEFT,
+  GHOSTTY_KEY_NUMPAD_PAREN_RIGHT,
+  GHOSTTY_KEY_NUMPAD_SUBTRACT,
+  GHOSTTY_KEY_NUMPAD_SEPARATOR,
+  GHOSTTY_KEY_NUMPAD_UP,
+  GHOSTTY_KEY_NUMPAD_DOWN,
+  GHOSTTY_KEY_NUMPAD_RIGHT,
+  GHOSTTY_KEY_NUMPAD_LEFT,
+  GHOSTTY_KEY_NUMPAD_BEGIN,
+  GHOSTTY_KEY_NUMPAD_HOME,
+  GHOSTTY_KEY_NUMPAD_END,
+  GHOSTTY_KEY_NUMPAD_INSERT,
+  GHOSTTY_KEY_NUMPAD_DELETE,
+  GHOSTTY_KEY_NUMPAD_PAGE_UP,
+  GHOSTTY_KEY_NUMPAD_PAGE_DOWN,
+
+  // "Function Section" § 3.5
+  GHOSTTY_KEY_ESCAPE,
+  GHOSTTY_KEY_F1,
+  GHOSTTY_KEY_F2,
+  GHOSTTY_KEY_F3,
+  GHOSTTY_KEY_F4,
+  GHOSTTY_KEY_F5,
+  GHOSTTY_KEY_F6,
+  GHOSTTY_KEY_F7,
+  GHOSTTY_KEY_F8,
+  GHOSTTY_KEY_F9,
+  GHOSTTY_KEY_F10,
+  GHOSTTY_KEY_F11,
+  GHOSTTY_KEY_F12,
+  GHOSTTY_KEY_F13,
+  GHOSTTY_KEY_F14,
+  GHOSTTY_KEY_F15,
+  GHOSTTY_KEY_F16,
+  GHOSTTY_KEY_F17,
+  GHOSTTY_KEY_F18,
+  GHOSTTY_KEY_F19,
+  GHOSTTY_KEY_F20,
+  GHOSTTY_KEY_F21,
+  GHOSTTY_KEY_F22,
+  GHOSTTY_KEY_F23,
+  GHOSTTY_KEY_F24,
+  GHOSTTY_KEY_F25,
+  GHOSTTY_KEY_FN,
+  GHOSTTY_KEY_FN_LOCK,
+  GHOSTTY_KEY_PRINT_SCREEN,
+  GHOSTTY_KEY_SCROLL_LOCK,
+  GHOSTTY_KEY_PAUSE,
+
+  // "Media Keys" § 3.6
+  GHOSTTY_KEY_BROWSER_BACK,
+  GHOSTTY_KEY_BROWSER_FAVORITES,
+  GHOSTTY_KEY_BROWSER_FORWARD,
+  GHOSTTY_KEY_BROWSER_HOME,
+  GHOSTTY_KEY_BROWSER_REFRESH,
+  GHOSTTY_KEY_BROWSER_SEARCH,
+  GHOSTTY_KEY_BROWSER_STOP,
+  GHOSTTY_KEY_EJECT,
+  GHOSTTY_KEY_LAUNCH_APP_1,
+  GHOSTTY_KEY_LAUNCH_APP_2,
+  GHOSTTY_KEY_LAUNCH_MAIL,
+  GHOSTTY_KEY_MEDIA_PLAY_PAUSE,
+  GHOSTTY_KEY_MEDIA_SELECT,
+  GHOSTTY_KEY_MEDIA_STOP,
+  GHOSTTY_KEY_MEDIA_TRACK_NEXT,
+  GHOSTTY_KEY_MEDIA_TRACK_PREVIOUS,
+  GHOSTTY_KEY_POWER,
+  GHOSTTY_KEY_SLEEP,
+  GHOSTTY_KEY_AUDIO_VOLUME_DOWN,
+  GHOSTTY_KEY_AUDIO_VOLUME_MUTE,
+  GHOSTTY_KEY_AUDIO_VOLUME_UP,
+  GHOSTTY_KEY_WAKE_UP,
+
+  // "Legacy, Non-standard, and Special Keys" § 3.7
+  GHOSTTY_KEY_COPY,
+  GHOSTTY_KEY_CUT,
+  GHOSTTY_KEY_PASTE,
+} ghostty_input_key_e;
+
+typedef struct {
+  ghostty_input_action_e action;
+  ghostty_input_mods_e mods;
+  ghostty_input_mods_e consumed_mods;
+  uint32_t keycode;
+  const char* text;
+  uint32_t unshifted_codepoint;
+  bool composing;
+} ghostty_input_key_s;
+
+typedef enum {
+  GHOSTTY_TRIGGER_PHYSICAL,
+  GHOSTTY_TRIGGER_UNICODE,
+  GHOSTTY_TRIGGER_CATCH_ALL,
+} ghostty_input_trigger_tag_e;
+
+typedef union {
+  ghostty_input_key_e translated;
+  ghostty_input_key_e physical;
+  uint32_t unicode;
+  // catch_all has no payload
+} ghostty_input_trigger_key_u;
+
+typedef struct {
+  ghostty_input_trigger_tag_e tag;
+  ghostty_input_trigger_key_u key;
+  ghostty_input_mods_e mods;
+} ghostty_input_trigger_s;
+
+typedef struct {
+  const char* action_key;
+  const char* action;
+  const char* title;
+  const char* description;
+} ghostty_command_s;
+
+typedef enum {
+  GHOSTTY_BUILD_MODE_DEBUG,
+  GHOSTTY_BUILD_MODE_RELEASE_SAFE,
+  GHOSTTY_BUILD_MODE_RELEASE_FAST,
+  GHOSTTY_BUILD_MODE_RELEASE_SMALL,
+} ghostty_build_mode_e;
+
+typedef struct {
+  ghostty_build_mode_e build_mode;
+  const char* version;
+  uintptr_t version_len;
+} ghostty_info_s;
+
+typedef struct {
+  const char* message;
+} ghostty_diagnostic_s;
+
+typedef struct {
+  const char* ptr;
+  uintptr_t len;
+  bool sentinel;
+} ghostty_string_s;
+
+typedef struct {
+  double tl_px_x;
+  double tl_px_y;
+  uint32_t offset_start;
+  uint32_t offset_len;
+  const char* text;
+  uintptr_t text_len;
+} ghostty_text_s;
+
+typedef enum {
+  GHOSTTY_POINT_ACTIVE,
+  GHOSTTY_POINT_VIEWPORT,
+  GHOSTTY_POINT_SCREEN,
+  GHOSTTY_POINT_SURFACE,
+} ghostty_point_tag_e;
+
+typedef enum {
+  GHOSTTY_POINT_COORD_EXACT,
+  GHOSTTY_POINT_COORD_TOP_LEFT,
+  GHOSTTY_POINT_COORD_BOTTOM_RIGHT,
+} ghostty_point_coord_e;
+
+typedef struct {
+  ghostty_point_tag_e tag;
+  ghostty_point_coord_e coord;
+  uint32_t x;
+  uint32_t y;
+} ghostty_point_s;
+
+typedef struct {
+  ghostty_point_s top_left;
+  ghostty_point_s bottom_right;
+  bool rectangle;
+} ghostty_selection_s;
+
+typedef struct {
+  const char* key;
+  const char* value;
+} ghostty_env_var_s;
+
+typedef struct {
+  void* nsview;
+} ghostty_platform_macos_s;
+
+typedef struct {
+  void* uiview;
+} ghostty_platform_ios_s;
+
+typedef union {
+  ghostty_platform_macos_s macos;
+  ghostty_platform_ios_s ios;
+} ghostty_platform_u;
+
+typedef enum {
+  GHOSTTY_SURFACE_CONTEXT_WINDOW = 0,
+  GHOSTTY_SURFACE_CONTEXT_TAB = 1,
+  GHOSTTY_SURFACE_CONTEXT_SPLIT = 2,
+} ghostty_surface_context_e;
+
+typedef struct {
+  ghostty_platform_e platform_tag;
+  ghostty_platform_u platform;
+  void* userdata;
+  double scale_factor;
+  float font_size;
+  const char* working_directory;
+  const char* command;
+  ghostty_env_var_s* env_vars;
+  size_t env_var_count;
+  const char* initial_input;
+  bool wait_after_command;
+  ghostty_surface_context_e context;
+  bool use_custom_io;
+} ghostty_surface_config_s;
+
+typedef struct {
+  uint16_t columns;
+  uint16_t rows;
+  uint32_t width_px;
+  uint32_t height_px;
+  uint32_t cell_width_px;
+  uint32_t cell_height_px;
+} ghostty_surface_size_s;
+
+// Config types
+
+// config.Path
+typedef struct {
+  const char* path;
+  bool optional;
+} ghostty_config_path_s;
+
+// config.Color
+typedef struct {
+  uint8_t r;
+  uint8_t g;
+  uint8_t b;
+} ghostty_config_color_s;
+
+// config.ColorList
+typedef struct {
+  const ghostty_config_color_s* colors;
+  size_t len;
+} ghostty_config_color_list_s;
+
+// config.RepeatableCommand
+typedef struct {
+  const ghostty_command_s* commands;
+  size_t len;
+} ghostty_config_command_list_s;
+
+// config.Palette
+typedef struct {
+  ghostty_config_color_s colors[256];
+} ghostty_config_palette_s;
+
+// config.QuickTerminalSize
+typedef enum {
+  GHOSTTY_QUICK_TERMINAL_SIZE_NONE,
+  GHOSTTY_QUICK_TERMINAL_SIZE_PERCENTAGE,
+  GHOSTTY_QUICK_TERMINAL_SIZE_PIXELS,
+} ghostty_quick_terminal_size_tag_e;
+
+typedef union {
+  float percentage;
+  uint32_t pixels;
+} ghostty_quick_terminal_size_value_u;
+
+typedef struct {
+  ghostty_quick_terminal_size_tag_e tag;
+  ghostty_quick_terminal_size_value_u value;
+} ghostty_quick_terminal_size_s;
+
+typedef struct {
+  ghostty_quick_terminal_size_s primary;
+  ghostty_quick_terminal_size_s secondary;
+} ghostty_config_quick_terminal_size_s;
+
+// config.Fullscreen
+typedef enum {
+  GHOSTTY_CONFIG_FULLSCREEN_FALSE,
+  GHOSTTY_CONFIG_FULLSCREEN_TRUE,
+  GHOSTTY_CONFIG_FULLSCREEN_NON_NATIVE,
+  GHOSTTY_CONFIG_FULLSCREEN_NON_NATIVE_VISIBLE_MENU,
+  GHOSTTY_CONFIG_FULLSCREEN_NON_NATIVE_PADDED_NOTCH,
+} ghostty_config_fullscreen_e;
+
+// apprt.Target.Key
+typedef enum {
+  GHOSTTY_TARGET_APP,
+  GHOSTTY_TARGET_SURFACE,
+} ghostty_target_tag_e;
+
+typedef union {
+  ghostty_surface_t surface;
+} ghostty_target_u;
+
+typedef struct {
+  ghostty_target_tag_e tag;
+  ghostty_target_u target;
+} ghostty_target_s;
+
+// apprt.action.SplitDirection
+typedef enum {
+  GHOSTTY_SPLIT_DIRECTION_RIGHT,
+  GHOSTTY_SPLIT_DIRECTION_DOWN,
+  GHOSTTY_SPLIT_DIRECTION_LEFT,
+  GHOSTTY_SPLIT_DIRECTION_UP,
+} ghostty_action_split_direction_e;
+
+// apprt.action.GotoSplit
+typedef enum {
+  GHOSTTY_GOTO_SPLIT_PREVIOUS,
+  GHOSTTY_GOTO_SPLIT_NEXT,
+  GHOSTTY_GOTO_SPLIT_UP,
+  GHOSTTY_GOTO_SPLIT_LEFT,
+  GHOSTTY_GOTO_SPLIT_DOWN,
+  GHOSTTY_GOTO_SPLIT_RIGHT,
+} ghostty_action_goto_split_e;
+
+// apprt.action.GotoWindow
+typedef enum {
+  GHOSTTY_GOTO_WINDOW_PREVIOUS,
+  GHOSTTY_GOTO_WINDOW_NEXT,
+} ghostty_action_goto_window_e;
+
+// apprt.action.ResizeSplit.Direction
+typedef enum {
+  GHOSTTY_RESIZE_SPLIT_UP,
+  GHOSTTY_RESIZE_SPLIT_DOWN,
+  GHOSTTY_RESIZE_SPLIT_LEFT,
+  GHOSTTY_RESIZE_SPLIT_RIGHT,
+} ghostty_action_resize_split_direction_e;
+
+// apprt.action.ResizeSplit
+typedef struct {
+  uint16_t amount;
+  ghostty_action_resize_split_direction_e direction;
+} ghostty_action_resize_split_s;
+
+// apprt.action.MoveTab
+typedef struct {
+  ssize_t amount;
+} ghostty_action_move_tab_s;
+
+// apprt.action.GotoTab
+typedef enum {
+  GHOSTTY_GOTO_TAB_PREVIOUS = -1,
+  GHOSTTY_GOTO_TAB_NEXT = -2,
+  GHOSTTY_GOTO_TAB_LAST = -3,
+} ghostty_action_goto_tab_e;
+
+// apprt.action.Fullscreen
+typedef enum {
+  GHOSTTY_FULLSCREEN_NATIVE,
+  GHOSTTY_FULLSCREEN_MACOS_NON_NATIVE,
+  GHOSTTY_FULLSCREEN_MACOS_NON_NATIVE_VISIBLE_MENU,
+  GHOSTTY_FULLSCREEN_MACOS_NON_NATIVE_PADDED_NOTCH,
+} ghostty_action_fullscreen_e;
+
+// apprt.action.FloatWindow
+typedef enum {
+  GHOSTTY_FLOAT_WINDOW_ON,
+  GHOSTTY_FLOAT_WINDOW_OFF,
+  GHOSTTY_FLOAT_WINDOW_TOGGLE,
+} ghostty_action_float_window_e;
+
+// apprt.action.SecureInput
+typedef enum {
+  GHOSTTY_SECURE_INPUT_ON,
+  GHOSTTY_SECURE_INPUT_OFF,
+  GHOSTTY_SECURE_INPUT_TOGGLE,
+} ghostty_action_secure_input_e;
+
+// apprt.action.Inspector
+typedef enum {
+  GHOSTTY_INSPECTOR_TOGGLE,
+  GHOSTTY_INSPECTOR_SHOW,
+  GHOSTTY_INSPECTOR_HIDE,
+} ghostty_action_inspector_e;
+
+// apprt.action.QuitTimer
+typedef enum {
+  GHOSTTY_QUIT_TIMER_START,
+  GHOSTTY_QUIT_TIMER_STOP,
+} ghostty_action_quit_timer_e;
+
+// apprt.action.Readonly
+typedef enum {
+  GHOSTTY_READONLY_OFF,
+  GHOSTTY_READONLY_ON,
+} ghostty_action_readonly_e;
+
+// apprt.action.DesktopNotification.C
+typedef struct {
+  const char* title;
+  const char* body;
+} ghostty_action_desktop_notification_s;
+
+// apprt.action.SetTitle.C
+typedef struct {
+  const char* title;
+} ghostty_action_set_title_s;
+
+// apprt.action.PromptTitle
+typedef enum {
+  GHOSTTY_PROMPT_TITLE_SURFACE,
+  GHOSTTY_PROMPT_TITLE_TAB,
+} ghostty_action_prompt_title_e;
+
+// apprt.action.Pwd.C
+typedef struct {
+  const char* pwd;
+} ghostty_action_pwd_s;
+
+// terminal.MouseShape
+typedef enum {
+  GHOSTTY_MOUSE_SHAPE_DEFAULT,
+  GHOSTTY_MOUSE_SHAPE_CONTEXT_MENU,
+  GHOSTTY_MOUSE_SHAPE_HELP,
+  GHOSTTY_MOUSE_SHAPE_POINTER,
+  GHOSTTY_MOUSE_SHAPE_PROGRESS,
+  GHOSTTY_MOUSE_SHAPE_WAIT,
+  GHOSTTY_MOUSE_SHAPE_CELL,
+  GHOSTTY_MOUSE_SHAPE_CROSSHAIR,
+  GHOSTTY_MOUSE_SHAPE_TEXT,
+  GHOSTTY_MOUSE_SHAPE_VERTICAL_TEXT,
+  GHOSTTY_MOUSE_SHAPE_ALIAS,
+  GHOSTTY_MOUSE_SHAPE_COPY,
+  GHOSTTY_MOUSE_SHAPE_MOVE,
+  GHOSTTY_MOUSE_SHAPE_NO_DROP,
+  GHOSTTY_MOUSE_SHAPE_NOT_ALLOWED,
+  GHOSTTY_MOUSE_SHAPE_GRAB,
+  GHOSTTY_MOUSE_SHAPE_GRABBING,
+  GHOSTTY_MOUSE_SHAPE_ALL_SCROLL,
+  GHOSTTY_MOUSE_SHAPE_COL_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_ROW_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_N_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_E_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_S_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_W_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_NE_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_NW_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_SE_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_SW_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_EW_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_NS_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_NESW_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_NWSE_RESIZE,
+  GHOSTTY_MOUSE_SHAPE_ZOOM_IN,
+  GHOSTTY_MOUSE_SHAPE_ZOOM_OUT,
+} ghostty_action_mouse_shape_e;
+
+// apprt.action.MouseVisibility
+typedef enum {
+  GHOSTTY_MOUSE_VISIBLE,
+  GHOSTTY_MOUSE_HIDDEN,
+} ghostty_action_mouse_visibility_e;
+
+// apprt.action.MouseOverLink
+typedef struct {
+  const char* url;
+  size_t len;
+} ghostty_action_mouse_over_link_s;
+
+// apprt.action.SizeLimit
+typedef struct {
+  uint32_t min_width;
+  uint32_t min_height;
+  uint32_t max_width;
+  uint32_t max_height;
+} ghostty_action_size_limit_s;
+
+// apprt.action.InitialSize
+typedef struct {
+  uint32_t width;
+  uint32_t height;
+} ghostty_action_initial_size_s;
+
+// apprt.action.CellSize
+typedef struct {
+  uint32_t width;
+  uint32_t height;
+} ghostty_action_cell_size_s;
+
+// renderer.Health
+typedef enum {
+  GHOSTTY_RENDERER_HEALTH_HEALTHY,
+  GHOSTTY_RENDERER_HEALTH_UNHEALTHY,
+} ghostty_action_renderer_health_e;
+
+// apprt.action.KeySequence
+typedef struct {
+  bool active;
+  ghostty_input_trigger_s trigger;
+} ghostty_action_key_sequence_s;
+
+// apprt.action.KeyTable.Tag
+typedef enum {
+  GHOSTTY_KEY_TABLE_ACTIVATE,
+  GHOSTTY_KEY_TABLE_DEACTIVATE,
+  GHOSTTY_KEY_TABLE_DEACTIVATE_ALL,
+} ghostty_action_key_table_tag_e;
+
+// apprt.action.KeyTable.CValue
+typedef union {
+  struct {
+    const char *name;
+    size_t len;
+  } activate;
+} ghostty_action_key_table_u;
+
+// apprt.action.KeyTable.C
+typedef struct {
+  ghostty_action_key_table_tag_e tag;
+  ghostty_action_key_table_u value;
+} ghostty_action_key_table_s;
+
+// apprt.action.ColorKind
+typedef enum {
+  GHOSTTY_ACTION_COLOR_KIND_FOREGROUND = -1,
+  GHOSTTY_ACTION_COLOR_KIND_BACKGROUND = -2,
+  GHOSTTY_ACTION_COLOR_KIND_CURSOR = -3,
+} ghostty_action_color_kind_e;
+
+// apprt.action.ColorChange
+typedef struct {
+  ghostty_action_color_kind_e kind;
+  uint8_t r;
+  uint8_t g;
+  uint8_t b;
+} ghostty_action_color_change_s;
+
+// apprt.action.ConfigChange
+typedef struct {
+  ghostty_config_t config;
+} ghostty_action_config_change_s;
+
+// apprt.action.ReloadConfig
+typedef struct {
+  bool soft;
+} ghostty_action_reload_config_s;
+
+// apprt.action.OpenUrlKind
+typedef enum {
+  GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN,
+  GHOSTTY_ACTION_OPEN_URL_KIND_TEXT,
+  GHOSTTY_ACTION_OPEN_URL_KIND_HTML,
+} ghostty_action_open_url_kind_e;
+
+// apprt.action.OpenUrl.C
+typedef struct {
+  ghostty_action_open_url_kind_e kind;
+  const char* url;
+  uintptr_t len;
+} ghostty_action_open_url_s;
+
+// apprt.action.CloseTabMode
+typedef enum {
+  GHOSTTY_ACTION_CLOSE_TAB_MODE_THIS,
+  GHOSTTY_ACTION_CLOSE_TAB_MODE_OTHER,
+  GHOSTTY_ACTION_CLOSE_TAB_MODE_RIGHT,
+} ghostty_action_close_tab_mode_e;
+
+// apprt.surface.Message.ChildExited
+typedef struct {
+  uint32_t exit_code;
+  uint64_t timetime_ms;
+} ghostty_surface_message_childexited_s;
+
+// terminal.osc.Command.ProgressReport.State
+typedef enum {
+  GHOSTTY_PROGRESS_STATE_REMOVE,
+  GHOSTTY_PROGRESS_STATE_SET,
+  GHOSTTY_PROGRESS_STATE_ERROR,
+  GHOSTTY_PROGRESS_STATE_INDETERMINATE,
+  GHOSTTY_PROGRESS_STATE_PAUSE,
+} ghostty_action_progress_report_state_e;
+
+// terminal.osc.Command.ProgressReport.C
+typedef struct {
+  ghostty_action_progress_report_state_e state;
+  // -1 if no progress was reported, otherwise 0-100 indicating percent
+  // completeness.
+  int8_t progress;
+} ghostty_action_progress_report_s;
+
+// apprt.action.CommandFinished.C
+typedef struct {
+  // -1 if no exit code was reported, otherwise 0-255
+  int16_t exit_code;
+  // number of nanoseconds that command was running for
+  uint64_t duration;
+} ghostty_action_command_finished_s;
+
+// apprt.action.StartSearch.C
+typedef struct {
+  const char* needle;
+} ghostty_action_start_search_s;
+
+// apprt.action.SearchTotal
+typedef struct {
+  ssize_t total;
+} ghostty_action_search_total_s;
+
+// apprt.action.SearchSelected
+typedef struct {
+  ssize_t selected;
+} ghostty_action_search_selected_s;
+
+// terminal.Scrollbar
+typedef struct {
+  uint64_t total;
+  uint64_t offset;
+  uint64_t len;
+} ghostty_action_scrollbar_s;
+
+// apprt.Action.Key
+typedef enum {
+  GHOSTTY_ACTION_QUIT,
+  GHOSTTY_ACTION_NEW_WINDOW,
+  GHOSTTY_ACTION_NEW_TAB,
+  GHOSTTY_ACTION_CLOSE_TAB,
+  GHOSTTY_ACTION_NEW_SPLIT,
+  GHOSTTY_ACTION_CLOSE_ALL_WINDOWS,
+  GHOSTTY_ACTION_TOGGLE_MAXIMIZE,
+  GHOSTTY_ACTION_TOGGLE_FULLSCREEN,
+  GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW,
+  GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS,
+  GHOSTTY_ACTION_TOGGLE_QUICK_TERMINAL,
+  GHOSTTY_ACTION_TOGGLE_COMMAND_PALETTE,
+  GHOSTTY_ACTION_TOGGLE_VISIBILITY,
+  GHOSTTY_ACTION_TOGGLE_BACKGROUND_OPACITY,
+  GHOSTTY_ACTION_MOVE_TAB,
+  GHOSTTY_ACTION_GOTO_TAB,
+  GHOSTTY_ACTION_GOTO_SPLIT,
+  GHOSTTY_ACTION_GOTO_WINDOW,
+  GHOSTTY_ACTION_RESIZE_SPLIT,
+  GHOSTTY_ACTION_EQUALIZE_SPLITS,
+  GHOSTTY_ACTION_TOGGLE_SPLIT_ZOOM,
+  GHOSTTY_ACTION_PRESENT_TERMINAL,
+  GHOSTTY_ACTION_SIZE_LIMIT,
+  GHOSTTY_ACTION_RESET_WINDOW_SIZE,
+  GHOSTTY_ACTION_INITIAL_SIZE,
+  GHOSTTY_ACTION_CELL_SIZE,
+  GHOSTTY_ACTION_SCROLLBAR,
+  GHOSTTY_ACTION_RENDER,
+  GHOSTTY_ACTION_INSPECTOR,
+  GHOSTTY_ACTION_SHOW_GTK_INSPECTOR,
+  GHOSTTY_ACTION_RENDER_INSPECTOR,
+  GHOSTTY_ACTION_DESKTOP_NOTIFICATION,
+  GHOSTTY_ACTION_SET_TITLE,
+  GHOSTTY_ACTION_SET_TAB_TITLE,
+  GHOSTTY_ACTION_PROMPT_TITLE,
+  GHOSTTY_ACTION_PWD,
+  GHOSTTY_ACTION_MOUSE_SHAPE,
+  GHOSTTY_ACTION_MOUSE_VISIBILITY,
+  GHOSTTY_ACTION_MOUSE_OVER_LINK,
+  GHOSTTY_ACTION_RENDERER_HEALTH,
+  GHOSTTY_ACTION_OPEN_CONFIG,
+  GHOSTTY_ACTION_QUIT_TIMER,
+  GHOSTTY_ACTION_FLOAT_WINDOW,
+  GHOSTTY_ACTION_SECURE_INPUT,
+  GHOSTTY_ACTION_KEY_SEQUENCE,
+  GHOSTTY_ACTION_KEY_TABLE,
+  GHOSTTY_ACTION_COLOR_CHANGE,
+  GHOSTTY_ACTION_RELOAD_CONFIG,
+  GHOSTTY_ACTION_CONFIG_CHANGE,
+  GHOSTTY_ACTION_CLOSE_WINDOW,
+  GHOSTTY_ACTION_RING_BELL,
+  GHOSTTY_ACTION_UNDO,
+  GHOSTTY_ACTION_REDO,
+  GHOSTTY_ACTION_CHECK_FOR_UPDATES,
+  GHOSTTY_ACTION_OPEN_URL,
+  GHOSTTY_ACTION_SHOW_CHILD_EXITED,
+  GHOSTTY_ACTION_PROGRESS_REPORT,
+  GHOSTTY_ACTION_SHOW_ON_SCREEN_KEYBOARD,
+  GHOSTTY_ACTION_COMMAND_FINISHED,
+  GHOSTTY_ACTION_START_SEARCH,
+  GHOSTTY_ACTION_END_SEARCH,
+  GHOSTTY_ACTION_SEARCH_TOTAL,
+  GHOSTTY_ACTION_SEARCH_SELECTED,
+  GHOSTTY_ACTION_READONLY,
+  GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD,
+} ghostty_action_tag_e;
+
+typedef union {
+  ghostty_action_split_direction_e new_split;
+  ghostty_action_fullscreen_e toggle_fullscreen;
+  ghostty_action_move_tab_s move_tab;
+  ghostty_action_goto_tab_e goto_tab;
+  ghostty_action_goto_split_e goto_split;
+  ghostty_action_goto_window_e goto_window;
+  ghostty_action_resize_split_s resize_split;
+  ghostty_action_size_limit_s size_limit;
+  ghostty_action_initial_size_s initial_size;
+  ghostty_action_cell_size_s cell_size;
+  ghostty_action_scrollbar_s scrollbar;
+  ghostty_action_inspector_e inspector;
+  ghostty_action_desktop_notification_s desktop_notification;
+  ghostty_action_set_title_s set_title;
+  ghostty_action_set_title_s set_tab_title;
+  ghostty_action_prompt_title_e prompt_title;
+  ghostty_action_pwd_s pwd;
+  ghostty_action_mouse_shape_e mouse_shape;
+  ghostty_action_mouse_visibility_e mouse_visibility;
+  ghostty_action_mouse_over_link_s mouse_over_link;
+  ghostty_action_renderer_health_e renderer_health;
+  ghostty_action_quit_timer_e quit_timer;
+  ghostty_action_float_window_e float_window;
+  ghostty_action_secure_input_e secure_input;
+  ghostty_action_key_sequence_s key_sequence;
+  ghostty_action_key_table_s key_table;
+  ghostty_action_color_change_s color_change;
+  ghostty_action_reload_config_s reload_config;
+  ghostty_action_config_change_s config_change;
+  ghostty_action_open_url_s open_url;
+  ghostty_action_close_tab_mode_e close_tab_mode;
+  ghostty_surface_message_childexited_s child_exited;
+  ghostty_action_progress_report_s progress_report;
+  ghostty_action_command_finished_s command_finished;
+  ghostty_action_start_search_s start_search;
+  ghostty_action_search_total_s search_total;
+  ghostty_action_search_selected_s search_selected;
+  ghostty_action_readonly_e readonly;
+} ghostty_action_u;
+
+typedef struct {
+  ghostty_action_tag_e tag;
+  ghostty_action_u action;
+} ghostty_action_s;
+
+typedef void (*ghostty_runtime_wakeup_cb)(void*);
+typedef bool (*ghostty_runtime_read_clipboard_cb)(void*,
+                                                  ghostty_clipboard_e,
+                                                  void*);
+typedef void (*ghostty_runtime_confirm_read_clipboard_cb)(
+    void*,
+    const char*,
+    void*,
+    ghostty_clipboard_request_e);
+typedef void (*ghostty_runtime_write_clipboard_cb)(void*,
+                                                   ghostty_clipboard_e,
+                                                   const ghostty_clipboard_content_s*,
+                                                   size_t,
+                                                   bool);
+typedef void (*ghostty_runtime_close_surface_cb)(void*, bool);
+typedef bool (*ghostty_runtime_action_cb)(ghostty_app_t,
+                                          ghostty_target_s,
+                                          ghostty_action_s);
+
+typedef struct {
+  void* userdata;
+  bool supports_selection_clipboard;
+  ghostty_runtime_wakeup_cb wakeup_cb;
+  ghostty_runtime_action_cb action_cb;
+  ghostty_runtime_read_clipboard_cb read_clipboard_cb;
+  ghostty_runtime_confirm_read_clipboard_cb confirm_read_clipboard_cb;
+  ghostty_runtime_write_clipboard_cb write_clipboard_cb;
+  ghostty_runtime_close_surface_cb close_surface_cb;
+} ghostty_runtime_config_s;
+
+// apprt.ipc.Target.Key
+typedef enum {
+  GHOSTTY_IPC_TARGET_CLASS,
+  GHOSTTY_IPC_TARGET_DETECT,
+} ghostty_ipc_target_tag_e;
+
+typedef union {
+  char *klass;
+} ghostty_ipc_target_u;
+
+typedef struct {
+  ghostty_ipc_target_tag_e tag;
+  ghostty_ipc_target_u target;
+} chostty_ipc_target_s;
+
+// apprt.ipc.Action.NewWindow
+typedef struct {
+  // This should be a null terminated list of strings.
+  const char **arguments;
+} ghostty_ipc_action_new_window_s;
+
+typedef union {
+  ghostty_ipc_action_new_window_s new_window;
+} ghostty_ipc_action_u;
+
+// apprt.ipc.Action.Key
+typedef enum {
+  GHOSTTY_IPC_ACTION_NEW_WINDOW,
+} ghostty_ipc_action_tag_e;
+
+//-------------------------------------------------------------------
+// Published API
+
+GHOSTTY_API int ghostty_init(uintptr_t, char**);
+GHOSTTY_API void ghostty_cli_try_action(void);
+GHOSTTY_API ghostty_info_s ghostty_info(void);
+GHOSTTY_API const char* ghostty_translate(const char*);
+GHOSTTY_API void ghostty_string_free(ghostty_string_s);
+
+GHOSTTY_API ghostty_config_t ghostty_config_new();
+GHOSTTY_API void ghostty_config_free(ghostty_config_t);
+GHOSTTY_API ghostty_config_t ghostty_config_clone(ghostty_config_t);
+GHOSTTY_API void ghostty_config_load_cli_args(ghostty_config_t);
+GHOSTTY_API void ghostty_config_load_file(ghostty_config_t, const char*);
+GHOSTTY_API void ghostty_config_load_default_files(ghostty_config_t);
+GHOSTTY_API void ghostty_config_load_recursive_files(ghostty_config_t);
+GHOSTTY_API void ghostty_config_finalize(ghostty_config_t);
+GHOSTTY_API bool ghostty_config_get(ghostty_config_t, void*, const char*, uintptr_t);
+GHOSTTY_API ghostty_input_trigger_s ghostty_config_trigger(ghostty_config_t,
+                                                              const char*,
+                                                              uintptr_t);
+GHOSTTY_API uint32_t ghostty_config_diagnostics_count(ghostty_config_t);
+GHOSTTY_API ghostty_diagnostic_s ghostty_config_get_diagnostic(ghostty_config_t, uint32_t);
+GHOSTTY_API ghostty_string_s ghostty_config_open_path(void);
+
+GHOSTTY_API ghostty_app_t ghostty_app_new(const ghostty_runtime_config_s*,
+                                             ghostty_config_t);
+GHOSTTY_API void ghostty_app_free(ghostty_app_t);
+GHOSTTY_API void ghostty_app_tick(ghostty_app_t);
+GHOSTTY_API void* ghostty_app_userdata(ghostty_app_t);
+GHOSTTY_API void ghostty_app_set_focus(ghostty_app_t, bool);
+GHOSTTY_API bool ghostty_app_key(ghostty_app_t, ghostty_input_key_s);
+GHOSTTY_API bool ghostty_app_key_is_binding(ghostty_app_t, ghostty_input_key_s);
+GHOSTTY_API void ghostty_app_keyboard_changed(ghostty_app_t);
+GHOSTTY_API void ghostty_app_open_config(ghostty_app_t);
+GHOSTTY_API void ghostty_app_update_config(ghostty_app_t, ghostty_config_t);
+GHOSTTY_API bool ghostty_app_needs_confirm_quit(ghostty_app_t);
+GHOSTTY_API bool ghostty_app_has_global_keybinds(ghostty_app_t);
+GHOSTTY_API void ghostty_app_set_color_scheme(ghostty_app_t, ghostty_color_scheme_e);
+
+GHOSTTY_API ghostty_surface_config_s ghostty_surface_config_new();
+
+GHOSTTY_API ghostty_surface_t ghostty_surface_new(ghostty_app_t,
+                                                     const ghostty_surface_config_s*);
+GHOSTTY_API void ghostty_surface_free(ghostty_surface_t);
+GHOSTTY_API void* ghostty_surface_userdata(ghostty_surface_t);
+GHOSTTY_API ghostty_app_t ghostty_surface_app(ghostty_surface_t);
+GHOSTTY_API ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t, ghostty_surface_context_e);
+GHOSTTY_API void ghostty_surface_update_config(ghostty_surface_t, ghostty_config_t);
+GHOSTTY_API bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_process_exited(ghostty_surface_t);
+GHOSTTY_API void ghostty_surface_refresh(ghostty_surface_t);
+GHOSTTY_API void ghostty_surface_draw(ghostty_surface_t);
+GHOSTTY_API void ghostty_surface_feed_data(ghostty_surface_t, const uint8_t*, size_t);
+GHOSTTY_API void ghostty_surface_set_write_callback(ghostty_surface_t,
+                                                       ghostty_surface_write_fn,
+                                                       void*);
+GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
+GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
+GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
+GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
+GHOSTTY_API ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
+GHOSTTY_API uint64_t ghostty_surface_foreground_pid(ghostty_surface_t);
+GHOSTTY_API ghostty_string_s ghostty_surface_tty_name(ghostty_surface_t);
+GHOSTTY_API void ghostty_surface_set_color_scheme(ghostty_surface_t,
+                                                     ghostty_color_scheme_e);
+GHOSTTY_API ghostty_input_mods_e ghostty_surface_key_translation_mods(ghostty_surface_t,
+                                                                         ghostty_input_mods_e);
+GHOSTTY_API bool ghostty_surface_key(ghostty_surface_t, ghostty_input_key_s);
+GHOSTTY_API bool ghostty_surface_key_is_binding(ghostty_surface_t,
+                                                   ghostty_input_key_s,
+                                                   ghostty_binding_flags_e*);
+GHOSTTY_API void ghostty_surface_text(ghostty_surface_t, const char*, uintptr_t);
+GHOSTTY_API void ghostty_surface_preedit(ghostty_surface_t, const char*, uintptr_t);
+GHOSTTY_API bool ghostty_surface_mouse_captured(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_mouse_button(ghostty_surface_t,
+                                                 ghostty_input_mouse_state_e,
+                                                 ghostty_input_mouse_button_e,
+                                                 ghostty_input_mods_e);
+GHOSTTY_API void ghostty_surface_mouse_pos(ghostty_surface_t,
+                                              double,
+                                              double,
+                                              ghostty_input_mods_e);
+GHOSTTY_API void ghostty_surface_mouse_scroll(ghostty_surface_t,
+                                                 double,
+                                                 double,
+                                                 ghostty_input_scroll_mods_t);
+GHOSTTY_API void ghostty_surface_mouse_pressure(ghostty_surface_t, uint32_t, double);
+GHOSTTY_API void ghostty_surface_ime_point(ghostty_surface_t, double*, double*, double*, double*);
+GHOSTTY_API void ghostty_surface_request_close(ghostty_surface_t);
+GHOSTTY_API void ghostty_surface_split(ghostty_surface_t, ghostty_action_split_direction_e);
+GHOSTTY_API void ghostty_surface_split_focus(ghostty_surface_t,
+                                                ghostty_action_goto_split_e);
+GHOSTTY_API void ghostty_surface_split_resize(ghostty_surface_t,
+                                                 ghostty_action_resize_split_direction_e,
+                                                 uint16_t);
+GHOSTTY_API void ghostty_surface_split_equalize(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_binding_action(ghostty_surface_t, const char*, uintptr_t);
+GHOSTTY_API void ghostty_surface_complete_clipboard_request(ghostty_surface_t,
+                                                               const char*,
+                                                               void*,
+                                                               bool);
+GHOSTTY_API bool ghostty_surface_has_selection(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
+GHOSTTY_API bool ghostty_surface_read_text(ghostty_surface_t,
+                                              ghostty_selection_s,
+                                              ghostty_text_s*);
+GHOSTTY_API void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
+
+#ifdef __APPLE__
+GHOSTTY_API void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);
+GHOSTTY_API void* ghostty_surface_quicklook_font(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_quicklook_word(ghostty_surface_t, ghostty_text_s*);
+#endif
+
+GHOSTTY_API ghostty_inspector_t ghostty_surface_inspector(ghostty_surface_t);
+GHOSTTY_API void ghostty_inspector_free(ghostty_surface_t);
+GHOSTTY_API void ghostty_inspector_set_focus(ghostty_inspector_t, bool);
+GHOSTTY_API void ghostty_inspector_set_content_scale(ghostty_inspector_t, double, double);
+GHOSTTY_API void ghostty_inspector_set_size(ghostty_inspector_t, uint32_t, uint32_t);
+GHOSTTY_API void ghostty_inspector_mouse_button(ghostty_inspector_t,
+                                                   ghostty_input_mouse_state_e,
+                                                   ghostty_input_mouse_button_e,
+                                                   ghostty_input_mods_e);
+GHOSTTY_API void ghostty_inspector_mouse_pos(ghostty_inspector_t, double, double);
+GHOSTTY_API void ghostty_inspector_mouse_scroll(ghostty_inspector_t,
+                                                   double,
+                                                   double,
+                                                   ghostty_input_scroll_mods_t);
+GHOSTTY_API void ghostty_inspector_key(ghostty_inspector_t,
+                                          ghostty_input_action_e,
+                                          ghostty_input_key_e,
+                                          ghostty_input_mods_e);
+GHOSTTY_API void ghostty_inspector_text(ghostty_inspector_t, const char*);
+
+#ifdef __APPLE__
+GHOSTTY_API bool ghostty_inspector_metal_init(ghostty_inspector_t, void*);
+GHOSTTY_API void ghostty_inspector_metal_render(ghostty_inspector_t, void*, void*);
+GHOSTTY_API bool ghostty_inspector_metal_shutdown(ghostty_inspector_t);
+#endif
+
+// APIs I'd like to get rid of eventually but are still needed for now.
+// Don't use these unless you know what you're doing.
+GHOSTTY_API void ghostty_set_window_background_blur(ghostty_app_t, void*);
+
+// Benchmark API, if available.
+GHOSTTY_API bool ghostty_benchmark_cli(const char*, const char*);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GHOSTTY_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt.h
@@ -1,0 +1,87 @@
+/**
+ * @file vt.h
+ *
+ * libghostty-vt - Virtual terminal emulator library
+ * 
+ * This library provides functionality for parsing and handling terminal
+ * escape sequences as well as maintaining terminal state such as styles,
+ * cursor position, screen, scrollback, and more.
+ *
+ * WARNING: This is an incomplete, work-in-progress API. It is not yet
+ * stable and is definitely going to change. 
+ */
+
+/**
+ * @mainpage libghostty-vt - Virtual Terminal Emulator Library
+ *
+ * libghostty-vt is a C library which implements a modern terminal emulator,
+ * extracted from the [Ghostty](https://ghostty.org) terminal emulator.
+ *
+ * libghostty-vt contains the logic for handling the core parts of a terminal
+ * emulator: parsing terminal escape sequences, maintaining terminal state,
+ * encoding input events, etc. It can handle scrollback, line wrapping, 
+ * reflow on resize, and more.
+ *
+ * @warning This library is currently in development and the API is not yet stable.
+ * Breaking changes are expected in future versions. Use with caution in production code.
+ *
+ * @section groups_sec API Reference
+ *
+ * The API is organized into the following groups:
+ * - @ref key "Key Encoding" - Encode key events into terminal sequences
+ * - @ref osc "OSC Parser" - Parse OSC (Operating System Command) sequences
+ * - @ref sgr "SGR Parser" - Parse SGR (Select Graphic Rendition) sequences
+ * - @ref paste "Paste Utilities" - Validate paste data safety
+ * - @ref allocator "Memory Management" - Memory management and custom allocators
+ * - @ref wasm "WebAssembly Utilities" - WebAssembly convenience functions
+ *
+ * @section examples_sec Examples
+ *
+ * Complete working examples:
+ * - @ref c-vt/src/main.c - OSC parser example
+ * - @ref c-vt-key-encode/src/main.c - Key encoding example
+ * - @ref c-vt-paste/src/main.c - Paste safety check example
+ * - @ref c-vt-sgr/src/main.c - SGR parser example
+ *
+ */
+
+/** @example c-vt/src/main.c
+ * This example demonstrates how to use the OSC parser to parse an OSC sequence,
+ * extract command information, and retrieve command-specific data like window titles.
+ */
+
+/** @example c-vt-key-encode/src/main.c
+ * This example demonstrates how to use the key encoder to convert key events
+ * into terminal escape sequences using the Kitty keyboard protocol.
+ */
+
+/** @example c-vt-paste/src/main.c
+ * This example demonstrates how to use the paste utilities to check if
+ * paste data is safe before sending it to the terminal.
+ */
+
+/** @example c-vt-sgr/src/main.c
+ * This example demonstrates how to use the SGR parser to parse terminal
+ * styling sequences and extract text attributes like colors and underline styles.
+ */
+
+#ifndef GHOSTTY_VT_H
+#define GHOSTTY_VT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <ghostty/vt/result.h>
+#include <ghostty/vt/allocator.h>
+#include <ghostty/vt/osc.h>
+#include <ghostty/vt/sgr.h>
+#include <ghostty/vt/key.h>
+#include <ghostty/vt/paste.h>
+#include <ghostty/vt/wasm.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GHOSTTY_VT_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/allocator.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/allocator.h
@@ -1,0 +1,196 @@
+/**
+ * @file allocator.h
+ *
+ * Memory management interface for libghostty-vt.
+ */
+
+#ifndef GHOSTTY_VT_ALLOCATOR_H
+#define GHOSTTY_VT_ALLOCATOR_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/** @defgroup allocator Memory Management
+ *
+ * libghostty-vt does require memory allocation for various operations,
+ * but is resilient to allocation failures and will gracefully handle
+ * out-of-memory situations by returning error codes.
+ *
+ * The exact memory management semantics are documented in the relevant
+ * functions and data structures.
+ *
+ * libghostty-vt uses explicit memory allocation via an allocator
+ * interface provided by GhosttyAllocator. The interface is based on the
+ * [Zig](https://ziglang.org) allocator interface, since this has been
+ * shown to be a flexible and powerful interface in practice and enables
+ * a wide variety of allocation strategies.
+ *
+ * **For the common case, you can pass NULL as the allocator for any
+ * function that accepts one,** and libghostty will use a default allocator.
+ * The default allocator will be libc malloc/free if libc is linked. 
+ * Otherwise, a custom allocator is used (currently Zig's SMP allocator)
+ * that doesn't require any external dependencies.
+ *
+ * ## Basic Usage
+ *
+ * For simple use cases, you can ignore this interface entirely by passing NULL
+ * as the allocator parameter to functions that accept one. This will use the
+ * default allocator (typically libc malloc/free, if libc is linked, but
+ * we provide our own default allocator if libc isn't linked).
+ *
+ * To use a custom allocator:
+ * 1. Implement the GhosttyAllocatorVtable function pointers
+ * 2. Create a GhosttyAllocator struct with your vtable and context
+ * 3. Pass the allocator to functions that accept one
+ *
+ * @{
+ */
+
+/**
+ * Function table for custom memory allocator operations.
+ * 
+ * This vtable defines the interface for a custom memory allocator. All
+ * function pointers must be valid and non-NULL.
+ *
+ * @ingroup allocator
+ *
+ * If you're not going to use a custom allocator, you can ignore all of
+ * this. All functions that take an allocator pointer allow NULL to use a
+ * default allocator.
+ *
+ * The interface is based on the Zig allocator interface. I'll say up front
+ * that it is easy to look at this interface and think "wow, this is really
+ * overcomplicated". The reason for this complexity is well thought out by
+ * the Zig folks, and it enables a diverse set of allocation strategies
+ * as shown by the Zig ecosystem. As a consolation, please note that many
+ * of the arguments are only needed for advanced use cases and can be
+ * safely ignored in simple implementations. For example, if you look at 
+ * the Zig implementation of the libc allocator in `lib/std/heap.zig`
+ * (search for CAllocator), you'll see it is very simple.
+ *
+ * We chose to align with the Zig allocator interface because:
+ *
+ *   1. It is a proven interface that serves a wide variety of use cases
+ *      in the real world via the Zig ecosystem. It's shown to work.
+ *
+ *   2. Our core implementation itself is Zig, and this lets us very
+ *      cheaply and easily convert between C and Zig allocators.
+ *
+ * NOTE(mitchellh): In the future, we can have default implementations of
+ * resize/remap and allow those to be null.
+ */
+typedef struct {
+    /**
+     * Return a pointer to `len` bytes with specified `alignment`, or return
+     * `NULL` indicating the allocation failed.
+     *
+     * @param ctx The allocator context
+     * @param len Number of bytes to allocate
+     * @param alignment Required alignment for the allocation. Guaranteed to
+     *   be a power of two between 1 and 16 inclusive.
+     * @param ret_addr First return address of the allocation call stack (0 if not provided)
+     * @return Pointer to allocated memory, or NULL if allocation failed
+     */
+    void* (*alloc)(void *ctx, size_t len, uint8_t alignment, uintptr_t ret_addr);
+    
+    /**
+     * Attempt to expand or shrink memory in place.
+     *
+     * `memory_len` must equal the length requested from the most recent
+     * successful call to `alloc`, `resize`, or `remap`. `alignment` must
+     * equal the same value that was passed as the `alignment` parameter to
+     * the original `alloc` call.
+     *
+     * `new_len` must be greater than zero.
+     *
+     * @param ctx The allocator context
+     * @param memory Pointer to the memory block to resize
+     * @param memory_len Current size of the memory block
+     * @param alignment Alignment (must match original allocation)
+     * @param new_len New requested size
+     * @param ret_addr First return address of the allocation call stack (0 if not provided)
+     * @return true if resize was successful in-place, false if relocation would be required
+     */
+    bool (*resize)(void *ctx, void *memory, size_t memory_len, uint8_t alignment, size_t new_len, uintptr_t ret_addr);
+    
+    /**
+     * Attempt to expand or shrink memory, allowing relocation.
+     *
+     * `memory_len` must equal the length requested from the most recent
+     * successful call to `alloc`, `resize`, or `remap`. `alignment` must
+     * equal the same value that was passed as the `alignment` parameter to
+     * the original `alloc` call.
+     *
+     * A non-`NULL` return value indicates the resize was successful. The
+     * allocation may have same address, or may have been relocated. In either
+     * case, the allocation now has size of `new_len`. A `NULL` return value
+     * indicates that the resize would be equivalent to allocating new memory,
+     * copying the bytes from the old memory, and then freeing the old memory.
+     * In such case, it is more efficient for the caller to perform the copy.
+     *
+     * `new_len` must be greater than zero.
+     *
+     * @param ctx The allocator context
+     * @param memory Pointer to the memory block to remap
+     * @param memory_len Current size of the memory block
+     * @param alignment Alignment (must match original allocation)
+     * @param new_len New requested size
+     * @param ret_addr First return address of the allocation call stack (0 if not provided)
+     * @return Pointer to resized memory (may be relocated), or NULL if manual copy is needed
+     */
+    void* (*remap)(void *ctx, void *memory, size_t memory_len, uint8_t alignment, size_t new_len, uintptr_t ret_addr);
+    
+    /**
+     * Free and invalidate a region of memory.
+     *
+     * `memory_len` must equal the length requested from the most recent
+     * successful call to `alloc`, `resize`, or `remap`. `alignment` must
+     * equal the same value that was passed as the `alignment` parameter to
+     * the original `alloc` call.
+     *
+     * @param ctx The allocator context
+     * @param memory Pointer to the memory block to free
+     * @param memory_len Size of the memory block
+     * @param alignment Alignment (must match original allocation)
+     * @param ret_addr First return address of the allocation call stack (0 if not provided)
+     */
+    void (*free)(void *ctx, void *memory, size_t memory_len, uint8_t alignment, uintptr_t ret_addr);
+} GhosttyAllocatorVtable;
+
+/**
+ * Custom memory allocator.
+ *
+ * For functions that take an allocator pointer, a NULL pointer indicates
+ * that the default allocator should be used. The default allocator will 
+ * be libc malloc/free if we're linking to libc. If libc isn't linked,
+ * a custom allocator is used (currently Zig's SMP allocator).
+ *
+ * @ingroup allocator
+ *
+ * Usage example:
+ * @code
+ * GhosttyAllocator allocator = {
+ *     .vtable = &my_allocator_vtable,
+ *     .ctx = my_allocator_state
+ * };
+ * @endcode
+ */
+typedef struct GhosttyAllocator {
+    /**
+     * Opaque context pointer passed to all vtable functions.
+     * This allows the allocator implementation to maintain state
+     * or reference external resources needed for memory management.
+     */
+    void *ctx;
+
+    /**
+     * Pointer to the allocator's vtable containing function pointers
+     * for memory operations (alloc, resize, remap, free).
+     */
+    const GhosttyAllocatorVtable *vtable;
+} GhosttyAllocator;
+
+/** @} */
+
+#endif /* GHOSTTY_VT_ALLOCATOR_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/color.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/color.h
@@ -1,0 +1,96 @@
+/**
+ * @file color.h
+ *
+ * Color types and utilities.
+ */
+
+#ifndef GHOSTTY_VT_COLOR_H
+#define GHOSTTY_VT_COLOR_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * RGB color value.
+ *
+ * @ingroup sgr
+ */
+typedef struct {
+  uint8_t r; /**< Red component (0-255) */
+  uint8_t g; /**< Green component (0-255) */
+  uint8_t b; /**< Blue component (0-255) */
+} GhosttyColorRgb;
+
+/**
+ * Palette color index (0-255).
+ *
+ * @ingroup sgr
+ */
+typedef uint8_t GhosttyColorPaletteIndex;
+
+/** @addtogroup sgr
+ * @{
+ */
+
+/** Black color (0) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BLACK 0
+/** Red color (1) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_RED 1
+/** Green color (2) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_GREEN 2
+/** Yellow color (3) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_YELLOW 3
+/** Blue color (4) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BLUE 4
+/** Magenta color (5) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_MAGENTA 5
+/** Cyan color (6) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_CYAN 6
+/** White color (7) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_WHITE 7
+/** Bright black color (8) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BRIGHT_BLACK 8
+/** Bright red color (9) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BRIGHT_RED 9
+/** Bright green color (10) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BRIGHT_GREEN 10
+/** Bright yellow color (11) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BRIGHT_YELLOW 11
+/** Bright blue color (12) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BRIGHT_BLUE 12
+/** Bright magenta color (13) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BRIGHT_MAGENTA 13
+/** Bright cyan color (14) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BRIGHT_CYAN 14
+/** Bright white color (15) @ingroup sgr */
+#define GHOSTTY_COLOR_NAMED_BRIGHT_WHITE 15
+
+/** @} */
+
+/**
+ * Get the RGB color components.
+ *
+ * This function extracts the individual red, green, and blue components
+ * from a GhosttyColorRgb value. Primarily useful in WebAssembly environments
+ * where accessing struct fields directly is difficult.
+ *
+ * @param color The RGB color value
+ * @param r Pointer to store the red component (0-255)
+ * @param g Pointer to store the green component (0-255)
+ * @param b Pointer to store the blue component (0-255)
+ *
+ * @ingroup sgr
+ */
+void ghostty_color_rgb_get(GhosttyColorRgb color,
+                           uint8_t* r,
+                           uint8_t* g,
+                           uint8_t* b);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GHOSTTY_VT_COLOR_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/key.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/key.h
@@ -1,0 +1,80 @@
+/**
+ * @file key.h
+ *
+ * Key encoding module - encode key events into terminal escape sequences.
+ */
+
+#ifndef GHOSTTY_VT_KEY_H
+#define GHOSTTY_VT_KEY_H
+
+/** @defgroup key Key Encoding
+ *
+ * Utilities for encoding key events into terminal escape sequences,
+ * supporting both legacy encoding as well as Kitty Keyboard Protocol.
+ *
+ * ## Basic Usage
+ *
+ * 1. Create an encoder instance with ghostty_key_encoder_new()
+ * 2. Configure encoder options with ghostty_key_encoder_setopt().
+ * 3. For each key event:
+ *    - Create a key event with ghostty_key_event_new()
+ *    - Set event properties (action, key, modifiers, etc.)
+ *    - Encode with ghostty_key_encoder_encode()
+ *    - Free the event with ghostty_key_event_free()
+ *    - Note: You can also reuse the same key event multiple times by
+ *      changing its properties.
+ * 4. Free the encoder with ghostty_key_encoder_free() when done
+ *
+ * ## Example
+ *
+ * @code{.c}
+ * #include <assert.h>
+ * #include <stdio.h>
+ * #include <ghostty/vt.h>
+ * 
+ * int main() {
+ *   // Create encoder
+ *   GhosttyKeyEncoder encoder;
+ *   GhosttyResult result = ghostty_key_encoder_new(NULL, &encoder);
+ *   assert(result == GHOSTTY_SUCCESS);
+ * 
+ *   // Enable Kitty keyboard protocol with all features
+ *   ghostty_key_encoder_setopt(encoder, GHOSTTY_KEY_ENCODER_OPT_KITTY_FLAGS, 
+ *                              &(uint8_t){GHOSTTY_KITTY_KEY_ALL});
+ * 
+ *   // Create and configure key event for Ctrl+C press
+ *   GhosttyKeyEvent event;
+ *   result = ghostty_key_event_new(NULL, &event);
+ *   assert(result == GHOSTTY_SUCCESS);
+ *   ghostty_key_event_set_action(event, GHOSTTY_KEY_ACTION_PRESS);
+ *   ghostty_key_event_set_key(event, GHOSTTY_KEY_C);
+ *   ghostty_key_event_set_mods(event, GHOSTTY_MODS_CTRL);
+ * 
+ *   // Encode the key event
+ *   char buf[128];
+ *   size_t written = 0;
+ *   result = ghostty_key_encoder_encode(encoder, event, buf, sizeof(buf), &written);
+ *   assert(result == GHOSTTY_SUCCESS);
+ * 
+ *   // Use the encoded sequence (e.g., write to terminal)
+ *   fwrite(buf, 1, written, stdout);
+ * 
+ *   // Cleanup
+ *   ghostty_key_event_free(event);
+ *   ghostty_key_encoder_free(encoder);
+ *   return 0;
+ * }
+ * @endcode
+ *
+ * For a complete working example, see example/c-vt-key-encode in the
+ * repository.
+ *
+ * @{
+ */
+
+#include <ghostty/vt/key/event.h>
+#include <ghostty/vt/key/encoder.h>
+
+/** @} */
+
+#endif /* GHOSTTY_VT_KEY_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/key/encoder.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/key/encoder.h
@@ -1,0 +1,221 @@
+/**
+ * @file encoder.h
+ *
+ * Key event encoding to terminal escape sequences.
+ */
+
+#ifndef GHOSTTY_VT_KEY_ENCODER_H
+#define GHOSTTY_VT_KEY_ENCODER_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <ghostty/vt/result.h>
+#include <ghostty/vt/allocator.h>
+#include <ghostty/vt/key/event.h>
+
+/**
+ * Opaque handle to a key encoder instance.
+ *
+ * This handle represents a key encoder that converts key events into terminal
+ * escape sequences.
+ *
+ * @ingroup key
+ */
+typedef struct GhosttyKeyEncoder *GhosttyKeyEncoder;
+
+/**
+ * Kitty keyboard protocol flags.
+ *
+ * Bitflags representing the various modes of the Kitty keyboard protocol.
+ * These can be combined using bitwise OR operations. Valid values all
+ * start with `GHOSTTY_KITTY_KEY_`.
+ *
+ * @ingroup key
+ */
+typedef uint8_t GhosttyKittyKeyFlags;
+
+/** Kitty keyboard protocol disabled (all flags off) */
+#define GHOSTTY_KITTY_KEY_DISABLED 0
+
+/** Disambiguate escape codes */
+#define GHOSTTY_KITTY_KEY_DISAMBIGUATE (1 << 0)
+
+/** Report key press and release events */
+#define GHOSTTY_KITTY_KEY_REPORT_EVENTS (1 << 1)
+
+/** Report alternate key codes */
+#define GHOSTTY_KITTY_KEY_REPORT_ALTERNATES (1 << 2)
+
+/** Report all key events including those normally handled by the terminal */
+#define GHOSTTY_KITTY_KEY_REPORT_ALL (1 << 3)
+
+/** Report associated text with key events */
+#define GHOSTTY_KITTY_KEY_REPORT_ASSOCIATED (1 << 4)
+
+/** All Kitty keyboard protocol flags enabled */
+#define GHOSTTY_KITTY_KEY_ALL (GHOSTTY_KITTY_KEY_DISAMBIGUATE | GHOSTTY_KITTY_KEY_REPORT_EVENTS | GHOSTTY_KITTY_KEY_REPORT_ALTERNATES | GHOSTTY_KITTY_KEY_REPORT_ALL | GHOSTTY_KITTY_KEY_REPORT_ASSOCIATED)
+
+/**
+ * macOS option key behavior.
+ *
+ * Determines whether the "option" key on macOS is treated as "alt" or not.
+ * See the Ghostty `macos-option-as-alt` configuration option for more details.
+ *
+ * @ingroup key
+ */
+typedef enum {
+    /** Option key is not treated as alt */
+    GHOSTTY_OPTION_AS_ALT_FALSE = 0,
+    /** Option key is treated as alt */
+    GHOSTTY_OPTION_AS_ALT_TRUE = 1,
+    /** Only left option key is treated as alt */
+    GHOSTTY_OPTION_AS_ALT_LEFT = 2,
+    /** Only right option key is treated as alt */
+    GHOSTTY_OPTION_AS_ALT_RIGHT = 3,
+} GhosttyOptionAsAlt;
+
+/**
+ * Key encoder option identifiers.
+ *
+ * These values are used with ghostty_key_encoder_setopt() to configure
+ * the behavior of the key encoder.
+ *
+ * @ingroup key
+ */
+typedef enum {
+    /** Terminal DEC mode 1: cursor key application mode (value: bool) */
+    GHOSTTY_KEY_ENCODER_OPT_CURSOR_KEY_APPLICATION = 0,
+    
+    /** Terminal DEC mode 66: keypad key application mode (value: bool) */
+    GHOSTTY_KEY_ENCODER_OPT_KEYPAD_KEY_APPLICATION = 1,
+    
+    /** Terminal DEC mode 1035: ignore keypad with numlock (value: bool) */
+    GHOSTTY_KEY_ENCODER_OPT_IGNORE_KEYPAD_WITH_NUMLOCK = 2,
+    
+    /** Terminal DEC mode 1036: alt sends escape prefix (value: bool) */
+    GHOSTTY_KEY_ENCODER_OPT_ALT_ESC_PREFIX = 3,
+    
+    /** xterm modifyOtherKeys mode 2 (value: bool) */
+    GHOSTTY_KEY_ENCODER_OPT_MODIFY_OTHER_KEYS_STATE_2 = 4,
+    
+    /** Kitty keyboard protocol flags (value: GhosttyKittyKeyFlags bitmask) */
+    GHOSTTY_KEY_ENCODER_OPT_KITTY_FLAGS = 5,
+    
+    /** macOS option-as-alt setting (value: GhosttyOptionAsAlt) */
+    GHOSTTY_KEY_ENCODER_OPT_MACOS_OPTION_AS_ALT = 6,
+} GhosttyKeyEncoderOption;
+
+/**
+ * Create a new key encoder instance.
+ *
+ * Creates a new key encoder with default options. The encoder can be configured
+ * using ghostty_key_encoder_setopt() and must be freed using
+ * ghostty_key_encoder_free() when no longer needed.
+ *
+ * @param allocator Pointer to the allocator to use for memory management, or NULL to use the default allocator
+ * @param encoder Pointer to store the created encoder handle
+ * @return GHOSTTY_SUCCESS on success, or an error code on failure
+ *
+ * @ingroup key
+ */
+GhosttyResult ghostty_key_encoder_new(const GhosttyAllocator *allocator, GhosttyKeyEncoder *encoder);
+
+/**
+ * Free a key encoder instance.
+ *
+ * Releases all resources associated with the key encoder. After this call,
+ * the encoder handle becomes invalid and must not be used.
+ *
+ * @param encoder The encoder handle to free (may be NULL)
+ *
+ * @ingroup key
+ */
+void ghostty_key_encoder_free(GhosttyKeyEncoder encoder);
+
+/**
+ * Set an option on the key encoder.
+ *
+ * Configures the behavior of the key encoder. Options control various aspects
+ * of encoding such as terminal modes (cursor key application mode, keypad mode),
+ * protocol selection (Kitty keyboard protocol flags), and platform-specific
+ * behaviors (macOS option-as-alt).
+ *
+ * A null pointer value does nothing. It does not reset the value to the
+ * default. The setopt call will do nothing.
+ *
+ * @param encoder The encoder handle, must not be NULL
+ * @param option The option to set
+ * @param value Pointer to the value to set (type depends on the option)
+ *
+ * @ingroup key
+ */
+void ghostty_key_encoder_setopt(GhosttyKeyEncoder encoder, GhosttyKeyEncoderOption option, const void *value);
+
+/**
+ * Encode a key event into a terminal escape sequence.
+ *
+ * Converts a key event into the appropriate terminal escape sequence based on
+ * the encoder's current options. The sequence is written to the provided buffer.
+ *
+ * Not all key events produce output. For example, unmodified modifier keys
+ * typically don't generate escape sequences. Check the out_len parameter to
+ * determine if any data was written.
+ *
+ * If the output buffer is too small, this function returns GHOSTTY_OUT_OF_MEMORY
+ * and out_len will contain the required buffer size. The caller can then
+ * allocate a larger buffer and call the function again.
+ *
+ * @param encoder The encoder handle, must not be NULL
+ * @param event The key event to encode, must not be NULL
+ * @param out_buf Buffer to write the encoded sequence to
+ * @param out_buf_size Size of the output buffer in bytes
+ * @param out_len Pointer to store the number of bytes written (may be NULL)
+ * @return GHOSTTY_SUCCESS on success, GHOSTTY_OUT_OF_MEMORY if buffer too small, or other error code
+ *
+ * ## Example: Calculate required buffer size
+ *
+ * @code{.c}
+ * // Query the required size with a NULL buffer (always returns OUT_OF_MEMORY)
+ * size_t required = 0;
+ * GhosttyResult result = ghostty_key_encoder_encode(encoder, event, NULL, 0, &required);
+ * assert(result == GHOSTTY_OUT_OF_MEMORY);
+ * 
+ * // Allocate buffer of required size
+ * char *buf = malloc(required);
+ * 
+ * // Encode with properly sized buffer
+ * size_t written = 0;
+ * result = ghostty_key_encoder_encode(encoder, event, buf, required, &written);
+ * assert(result == GHOSTTY_SUCCESS);
+ * 
+ * // Use the encoded sequence...
+ * 
+ * free(buf);
+ * @endcode
+ *
+ * ## Example: Direct encoding with static buffer
+ *
+ * @code{.c}
+ * // Most escape sequences are short, so a static buffer often suffices
+ * char buf[128];
+ * size_t written = 0;
+ * GhosttyResult result = ghostty_key_encoder_encode(encoder, event, buf, sizeof(buf), &written);
+ * 
+ * if (result == GHOSTTY_SUCCESS) {
+ *   // Write the encoded sequence to the terminal
+ *   write(pty_fd, buf, written);
+ * } else if (result == GHOSTTY_OUT_OF_MEMORY) {
+ *   // Buffer too small, written contains required size
+ *   char *dynamic_buf = malloc(written);
+ *   result = ghostty_key_encoder_encode(encoder, event, dynamic_buf, written, &written);
+ *   assert(result == GHOSTTY_SUCCESS);
+ *   write(pty_fd, dynamic_buf, written);
+ *   free(dynamic_buf);
+ * }
+ * @endcode
+ *
+ * @ingroup key
+ */
+GhosttyResult ghostty_key_encoder_encode(GhosttyKeyEncoder encoder, GhosttyKeyEvent event, char *out_buf, size_t out_buf_size, size_t *out_len);
+
+#endif /* GHOSTTY_VT_KEY_ENCODER_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/key/event.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/key/event.h
@@ -1,0 +1,474 @@
+/**
+ * @file event.h
+ *
+ * Key event representation and manipulation.
+ */
+
+#ifndef GHOSTTY_VT_KEY_EVENT_H
+#define GHOSTTY_VT_KEY_EVENT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <ghostty/vt/result.h>
+#include <ghostty/vt/allocator.h>
+
+/**
+ * Opaque handle to a key event.
+ * 
+ * This handle represents a keyboard input event containing information about
+ * the physical key pressed, modifiers, and generated text.
+ *
+ * @ingroup key
+ */
+typedef struct GhosttyKeyEvent *GhosttyKeyEvent;
+
+/**
+ * Keyboard input event types.
+ *
+ * @ingroup key
+ */
+typedef enum {
+    /** Key was released */
+    GHOSTTY_KEY_ACTION_RELEASE = 0,
+    /** Key was pressed */
+    GHOSTTY_KEY_ACTION_PRESS = 1,
+    /** Key is being repeated (held down) */
+    GHOSTTY_KEY_ACTION_REPEAT = 2,
+} GhosttyKeyAction;
+
+/**
+ * Keyboard modifier keys bitmask.
+ *
+ * A bitmask representing all keyboard modifiers. This tracks which modifier keys 
+ * are pressed and, where supported by the platform, which side (left or right) 
+ * of each modifier is active.
+ *
+ * Use the GHOSTTY_MODS_* constants to test and set individual modifiers.
+ *
+ * Modifier side bits are only meaningful when the corresponding modifier bit is set.
+ * Not all platforms support distinguishing between left and right modifier 
+ * keys and Ghostty is built to expect that some platforms may not provide this
+ * information.
+ *
+ * @ingroup key
+ */
+typedef uint16_t GhosttyMods;
+
+/** Shift key is pressed */
+#define GHOSTTY_MODS_SHIFT (1 << 0)
+/** Control key is pressed */
+#define GHOSTTY_MODS_CTRL (1 << 1)
+/** Alt/Option key is pressed */
+#define GHOSTTY_MODS_ALT (1 << 2)
+/** Super/Command/Windows key is pressed */
+#define GHOSTTY_MODS_SUPER (1 << 3)
+/** Caps Lock is active */
+#define GHOSTTY_MODS_CAPS_LOCK (1 << 4)
+/** Num Lock is active */
+#define GHOSTTY_MODS_NUM_LOCK (1 << 5)
+
+/**
+ * Right shift is pressed (0 = left, 1 = right).
+ * Only meaningful when GHOSTTY_MODS_SHIFT is set.
+ */
+#define GHOSTTY_MODS_SHIFT_SIDE (1 << 6)
+/**
+ * Right ctrl is pressed (0 = left, 1 = right).
+ * Only meaningful when GHOSTTY_MODS_CTRL is set.
+ */
+#define GHOSTTY_MODS_CTRL_SIDE (1 << 7)
+/**
+ * Right alt is pressed (0 = left, 1 = right).
+ * Only meaningful when GHOSTTY_MODS_ALT is set.
+ */
+#define GHOSTTY_MODS_ALT_SIDE (1 << 8)
+/**
+ * Right super is pressed (0 = left, 1 = right).
+ * Only meaningful when GHOSTTY_MODS_SUPER is set.
+ */
+#define GHOSTTY_MODS_SUPER_SIDE (1 << 9)
+
+/**
+ * Physical key codes.
+ *
+ * The set of key codes that Ghostty is aware of. These represent physical keys 
+ * on the keyboard and are layout-independent. For example, the "a" key on a US 
+ * keyboard is the same as the "ф" key on a Russian keyboard, but both will 
+ * report the same key_a value.
+ *
+ * Layout-dependent strings are provided separately as UTF-8 text and are produced 
+ * by the platform. These values are based on the W3C UI Events KeyboardEvent code 
+ * standard. See: https://www.w3.org/TR/uievents-code
+ *
+ * @ingroup key
+ */
+typedef enum {
+    GHOSTTY_KEY_UNIDENTIFIED = 0,
+
+    // Writing System Keys (W3C § 3.1.1)
+    GHOSTTY_KEY_BACKQUOTE,
+    GHOSTTY_KEY_BACKSLASH,
+    GHOSTTY_KEY_BRACKET_LEFT,
+    GHOSTTY_KEY_BRACKET_RIGHT,
+    GHOSTTY_KEY_COMMA,
+    GHOSTTY_KEY_DIGIT_0,
+    GHOSTTY_KEY_DIGIT_1,
+    GHOSTTY_KEY_DIGIT_2,
+    GHOSTTY_KEY_DIGIT_3,
+    GHOSTTY_KEY_DIGIT_4,
+    GHOSTTY_KEY_DIGIT_5,
+    GHOSTTY_KEY_DIGIT_6,
+    GHOSTTY_KEY_DIGIT_7,
+    GHOSTTY_KEY_DIGIT_8,
+    GHOSTTY_KEY_DIGIT_9,
+    GHOSTTY_KEY_EQUAL,
+    GHOSTTY_KEY_INTL_BACKSLASH,
+    GHOSTTY_KEY_INTL_RO,
+    GHOSTTY_KEY_INTL_YEN,
+    GHOSTTY_KEY_A,
+    GHOSTTY_KEY_B,
+    GHOSTTY_KEY_C,
+    GHOSTTY_KEY_D,
+    GHOSTTY_KEY_E,
+    GHOSTTY_KEY_F,
+    GHOSTTY_KEY_G,
+    GHOSTTY_KEY_H,
+    GHOSTTY_KEY_I,
+    GHOSTTY_KEY_J,
+    GHOSTTY_KEY_K,
+    GHOSTTY_KEY_L,
+    GHOSTTY_KEY_M,
+    GHOSTTY_KEY_N,
+    GHOSTTY_KEY_O,
+    GHOSTTY_KEY_P,
+    GHOSTTY_KEY_Q,
+    GHOSTTY_KEY_R,
+    GHOSTTY_KEY_S,
+    GHOSTTY_KEY_T,
+    GHOSTTY_KEY_U,
+    GHOSTTY_KEY_V,
+    GHOSTTY_KEY_W,
+    GHOSTTY_KEY_X,
+    GHOSTTY_KEY_Y,
+    GHOSTTY_KEY_Z,
+    GHOSTTY_KEY_MINUS,
+    GHOSTTY_KEY_PERIOD,
+    GHOSTTY_KEY_QUOTE,
+    GHOSTTY_KEY_SEMICOLON,
+    GHOSTTY_KEY_SLASH,
+
+    // Functional Keys (W3C § 3.1.2)
+    GHOSTTY_KEY_ALT_LEFT,
+    GHOSTTY_KEY_ALT_RIGHT,
+    GHOSTTY_KEY_BACKSPACE,
+    GHOSTTY_KEY_CAPS_LOCK,
+    GHOSTTY_KEY_CONTEXT_MENU,
+    GHOSTTY_KEY_CONTROL_LEFT,
+    GHOSTTY_KEY_CONTROL_RIGHT,
+    GHOSTTY_KEY_ENTER,
+    GHOSTTY_KEY_META_LEFT,
+    GHOSTTY_KEY_META_RIGHT,
+    GHOSTTY_KEY_SHIFT_LEFT,
+    GHOSTTY_KEY_SHIFT_RIGHT,
+    GHOSTTY_KEY_SPACE,
+    GHOSTTY_KEY_TAB,
+    GHOSTTY_KEY_CONVERT,
+    GHOSTTY_KEY_KANA_MODE,
+    GHOSTTY_KEY_NON_CONVERT,
+
+    // Control Pad Section (W3C § 3.2)
+    GHOSTTY_KEY_DELETE,
+    GHOSTTY_KEY_END,
+    GHOSTTY_KEY_HELP,
+    GHOSTTY_KEY_HOME,
+    GHOSTTY_KEY_INSERT,
+    GHOSTTY_KEY_PAGE_DOWN,
+    GHOSTTY_KEY_PAGE_UP,
+
+    // Arrow Pad Section (W3C § 3.3)
+    GHOSTTY_KEY_ARROW_DOWN,
+    GHOSTTY_KEY_ARROW_LEFT,
+    GHOSTTY_KEY_ARROW_RIGHT,
+    GHOSTTY_KEY_ARROW_UP,
+
+    // Numpad Section (W3C § 3.4)
+    GHOSTTY_KEY_NUM_LOCK,
+    GHOSTTY_KEY_NUMPAD_0,
+    GHOSTTY_KEY_NUMPAD_1,
+    GHOSTTY_KEY_NUMPAD_2,
+    GHOSTTY_KEY_NUMPAD_3,
+    GHOSTTY_KEY_NUMPAD_4,
+    GHOSTTY_KEY_NUMPAD_5,
+    GHOSTTY_KEY_NUMPAD_6,
+    GHOSTTY_KEY_NUMPAD_7,
+    GHOSTTY_KEY_NUMPAD_8,
+    GHOSTTY_KEY_NUMPAD_9,
+    GHOSTTY_KEY_NUMPAD_ADD,
+    GHOSTTY_KEY_NUMPAD_BACKSPACE,
+    GHOSTTY_KEY_NUMPAD_CLEAR,
+    GHOSTTY_KEY_NUMPAD_CLEAR_ENTRY,
+    GHOSTTY_KEY_NUMPAD_COMMA,
+    GHOSTTY_KEY_NUMPAD_DECIMAL,
+    GHOSTTY_KEY_NUMPAD_DIVIDE,
+    GHOSTTY_KEY_NUMPAD_ENTER,
+    GHOSTTY_KEY_NUMPAD_EQUAL,
+    GHOSTTY_KEY_NUMPAD_MEMORY_ADD,
+    GHOSTTY_KEY_NUMPAD_MEMORY_CLEAR,
+    GHOSTTY_KEY_NUMPAD_MEMORY_RECALL,
+    GHOSTTY_KEY_NUMPAD_MEMORY_STORE,
+    GHOSTTY_KEY_NUMPAD_MEMORY_SUBTRACT,
+    GHOSTTY_KEY_NUMPAD_MULTIPLY,
+    GHOSTTY_KEY_NUMPAD_PAREN_LEFT,
+    GHOSTTY_KEY_NUMPAD_PAREN_RIGHT,
+    GHOSTTY_KEY_NUMPAD_SUBTRACT,
+    GHOSTTY_KEY_NUMPAD_SEPARATOR,
+    GHOSTTY_KEY_NUMPAD_UP,
+    GHOSTTY_KEY_NUMPAD_DOWN,
+    GHOSTTY_KEY_NUMPAD_RIGHT,
+    GHOSTTY_KEY_NUMPAD_LEFT,
+    GHOSTTY_KEY_NUMPAD_BEGIN,
+    GHOSTTY_KEY_NUMPAD_HOME,
+    GHOSTTY_KEY_NUMPAD_END,
+    GHOSTTY_KEY_NUMPAD_INSERT,
+    GHOSTTY_KEY_NUMPAD_DELETE,
+    GHOSTTY_KEY_NUMPAD_PAGE_UP,
+    GHOSTTY_KEY_NUMPAD_PAGE_DOWN,
+
+    // Function Section (W3C § 3.5)
+    GHOSTTY_KEY_ESCAPE,
+    GHOSTTY_KEY_F1,
+    GHOSTTY_KEY_F2,
+    GHOSTTY_KEY_F3,
+    GHOSTTY_KEY_F4,
+    GHOSTTY_KEY_F5,
+    GHOSTTY_KEY_F6,
+    GHOSTTY_KEY_F7,
+    GHOSTTY_KEY_F8,
+    GHOSTTY_KEY_F9,
+    GHOSTTY_KEY_F10,
+    GHOSTTY_KEY_F11,
+    GHOSTTY_KEY_F12,
+    GHOSTTY_KEY_F13,
+    GHOSTTY_KEY_F14,
+    GHOSTTY_KEY_F15,
+    GHOSTTY_KEY_F16,
+    GHOSTTY_KEY_F17,
+    GHOSTTY_KEY_F18,
+    GHOSTTY_KEY_F19,
+    GHOSTTY_KEY_F20,
+    GHOSTTY_KEY_F21,
+    GHOSTTY_KEY_F22,
+    GHOSTTY_KEY_F23,
+    GHOSTTY_KEY_F24,
+    GHOSTTY_KEY_F25,
+    GHOSTTY_KEY_FN,
+    GHOSTTY_KEY_FN_LOCK,
+    GHOSTTY_KEY_PRINT_SCREEN,
+    GHOSTTY_KEY_SCROLL_LOCK,
+    GHOSTTY_KEY_PAUSE,
+
+    // Media Keys (W3C § 3.6)
+    GHOSTTY_KEY_BROWSER_BACK,
+    GHOSTTY_KEY_BROWSER_FAVORITES,
+    GHOSTTY_KEY_BROWSER_FORWARD,
+    GHOSTTY_KEY_BROWSER_HOME,
+    GHOSTTY_KEY_BROWSER_REFRESH,
+    GHOSTTY_KEY_BROWSER_SEARCH,
+    GHOSTTY_KEY_BROWSER_STOP,
+    GHOSTTY_KEY_EJECT,
+    GHOSTTY_KEY_LAUNCH_APP_1,
+    GHOSTTY_KEY_LAUNCH_APP_2,
+    GHOSTTY_KEY_LAUNCH_MAIL,
+    GHOSTTY_KEY_MEDIA_PLAY_PAUSE,
+    GHOSTTY_KEY_MEDIA_SELECT,
+    GHOSTTY_KEY_MEDIA_STOP,
+    GHOSTTY_KEY_MEDIA_TRACK_NEXT,
+    GHOSTTY_KEY_MEDIA_TRACK_PREVIOUS,
+    GHOSTTY_KEY_POWER,
+    GHOSTTY_KEY_SLEEP,
+    GHOSTTY_KEY_AUDIO_VOLUME_DOWN,
+    GHOSTTY_KEY_AUDIO_VOLUME_MUTE,
+    GHOSTTY_KEY_AUDIO_VOLUME_UP,
+    GHOSTTY_KEY_WAKE_UP,
+
+    // Legacy, Non-standard, and Special Keys (W3C § 3.7)
+    GHOSTTY_KEY_COPY,
+    GHOSTTY_KEY_CUT,
+    GHOSTTY_KEY_PASTE,
+} GhosttyKey;
+
+/**
+ * Create a new key event instance.
+ * 
+ * Creates a new key event with default values. The event must be freed using
+ * ghostty_key_event_free() when no longer needed.
+ * 
+ * @param allocator Pointer to the allocator to use for memory management, or NULL to use the default allocator
+ * @param event Pointer to store the created key event handle
+ * @return GHOSTTY_SUCCESS on success, or an error code on failure
+ * 
+ * @ingroup key
+ */
+GhosttyResult ghostty_key_event_new(const GhosttyAllocator *allocator, GhosttyKeyEvent *event);
+
+/**
+ * Free a key event instance.
+ * 
+ * Releases all resources associated with the key event. After this call,
+ * the event handle becomes invalid and must not be used.
+ * 
+ * @param event The key event handle to free (may be NULL)
+ * 
+ * @ingroup key
+ */
+void ghostty_key_event_free(GhosttyKeyEvent event);
+
+/**
+ * Set the key action (press, release, repeat).
+ *
+ * @param event The key event handle, must not be NULL
+ * @param action The action to set
+ *
+ * @ingroup key
+ */
+void ghostty_key_event_set_action(GhosttyKeyEvent event, GhosttyKeyAction action);
+
+/**
+ * Get the key action (press, release, repeat).
+ *
+ * @param event The key event handle, must not be NULL
+ * @return The key action
+ *
+ * @ingroup key
+ */
+GhosttyKeyAction ghostty_key_event_get_action(GhosttyKeyEvent event);
+
+/**
+ * Set the physical key code.
+ *
+ * @param event The key event handle, must not be NULL
+ * @param key The physical key code to set
+ *
+ * @ingroup key
+ */
+void ghostty_key_event_set_key(GhosttyKeyEvent event, GhosttyKey key);
+
+/**
+ * Get the physical key code.
+ *
+ * @param event The key event handle, must not be NULL
+ * @return The physical key code
+ *
+ * @ingroup key
+ */
+GhosttyKey ghostty_key_event_get_key(GhosttyKeyEvent event);
+
+/**
+ * Set the modifier keys bitmask.
+ *
+ * @param event The key event handle, must not be NULL
+ * @param mods The modifier keys bitmask to set
+ *
+ * @ingroup key
+ */
+void ghostty_key_event_set_mods(GhosttyKeyEvent event, GhosttyMods mods);
+
+/**
+ * Get the modifier keys bitmask.
+ *
+ * @param event The key event handle, must not be NULL
+ * @return The modifier keys bitmask
+ *
+ * @ingroup key
+ */
+GhosttyMods ghostty_key_event_get_mods(GhosttyKeyEvent event);
+
+/**
+ * Set the consumed modifiers bitmask.
+ *
+ * @param event The key event handle, must not be NULL
+ * @param consumed_mods The consumed modifiers bitmask to set
+ *
+ * @ingroup key
+ */
+void ghostty_key_event_set_consumed_mods(GhosttyKeyEvent event, GhosttyMods consumed_mods);
+
+/**
+ * Get the consumed modifiers bitmask.
+ *
+ * @param event The key event handle, must not be NULL
+ * @return The consumed modifiers bitmask
+ *
+ * @ingroup key
+ */
+GhosttyMods ghostty_key_event_get_consumed_mods(GhosttyKeyEvent event);
+
+/**
+ * Set whether the key event is part of a composition sequence.
+ *
+ * @param event The key event handle, must not be NULL
+ * @param composing Whether the key event is part of a composition sequence
+ *
+ * @ingroup key
+ */
+void ghostty_key_event_set_composing(GhosttyKeyEvent event, bool composing);
+
+/**
+ * Get whether the key event is part of a composition sequence.
+ *
+ * @param event The key event handle, must not be NULL
+ * @return Whether the key event is part of a composition sequence
+ *
+ * @ingroup key
+ */
+bool ghostty_key_event_get_composing(GhosttyKeyEvent event);
+
+/**
+ * Set the UTF-8 text generated by the key event.
+ *
+ * The key event does NOT take ownership of the text pointer. The caller
+ * must ensure the string remains valid for the lifetime needed by the event.
+ *
+ * @param event The key event handle, must not be NULL
+ * @param utf8 The UTF-8 text to set (or NULL for empty)
+ * @param len Length of the UTF-8 text in bytes
+ *
+ * @ingroup key
+ */
+void ghostty_key_event_set_utf8(GhosttyKeyEvent event, const char *utf8, size_t len);
+
+/**
+ * Get the UTF-8 text generated by the key event.
+ *
+ * The returned pointer is valid until the event is freed or the UTF-8 text is modified.
+ *
+ * @param event The key event handle, must not be NULL
+ * @param len Pointer to store the length of the UTF-8 text in bytes (may be NULL)
+ * @return The UTF-8 text (or NULL for empty)
+ *
+ * @ingroup key
+ */
+const char *ghostty_key_event_get_utf8(GhosttyKeyEvent event, size_t *len);
+
+/**
+ * Set the unshifted Unicode codepoint.
+ *
+ * @param event The key event handle, must not be NULL
+ * @param codepoint The unshifted Unicode codepoint to set
+ *
+ * @ingroup key
+ */
+void ghostty_key_event_set_unshifted_codepoint(GhosttyKeyEvent event, uint32_t codepoint);
+
+/**
+ * Get the unshifted Unicode codepoint.
+ *
+ * @param event The key event handle, must not be NULL
+ * @return The unshifted Unicode codepoint
+ *
+ * @ingroup key
+ */
+uint32_t ghostty_key_event_get_unshifted_codepoint(GhosttyKeyEvent event);
+
+#endif /* GHOSTTY_VT_KEY_EVENT_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/osc.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/osc.h
@@ -1,0 +1,233 @@
+/**
+ * @file osc.h
+ *
+ * OSC (Operating System Command) sequence parser and command handling.
+ */
+
+#ifndef GHOSTTY_VT_OSC_H
+#define GHOSTTY_VT_OSC_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <ghostty/vt/result.h>
+#include <ghostty/vt/allocator.h>
+
+/**
+ * Opaque handle to an OSC parser instance.
+ * 
+ * This handle represents an OSC (Operating System Command) parser that can
+ * be used to parse the contents of OSC sequences.
+ *
+ * @ingroup osc
+ */
+typedef struct GhosttyOscParser *GhosttyOscParser;
+
+/**
+ * Opaque handle to a single OSC command.
+ * 
+ * This handle represents a parsed OSC (Operating System Command) command.
+ * The command can be queried for its type and associated data.
+ *
+ * @ingroup osc
+ */
+typedef struct GhosttyOscCommand *GhosttyOscCommand;
+
+/** @defgroup osc OSC Parser
+ *
+ * OSC (Operating System Command) sequence parser and command handling.
+ *
+ * The parser operates in a streaming fashion, processing input byte-by-byte
+ * to handle OSC sequences that may arrive in fragments across multiple reads.
+ * This interface makes it easy to integrate into most environments and avoids
+ * over-allocating buffers.
+ *
+ * ## Basic Usage
+ *
+ * 1. Create a parser instance with ghostty_osc_new()
+ * 2. Feed bytes to the parser using ghostty_osc_next() 
+ * 3. Finalize parsing with ghostty_osc_end() to get the command
+ * 4. Query command type and extract data using ghostty_osc_command_type()
+ *    and ghostty_osc_command_data()
+ * 5. Free the parser with ghostty_osc_free() when done
+ *
+ * @{
+ */
+
+/**
+ * OSC command types.
+ *
+ * @ingroup osc
+ */
+typedef enum {
+  GHOSTTY_OSC_COMMAND_INVALID = 0,
+  GHOSTTY_OSC_COMMAND_CHANGE_WINDOW_TITLE = 1,
+  GHOSTTY_OSC_COMMAND_CHANGE_WINDOW_ICON = 2,
+  GHOSTTY_OSC_COMMAND_SEMANTIC_PROMPT = 3,
+  GHOSTTY_OSC_COMMAND_CLIPBOARD_CONTENTS = 4,
+  GHOSTTY_OSC_COMMAND_REPORT_PWD = 5,
+  GHOSTTY_OSC_COMMAND_MOUSE_SHAPE = 6,
+  GHOSTTY_OSC_COMMAND_COLOR_OPERATION = 7,
+  GHOSTTY_OSC_COMMAND_KITTY_COLOR_PROTOCOL = 8,
+  GHOSTTY_OSC_COMMAND_SHOW_DESKTOP_NOTIFICATION = 9,
+  GHOSTTY_OSC_COMMAND_HYPERLINK_START = 10,
+  GHOSTTY_OSC_COMMAND_HYPERLINK_END = 11,
+  GHOSTTY_OSC_COMMAND_CONEMU_SLEEP = 12,
+  GHOSTTY_OSC_COMMAND_CONEMU_SHOW_MESSAGE_BOX = 13,
+  GHOSTTY_OSC_COMMAND_CONEMU_CHANGE_TAB_TITLE = 14,
+  GHOSTTY_OSC_COMMAND_CONEMU_PROGRESS_REPORT = 15,
+  GHOSTTY_OSC_COMMAND_CONEMU_WAIT_INPUT = 16,
+  GHOSTTY_OSC_COMMAND_CONEMU_GUIMACRO = 17,
+  GHOSTTY_OSC_COMMAND_CONEMU_RUN_PROCESS = 18,
+  GHOSTTY_OSC_COMMAND_CONEMU_OUTPUT_ENVIRONMENT_VARIABLE = 19,
+  GHOSTTY_OSC_COMMAND_CONEMU_XTERM_EMULATION = 20,
+  GHOSTTY_OSC_COMMAND_CONEMU_COMMENT = 21,
+  GHOSTTY_OSC_COMMAND_KITTY_TEXT_SIZING = 22,
+} GhosttyOscCommandType;
+
+/**
+ * OSC command data types.
+ * 
+ * These values specify what type of data to extract from an OSC command
+ * using `ghostty_osc_command_data`.
+ *
+ * @ingroup osc
+ */
+typedef enum {
+  /** Invalid data type. Never results in any data extraction. */
+  GHOSTTY_OSC_DATA_INVALID = 0,
+  
+  /** 
+   * Window title string data.
+   *
+   * Valid for: GHOSTTY_OSC_COMMAND_CHANGE_WINDOW_TITLE
+   *
+   * Output type: const char ** (pointer to null-terminated string)
+   *
+   * Lifetime: Valid until the next call to any ghostty_osc_* function with 
+   * the same parser instance. Memory is owned by the parser.
+   */
+  GHOSTTY_OSC_DATA_CHANGE_WINDOW_TITLE_STR = 1,
+} GhosttyOscCommandData;
+
+/**
+ * Create a new OSC parser instance.
+ * 
+ * Creates a new OSC (Operating System Command) parser using the provided
+ * allocator. The parser must be freed using ghostty_vt_osc_free() when
+ * no longer needed.
+ * 
+ * @param allocator Pointer to the allocator to use for memory management, or NULL to use the default allocator
+ * @param parser Pointer to store the created parser handle
+ * @return GHOSTTY_SUCCESS on success, or an error code on failure
+ * 
+ * @ingroup osc
+ */
+GhosttyResult ghostty_osc_new(const GhosttyAllocator *allocator, GhosttyOscParser *parser);
+
+/**
+ * Free an OSC parser instance.
+ * 
+ * Releases all resources associated with the OSC parser. After this call,
+ * the parser handle becomes invalid and must not be used.
+ * 
+ * @param parser The parser handle to free (may be NULL)
+ * 
+ * @ingroup osc
+ */
+void ghostty_osc_free(GhosttyOscParser parser);
+
+/**
+ * Reset an OSC parser instance to its initial state.
+ * 
+ * Resets the parser state, clearing any partially parsed OSC sequences
+ * and returning the parser to its initial state. This is useful for
+ * reusing a parser instance or recovering from parse errors.
+ * 
+ * @param parser The parser handle to reset, must not be null.
+ * 
+ * @ingroup osc
+ */
+void ghostty_osc_reset(GhosttyOscParser parser);
+
+/**
+ * Parse the next byte in an OSC sequence.
+ * 
+ * Processes a single byte as part of an OSC sequence. The parser maintains
+ * internal state to track the progress through the sequence. Call this
+ * function for each byte in the sequence data.
+ *
+ * When finished pumping the parser with bytes, call ghostty_osc_end
+ * to get the final result.
+ * 
+ * @param parser The parser handle, must not be null.
+ * @param byte The next byte to parse
+ * 
+ * @ingroup osc
+ */
+void ghostty_osc_next(GhosttyOscParser parser, uint8_t byte);
+
+/**
+ * Finalize OSC parsing and retrieve the parsed command.
+ * 
+ * Call this function after feeding all bytes of an OSC sequence to the parser
+ * using ghostty_osc_next() with the exception of the terminating character
+ * (ESC or ST). This function finalizes the parsing process and returns the 
+ * parsed OSC command.
+ *
+ * The return value is never NULL. Invalid commands will return a command
+ * with type GHOSTTY_OSC_COMMAND_INVALID.
+ * 
+ * The terminator parameter specifies the byte that terminated the OSC sequence
+ * (typically 0x07 for BEL or 0x5C for ST after ESC). This information is
+ * preserved in the parsed command so that responses can use the same terminator
+ * format for better compatibility with the calling program. For commands that
+ * do not require a response, this parameter is ignored and the resulting
+ * command will not retain the terminator information.
+ * 
+ * The returned command handle is valid until the next call to any 
+ * `ghostty_osc_*` function with the same parser instance with the exception
+ * of command introspection functions such as `ghostty_osc_command_type`.
+ * 
+ * @param parser The parser handle, must not be null.
+ * @param terminator The terminating byte of the OSC sequence (0x07 for BEL, 0x5C for ST)
+ * @return Handle to the parsed OSC command
+ * 
+ * @ingroup osc
+ */
+GhosttyOscCommand ghostty_osc_end(GhosttyOscParser parser, uint8_t terminator);
+
+/**
+ * Get the type of an OSC command.
+ * 
+ * Returns the type identifier for the given OSC command. This can be used
+ * to determine what kind of command was parsed and what data might be
+ * available from it.
+ * 
+ * @param command The OSC command handle to query (may be NULL)
+ * @return The command type, or GHOSTTY_OSC_COMMAND_INVALID if command is NULL
+ * 
+ * @ingroup osc
+ */
+GhosttyOscCommandType ghostty_osc_command_type(GhosttyOscCommand command);
+
+/**
+ * Extract data from an OSC command.
+ * 
+ * Extracts typed data from the given OSC command based on the specified
+ * data type. The output pointer must be of the appropriate type for the
+ * requested data kind. Valid command types, output types, and memory
+ * safety information are documented in the `GhosttyOscCommandData` enum.
+ *
+ * @param command The OSC command handle to query (may be NULL)
+ * @param data The type of data to extract
+ * @param out Pointer to store the extracted data (type depends on data parameter)
+ * @return true if data extraction was successful, false otherwise
+ * 
+ * @ingroup osc
+ */
+bool ghostty_osc_command_data(GhosttyOscCommand command, GhosttyOscCommandData data, void *out);
+
+/** @} */
+
+#endif /* GHOSTTY_VT_OSC_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/paste.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/paste.h
@@ -1,0 +1,75 @@
+/**
+ * @file paste.h
+ *
+ * Paste utilities - validate and encode paste data for terminal input.
+ */
+
+#ifndef GHOSTTY_VT_PASTE_H
+#define GHOSTTY_VT_PASTE_H
+
+/** @defgroup paste Paste Utilities
+ *
+ * Utilities for validating paste data safety.
+ *
+ * ## Basic Usage
+ *
+ * Use ghostty_paste_is_safe() to check if paste data contains potentially
+ * dangerous sequences before sending it to the terminal.
+ *
+ * ## Example
+ *
+ * @code{.c}
+ * #include <stdio.h>
+ * #include <string.h>
+ * #include <ghostty/vt.h>
+ * 
+ * int main() {
+ *   const char* safe_data = "hello world";
+ *   const char* unsafe_data = "rm -rf /\n";
+ * 
+ *   if (ghostty_paste_is_safe(safe_data, strlen(safe_data))) {
+ *     printf("Safe to paste\n");
+ *   }
+ * 
+ *   if (!ghostty_paste_is_safe(unsafe_data, strlen(unsafe_data))) {
+ *     printf("Unsafe! Contains newline\n");
+ *   }
+ * 
+ *   return 0;
+ * }
+ * @endcode
+ *
+ * @{
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Check if paste data is safe to paste into the terminal.
+ *
+ * Data is considered unsafe if it contains:
+ * - Newlines (`\n`) which can inject commands
+ * - The bracketed paste end sequence (`\x1b[201~`) which can be used
+ *   to exit bracketed paste mode and inject commands
+ *
+ * This check is conservative and considers data unsafe regardless of
+ * current terminal state.
+ *
+ * @param data The paste data to check (must not be NULL)
+ * @param len The length of the data in bytes
+ * @return true if the data is safe to paste, false otherwise
+ */
+bool ghostty_paste_is_safe(const char* data, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* GHOSTTY_VT_PASTE_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/result.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/result.h
@@ -1,0 +1,22 @@
+/**
+ * @file result.h
+ *
+ * Result codes for libghostty-vt operations.
+ */
+
+#ifndef GHOSTTY_VT_RESULT_H
+#define GHOSTTY_VT_RESULT_H
+
+/**
+ * Result codes for libghostty-vt operations.
+ */
+typedef enum {
+    /** Operation completed successfully */
+    GHOSTTY_SUCCESS = 0,
+    /** Operation failed due to failed allocation */
+    GHOSTTY_OUT_OF_MEMORY = -1,
+    /** Operation failed due to invalid value */
+    GHOSTTY_INVALID_VALUE = -2,
+} GhosttyResult;
+
+#endif /* GHOSTTY_VT_RESULT_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/sgr.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/sgr.h
@@ -1,0 +1,394 @@
+/**
+ * @file sgr.h
+ *
+ * SGR (Select Graphic Rendition) attribute parsing and handling.
+ */
+
+#ifndef GHOSTTY_VT_SGR_H
+#define GHOSTTY_VT_SGR_H
+
+/** @defgroup sgr SGR Parser
+ *
+ * SGR (Select Graphic Rendition) attribute parser.
+ *
+ * SGR sequences are the syntax used to set styling attributes such as
+ * bold, italic, underline, and colors for text in terminal emulators.
+ * For example, you may be familiar with sequences like `ESC[1;31m`. The
+ * `1;31` is the SGR attribute list.
+ *
+ * The parser processes SGR parameters from CSI sequences (e.g., `ESC[1;31m`)
+ * and returns individual text attributes like bold, italic, colors, etc.
+ * It supports both semicolon (`;`) and colon (`:`) separators, possibly mixed,
+ * and handles various color formats including 8-color, 16-color, 256-color,
+ * X11 named colors, and RGB in multiple formats.
+ *
+ * ## Basic Usage
+ *
+ * 1. Create a parser instance with ghostty_sgr_new()
+ * 2. Set SGR parameters with ghostty_sgr_set_params()
+ * 3. Iterate through attributes using ghostty_sgr_next()
+ * 4. Free the parser with ghostty_sgr_free() when done
+ *
+ * ## Example
+ *
+ * @code{.c}
+ * #include <assert.h>
+ * #include <stdio.h>
+ * #include <ghostty/vt.h>
+ *
+ * int main() {
+ *   // Create parser
+ *   GhosttySgrParser parser;
+ *   GhosttyResult result = ghostty_sgr_new(NULL, &parser);
+ *   assert(result == GHOSTTY_SUCCESS);
+ *
+ *   // Parse "bold, red foreground" sequence: ESC[1;31m
+ *   uint16_t params[] = {1, 31};
+ *   result = ghostty_sgr_set_params(parser, params, NULL, 2);
+ *   assert(result == GHOSTTY_SUCCESS);
+ *
+ *   // Iterate through attributes
+ *   GhosttySgrAttribute attr;
+ *   while (ghostty_sgr_next(parser, &attr)) {
+ *     switch (attr.tag) {
+ *       case GHOSTTY_SGR_ATTR_BOLD:
+ *         printf("Bold enabled\n");
+ *         break;
+ *       case GHOSTTY_SGR_ATTR_FG_8:
+ *         printf("Foreground color: %d\n", attr.value.fg_8);
+ *         break;
+ *       default:
+ *         break;
+ *     }
+ *   }
+ *
+ *   // Cleanup
+ *   ghostty_sgr_free(parser);
+ *   return 0;
+ * }
+ * @endcode
+ *
+ * @{
+ */
+
+#include <ghostty/vt/allocator.h>
+#include <ghostty/vt/color.h>
+#include <ghostty/vt/result.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Opaque handle to an SGR parser instance.
+ *
+ * This handle represents an SGR (Select Graphic Rendition) parser that can
+ * be used to parse SGR sequences and extract individual text attributes.
+ *
+ * @ingroup sgr
+ */
+typedef struct GhosttySgrParser* GhosttySgrParser;
+
+/**
+ * SGR attribute tags.
+ *
+ * These values identify the type of an SGR attribute in a tagged union.
+ * Use the tag to determine which field in the attribute value union to access.
+ *
+ * @ingroup sgr
+ */
+typedef enum {
+  GHOSTTY_SGR_ATTR_UNSET = 0,
+  GHOSTTY_SGR_ATTR_UNKNOWN = 1,
+  GHOSTTY_SGR_ATTR_BOLD = 2,
+  GHOSTTY_SGR_ATTR_RESET_BOLD = 3,
+  GHOSTTY_SGR_ATTR_ITALIC = 4,
+  GHOSTTY_SGR_ATTR_RESET_ITALIC = 5,
+  GHOSTTY_SGR_ATTR_FAINT = 6,
+  GHOSTTY_SGR_ATTR_UNDERLINE = 7,
+  GHOSTTY_SGR_ATTR_RESET_UNDERLINE = 8,
+  GHOSTTY_SGR_ATTR_UNDERLINE_COLOR = 9,
+  GHOSTTY_SGR_ATTR_UNDERLINE_COLOR_256 = 10,
+  GHOSTTY_SGR_ATTR_RESET_UNDERLINE_COLOR = 11,
+  GHOSTTY_SGR_ATTR_OVERLINE = 12,
+  GHOSTTY_SGR_ATTR_RESET_OVERLINE = 13,
+  GHOSTTY_SGR_ATTR_BLINK = 14,
+  GHOSTTY_SGR_ATTR_RESET_BLINK = 15,
+  GHOSTTY_SGR_ATTR_INVERSE = 16,
+  GHOSTTY_SGR_ATTR_RESET_INVERSE = 17,
+  GHOSTTY_SGR_ATTR_INVISIBLE = 18,
+  GHOSTTY_SGR_ATTR_RESET_INVISIBLE = 19,
+  GHOSTTY_SGR_ATTR_STRIKETHROUGH = 20,
+  GHOSTTY_SGR_ATTR_RESET_STRIKETHROUGH = 21,
+  GHOSTTY_SGR_ATTR_DIRECT_COLOR_FG = 22,
+  GHOSTTY_SGR_ATTR_DIRECT_COLOR_BG = 23,
+  GHOSTTY_SGR_ATTR_BG_8 = 24,
+  GHOSTTY_SGR_ATTR_FG_8 = 25,
+  GHOSTTY_SGR_ATTR_RESET_FG = 26,
+  GHOSTTY_SGR_ATTR_RESET_BG = 27,
+  GHOSTTY_SGR_ATTR_BRIGHT_BG_8 = 28,
+  GHOSTTY_SGR_ATTR_BRIGHT_FG_8 = 29,
+  GHOSTTY_SGR_ATTR_BG_256 = 30,
+  GHOSTTY_SGR_ATTR_FG_256 = 31,
+} GhosttySgrAttributeTag;
+
+/**
+ * Underline style types.
+ *
+ * @ingroup sgr
+ */
+typedef enum {
+  GHOSTTY_SGR_UNDERLINE_NONE = 0,
+  GHOSTTY_SGR_UNDERLINE_SINGLE = 1,
+  GHOSTTY_SGR_UNDERLINE_DOUBLE = 2,
+  GHOSTTY_SGR_UNDERLINE_CURLY = 3,
+  GHOSTTY_SGR_UNDERLINE_DOTTED = 4,
+  GHOSTTY_SGR_UNDERLINE_DASHED = 5,
+} GhosttySgrUnderline;
+
+/**
+ * Unknown SGR attribute data.
+ *
+ * Contains the full parameter list and the partial list where parsing
+ * encountered an unknown or invalid sequence.
+ *
+ * @ingroup sgr
+ */
+typedef struct {
+  const uint16_t* full_ptr;
+  size_t full_len;
+  const uint16_t* partial_ptr;
+  size_t partial_len;
+} GhosttySgrUnknown;
+
+/**
+ * SGR attribute value union.
+ *
+ * This union contains all possible attribute values. Use the tag field
+ * to determine which union member is active. Attributes without associated
+ * data (like bold, italic) don't use the union value.
+ *
+ * @ingroup sgr
+ */
+typedef union {
+  GhosttySgrUnknown unknown;
+  GhosttySgrUnderline underline;
+  GhosttyColorRgb underline_color;
+  GhosttyColorPaletteIndex underline_color_256;
+  GhosttyColorRgb direct_color_fg;
+  GhosttyColorRgb direct_color_bg;
+  GhosttyColorPaletteIndex bg_8;
+  GhosttyColorPaletteIndex fg_8;
+  GhosttyColorPaletteIndex bright_bg_8;
+  GhosttyColorPaletteIndex bright_fg_8;
+  GhosttyColorPaletteIndex bg_256;
+  GhosttyColorPaletteIndex fg_256;
+  uint64_t _padding[8];
+} GhosttySgrAttributeValue;
+
+/**
+ * SGR attribute (tagged union).
+ *
+ * A complete SGR attribute with both its type tag and associated value.
+ * Always check the tag field to determine which value union member is valid.
+ *
+ * Attributes without associated data (e.g., GHOSTTY_SGR_ATTR_BOLD) can be
+ * identified by tag alone; the value union is not used for these and
+ * the memory in the value field is undefined.
+ *
+ * @ingroup sgr
+ */
+typedef struct {
+  GhosttySgrAttributeTag tag;
+  GhosttySgrAttributeValue value;
+} GhosttySgrAttribute;
+
+/**
+ * Create a new SGR parser instance.
+ *
+ * Creates a new SGR (Select Graphic Rendition) parser using the provided
+ * allocator. The parser must be freed using ghostty_sgr_free() when
+ * no longer needed.
+ *
+ * @param allocator Pointer to the allocator to use for memory management, or
+ * NULL to use the default allocator
+ * @param parser Pointer to store the created parser handle
+ * @return GHOSTTY_SUCCESS on success, or an error code on failure
+ *
+ * @ingroup sgr
+ */
+GhosttyResult ghostty_sgr_new(const GhosttyAllocator* allocator,
+                              GhosttySgrParser* parser);
+
+/**
+ * Free an SGR parser instance.
+ *
+ * Releases all resources associated with the SGR parser. After this call,
+ * the parser handle becomes invalid and must not be used. This includes
+ * any attributes previously returned by ghostty_sgr_next().
+ *
+ * @param parser The parser handle to free (may be NULL)
+ *
+ * @ingroup sgr
+ */
+void ghostty_sgr_free(GhosttySgrParser parser);
+
+/**
+ * Reset an SGR parser instance to the beginning of the parameter list.
+ *
+ * Resets the parser's iteration state without clearing the parameters.
+ * After calling this, ghostty_sgr_next() will start from the beginning
+ * of the parameter list again.
+ *
+ * @param parser The parser handle to reset, must not be NULL
+ *
+ * @ingroup sgr
+ */
+void ghostty_sgr_reset(GhosttySgrParser parser);
+
+/**
+ * Set SGR parameters for parsing.
+ *
+ * Sets the SGR parameter list to parse. Parameters are the numeric values
+ * from a CSI SGR sequence (e.g., for `ESC[1;31m`, params would be {1, 31}).
+ *
+ * The separators array optionally specifies the separator type for each
+ * parameter position. Each byte should be either ';' for semicolon or ':'
+ * for colon. This is needed for certain color formats that use colon
+ * separators (e.g., `ESC[4:3m` for curly underline). Any invalid separator
+ * values are treated as semicolons. The separators array must have the same
+ * length as the params array, if it is not NULL.
+ *
+ * If separators is NULL, all parameters are assumed to be semicolon-separated.
+ *
+ * This function makes an internal copy of the parameter and separator data,
+ * so the caller can safely free or modify the input arrays after this call.
+ *
+ * After calling this function, the parser is automatically reset and ready
+ * to iterate from the beginning.
+ *
+ * @param parser The parser handle, must not be NULL
+ * @param params Array of SGR parameter values
+ * @param separators Optional array of separator characters (';' or ':'), or
+ * NULL
+ * @param len Number of parameters (and separators if provided)
+ * @return GHOSTTY_SUCCESS on success, or an error code on failure
+ *
+ * @ingroup sgr
+ */
+GhosttyResult ghostty_sgr_set_params(GhosttySgrParser parser,
+                                     const uint16_t* params,
+                                     const char* separators,
+                                     size_t len);
+
+/**
+ * Get the next SGR attribute.
+ *
+ * Parses and returns the next attribute from the parameter list.
+ * Call this function repeatedly until it returns false to process
+ * all attributes in the sequence.
+ *
+ * @param parser The parser handle, must not be NULL
+ * @param attr Pointer to store the next attribute
+ * @return true if an attribute was returned, false if no more attributes
+ *
+ * @ingroup sgr
+ */
+bool ghostty_sgr_next(GhosttySgrParser parser, GhosttySgrAttribute* attr);
+
+/**
+ * Get the full parameter list from an unknown SGR attribute.
+ *
+ * This function retrieves the full parameter list that was provided to the
+ * parser when an unknown attribute was encountered. Primarily useful in
+ * WebAssembly environments where accessing struct fields directly is difficult.
+ *
+ * @param unknown The unknown attribute data
+ * @param ptr Pointer to store the pointer to the parameter array (may be NULL)
+ * @return The length of the full parameter array
+ *
+ * @ingroup sgr
+ */
+size_t ghostty_sgr_unknown_full(GhosttySgrUnknown unknown,
+                                const uint16_t** ptr);
+
+/**
+ * Get the partial parameter list from an unknown SGR attribute.
+ *
+ * This function retrieves the partial parameter list where parsing stopped
+ * when an unknown attribute was encountered. Primarily useful in WebAssembly
+ * environments where accessing struct fields directly is difficult.
+ *
+ * @param unknown The unknown attribute data
+ * @param ptr Pointer to store the pointer to the parameter array (may be NULL)
+ * @return The length of the partial parameter array
+ *
+ * @ingroup sgr
+ */
+size_t ghostty_sgr_unknown_partial(GhosttySgrUnknown unknown,
+                                   const uint16_t** ptr);
+
+/**
+ * Get the tag from an SGR attribute.
+ *
+ * This function extracts the tag that identifies which type of attribute
+ * this is. Primarily useful in WebAssembly environments where accessing
+ * struct fields directly is difficult.
+ *
+ * @param attr The SGR attribute
+ * @return The attribute tag
+ *
+ * @ingroup sgr
+ */
+GhosttySgrAttributeTag ghostty_sgr_attribute_tag(GhosttySgrAttribute attr);
+
+/**
+ * Get the value from an SGR attribute.
+ *
+ * This function returns a pointer to the value union from an SGR attribute. Use
+ * the tag to determine which field of the union is valid. Primarily useful in
+ * WebAssembly environments where accessing struct fields directly is difficult.
+ *
+ * @param attr Pointer to the SGR attribute
+ * @return Pointer to the attribute value union
+ *
+ * @ingroup sgr
+ */
+GhosttySgrAttributeValue* ghostty_sgr_attribute_value(
+    GhosttySgrAttribute* attr);
+
+#ifdef __wasm__
+/**
+ * Allocate memory for an SGR attribute (WebAssembly only).
+ *
+ * This is a convenience function for WebAssembly environments to allocate
+ * memory for an SGR attribute structure that can be passed to ghostty_sgr_next.
+ *
+ * @return Pointer to the allocated attribute structure
+ *
+ * @ingroup wasm
+ */
+GhosttySgrAttribute* ghostty_wasm_alloc_sgr_attribute(void);
+
+/**
+ * Free memory for an SGR attribute (WebAssembly only).
+ *
+ * Frees memory allocated by ghostty_wasm_alloc_sgr_attribute.
+ *
+ * @param attr Pointer to the attribute structure to free
+ *
+ * @ingroup wasm
+ */
+void ghostty_wasm_free_sgr_attribute(GhosttySgrAttribute* attr);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* GHOSTTY_VT_SGR_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/wasm.h
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/ghostty/vt/wasm.h
@@ -1,0 +1,159 @@
+/**
+ * @file wasm.h
+ *
+ * WebAssembly utility functions for libghostty-vt.
+ */
+
+#ifndef GHOSTTY_VT_WASM_H
+#define GHOSTTY_VT_WASM_H
+
+#ifdef __wasm__
+
+#include <stddef.h>
+#include <stdint.h>
+
+/** @defgroup wasm WebAssembly Utilities
+ *
+ * Convenience functions for allocating various types in WebAssembly builds.
+ * **These are only available the libghostty-vt wasm module.**
+ *
+ * Ghostty relies on pointers to various types for ABI compatibility, and
+ * creating those pointers in Wasm can be tedious. These functions provide
+ * a purely additive set of utilities that simplify memory management in
+ * Wasm environments without changing the core C library API.
+ *
+ * @note These functions always use the default allocator. If you need
+ * custom allocation strategies, you should allocate types manually using
+ * your custom allocator. This is a very rare use case in the WebAssembly
+ * world so these are optimized for simplicity.
+ *
+ * ## Example Usage
+ *
+ * Here's a simple example of using the Wasm utilities with the key encoder:
+ *
+ * @code
+ * const { exports } = wasmInstance;
+ * const view = new DataView(wasmMemory.buffer);
+ *
+ * // Create key encoder
+ * const encoderPtr = exports.ghostty_wasm_alloc_opaque();
+ * exports.ghostty_key_encoder_new(null, encoderPtr);
+ * const encoder = view.getUint32(encoder, true);
+ *
+ * // Configure encoder with Kitty protocol flags
+ * const flagsPtr = exports.ghostty_wasm_alloc_u8();
+ * view.setUint8(flagsPtr, 0x1F);
+ * exports.ghostty_key_encoder_setopt(encoder, 5, flagsPtr);
+ *
+ * // Allocate output buffer and size pointer
+ * const bufferSize = 32;
+ * const bufPtr = exports.ghostty_wasm_alloc_u8_array(bufferSize);
+ * const writtenPtr = exports.ghostty_wasm_alloc_usize();
+ *
+ * // Encode the key event
+ * exports.ghostty_key_encoder_encode(
+ *     encoder, eventPtr, bufPtr, bufferSize, writtenPtr
+ * );
+ *
+ * // Read encoded output
+ * const bytesWritten = view.getUint32(writtenPtr, true);
+ * const encoded = new Uint8Array(wasmMemory.buffer, bufPtr, bytesWritten);
+ * @endcode
+ *
+ * @remark The code above is pretty ugly! This is the lowest level interface
+ * to the libghostty-vt Wasm module. In practice, this should be wrapped
+ * in a higher-level API that abstracts away all this.
+ *
+ * @{
+ */
+
+/**
+ * Allocate an opaque pointer. This can be used for any opaque pointer
+ * types such as GhosttyKeyEncoder, GhosttyKeyEvent, etc.
+ *
+ * @return Pointer to allocated opaque pointer, or NULL if allocation failed
+ * @ingroup wasm
+ */
+void** ghostty_wasm_alloc_opaque(void);
+
+/**
+ * Free an opaque pointer allocated by ghostty_wasm_alloc_opaque().
+ *
+ * @param ptr Pointer to free, or NULL (NULL is safely ignored)
+ * @ingroup wasm
+ */
+void ghostty_wasm_free_opaque(void **ptr);
+
+/**
+ * Allocate an array of uint8_t values.
+ *
+ * @param len Number of uint8_t elements to allocate
+ * @return Pointer to allocated array, or NULL if allocation failed
+ * @ingroup wasm
+ */
+uint8_t* ghostty_wasm_alloc_u8_array(size_t len);
+
+/**
+ * Free an array allocated by ghostty_wasm_alloc_u8_array().
+ *
+ * @param ptr Pointer to the array to free, or NULL (NULL is safely ignored)
+ * @param len Length of the array (must match the length passed to alloc)
+ * @ingroup wasm
+ */
+void ghostty_wasm_free_u8_array(uint8_t *ptr, size_t len);
+
+/**
+ * Allocate an array of uint16_t values.
+ *
+ * @param len Number of uint16_t elements to allocate
+ * @return Pointer to allocated array, or NULL if allocation failed
+ * @ingroup wasm
+ */
+uint16_t* ghostty_wasm_alloc_u16_array(size_t len);
+
+/**
+ * Free an array allocated by ghostty_wasm_alloc_u16_array().
+ *
+ * @param ptr Pointer to the array to free, or NULL (NULL is safely ignored)
+ * @param len Length of the array (must match the length passed to alloc)
+ * @ingroup wasm
+ */
+void ghostty_wasm_free_u16_array(uint16_t *ptr, size_t len);
+
+/**
+ * Allocate a single uint8_t value.
+ *
+ * @return Pointer to allocated uint8_t, or NULL if allocation failed
+ * @ingroup wasm
+ */
+uint8_t* ghostty_wasm_alloc_u8(void);
+
+/**
+ * Free a uint8_t allocated by ghostty_wasm_alloc_u8().
+ *
+ * @param ptr Pointer to free, or NULL (NULL is safely ignored)
+ * @ingroup wasm
+ */
+void ghostty_wasm_free_u8(uint8_t *ptr);
+
+/**
+ * Allocate a single size_t value.
+ *
+ * @return Pointer to allocated size_t, or NULL if allocation failed
+ * @ingroup wasm
+ */
+size_t* ghostty_wasm_alloc_usize(void);
+
+/**
+ * Free a size_t allocated by ghostty_wasm_alloc_usize().
+ *
+ * @param ptr Pointer to free, or NULL (NULL is safely ignored)
+ * @ingroup wasm
+ */
+void ghostty_wasm_free_usize(size_t *ptr);
+
+/** @} */
+
+#endif /* __wasm__ */
+
+#endif /* GHOSTTY_VT_WASM_H */

--- a/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/module.modulemap
+++ b/CodexMobile/CodexMobile/Terminal/Vendor/GhosttyKit.xcframework/ios-arm64/Headers/module.modulemap
@@ -1,0 +1,7 @@
+// This makes Ghostty available to the XCode build for the macOS app.
+// We append "Kit" to it not to be cute, but because targets have to have
+// unique names and we use Ghostty for other things.
+module GhosttyKit {
+    umbrella header "ghostty.h"
+    export *
+}

--- a/CodexMobile/CodexMobile/Views/Sidebar/SidebarFloatingSettingsButton.swift
+++ b/CodexMobile/CodexMobile/Views/Sidebar/SidebarFloatingSettingsButton.swift
@@ -1,7 +1,7 @@
 // FILE: SidebarFloatingSettingsButton.swift
-// Purpose: Floating shortcut used to open sidebar settings.
+// Purpose: Floating shortcuts used to open sidebar settings and terminal tools.
 // Layer: View Component
-// Exports: SidebarFloatingSettingsButton, SidebarComputerConnectionStatusView
+// Exports: SidebarFloatingSettingsButton, SidebarFloatingTerminalButton, SidebarComputerConnectionStatusView
 
 import SwiftUI
 
@@ -23,6 +23,27 @@ struct SidebarFloatingSettingsButton: View {
         .buttonStyle(.plain)
         .contentShape(Circle())
         .accessibilityLabel("Settings")
+    }
+}
+
+struct SidebarFloatingTerminalButton: View {
+    let colorScheme: ColorScheme
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: {
+            HapticFeedback.shared.triggerImpactFeedback()
+            action()
+        }) {
+            Image(systemName: "terminal.fill")
+                .font(AppFont.system(size: 17, weight: .semibold))
+                .foregroundStyle(colorScheme == .dark ? Color.white : Color.black)
+                .frame(width: 44, height: 44)
+                .adaptiveGlass(.regular, in: Circle())
+        }
+        .buttonStyle(.plain)
+        .contentShape(Circle())
+        .accessibilityLabel("Terminal")
     }
 }
 

--- a/CodexMobile/CodexMobile/Views/SidebarView.swift
+++ b/CodexMobile/CodexMobile/Views/SidebarView.swift
@@ -17,6 +17,7 @@ struct SidebarView: View {
     var isVisible: Bool = true
 
     let onClose: () -> Void
+    let onOpenTerminal: () -> Void
     let onNewChatCreationStateChange: (Bool) -> Void
     let onOpenThread: (CodexThread) -> Void
 
@@ -121,6 +122,7 @@ struct SidebarView: View {
             }
 
             HStack(spacing: 10) {
+                SidebarFloatingTerminalButton(colorScheme: colorScheme, action: openTerminal)
                 SidebarFloatingSettingsButton(colorScheme: colorScheme, action: openSettings)
                 Spacer(minLength: 0)
                 if let trustedPairPresentation = codex.trustedPairPresentation {
@@ -359,6 +361,13 @@ struct SidebarView: View {
         searchText = ""
         isSearchActive = false
         showSettings = true
+        onClose()
+    }
+
+    private func openTerminal() {
+        searchText = ""
+        isSearchActive = false
+        onOpenTerminal()
         onClose()
     }
 

--- a/CodexMobile/CodexMobile/Views/Terminal/GhosttyTerminalSurface.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/GhosttyTerminalSurface.swift
@@ -20,33 +20,37 @@ struct RemodexTerminalTheme: Equatable {
         colorScheme == .light ? light : dark
     }
 
+    // Ghostty ships many bundled themes from iTerm2 color schemes; the screenshots match the
+    // softer "pastel on near-black" family much more than the stock/vivid ANSI palette.
+    // These values are based on Catppuccin Frappe's official Ghostty ANSI colors, with the
+    // darker neutral background from the reference screenshots.
     static let light = RemodexTerminalTheme(
-        background: "#f2f2f7",
-        foreground: "#6C6C71",
-        mutedForeground: "#8E8E95",
-        border: "#eeeeef",
-        cursorForeground: "#009fff",
-        cursorBackground: "#f2f2f7",
+        background: "#eff1f5",
+        foreground: "#4c4f69",
+        mutedForeground: "#8c8fa1",
+        border: "#ccd0da",
+        cursorForeground: "#dc8a78",
+        cursorBackground: "#eff1f5",
         palette: [
-            "#1f1f21", "#ff2e3f", "#0dbe4e", "#ffca00",
-            "#009fff", "#c635e4", "#08c0ef", "#c6c6c8",
-            "#1f1f21", "#ff2e3f", "#0dbe4e", "#ffca00",
-            "#009fff", "#c635e4", "#08c0ef", "#c6c6c8",
+            "#5c5f77", "#d20f39", "#40a02b", "#df8e1d",
+            "#1e66f5", "#ea76cb", "#179299", "#acb0be",
+            "#6c6f85", "#d20f39", "#40a02b", "#df8e1d",
+            "#1e66f5", "#ea76cb", "#179299", "#bcc0cc",
         ]
     )
 
     static let dark = RemodexTerminalTheme(
-        background: "#0a0a0a",
-        foreground: "#adadb1",
-        mutedForeground: "#8e8e95",
-        border: "#2e2e30",
-        cursorForeground: "#009fff",
-        cursorBackground: "#0a0a0a",
+        background: "#101113",
+        foreground: "#d7d7dc",
+        mutedForeground: "#96979f",
+        border: "#2d2e33",
+        cursorForeground: "#4dd78a",
+        cursorBackground: "#101113",
         palette: [
-            "#141415", "#ff2e3f", "#0dbe4e", "#ffca00",
-            "#009fff", "#c635e4", "#08c0ef", "#c6c6c8",
-            "#141415", "#ff2e3f", "#0dbe4e", "#ffca00",
-            "#009fff", "#c635e4", "#08c0ef", "#c6c6c8",
+            "#535766", "#e78284", "#a6d189", "#e5c890",
+            "#8caaee", "#f4b8e4", "#81c8be", "#b7bfd6",
+            "#626880", "#e78284", "#a6d189", "#e5c890",
+            "#8caaee", "#f4b8e4", "#81c8be", "#d8dee9",
         ]
     )
 

--- a/CodexMobile/CodexMobile/Views/Terminal/GhosttyTerminalSurface.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/GhosttyTerminalSurface.swift
@@ -1,0 +1,99 @@
+// FILE: GhosttyTerminalSurface.swift
+// Purpose: SwiftUI wrapper and theme mapping for the native Ghostty terminal view.
+// Layer: View Infrastructure
+// Exports: GhosttyTerminalSurface, RemodexTerminalTheme
+// Depends on: SwiftUI, GhosttyTerminalView
+
+import Foundation
+import SwiftUI
+
+struct RemodexTerminalTheme: Equatable {
+    let background: String
+    let foreground: String
+    let mutedForeground: String
+    let border: String
+    let cursorForeground: String
+    let cursorBackground: String
+    let palette: [String]
+
+    static func resolved(for colorScheme: ColorScheme) -> RemodexTerminalTheme {
+        colorScheme == .light ? light : dark
+    }
+
+    static let light = RemodexTerminalTheme(
+        background: "#f2f2f7",
+        foreground: "#6C6C71",
+        mutedForeground: "#8E8E95",
+        border: "#eeeeef",
+        cursorForeground: "#009fff",
+        cursorBackground: "#f2f2f7",
+        palette: [
+            "#1f1f21", "#ff2e3f", "#0dbe4e", "#ffca00",
+            "#009fff", "#c635e4", "#08c0ef", "#c6c6c8",
+            "#1f1f21", "#ff2e3f", "#0dbe4e", "#ffca00",
+            "#009fff", "#c635e4", "#08c0ef", "#c6c6c8",
+        ]
+    )
+
+    static let dark = RemodexTerminalTheme(
+        background: "#0a0a0a",
+        foreground: "#adadb1",
+        mutedForeground: "#8e8e95",
+        border: "#2e2e30",
+        cursorForeground: "#009fff",
+        cursorBackground: "#0a0a0a",
+        palette: [
+            "#141415", "#ff2e3f", "#0dbe4e", "#ffca00",
+            "#009fff", "#c635e4", "#08c0ef", "#c6c6c8",
+            "#141415", "#ff2e3f", "#0dbe4e", "#ffca00",
+            "#009fff", "#c635e4", "#08c0ef", "#c6c6c8",
+        ]
+    )
+
+    var ghosttyConfig: String {
+        var lines = [
+            "background = \(background)",
+            "foreground = \(foreground)",
+            "cursor-color = \(cursorForeground)",
+            "cursor-text = \(cursorBackground)",
+        ]
+        for (index, color) in palette.enumerated() {
+            lines.append("palette = \(index)=\(color)")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+}
+
+struct GhosttyTerminalSurface: UIViewRepresentable {
+    let terminalKey: String
+    let buffer: Data
+    let fontSize: CGFloat
+    let colorScheme: ColorScheme
+    let theme: RemodexTerminalTheme
+    let onInput: (Data) -> Void
+    let onResize: (Int, Int) -> Void
+    var onNativeAvailabilityChanged: ((Bool) -> Void)? = nil
+
+    func makeUIView(context: Context) -> GhosttyTerminalView {
+        let view = GhosttyTerminalView()
+        configure(view)
+        return view
+    }
+
+    func updateUIView(_ uiView: GhosttyTerminalView, context: Context) {
+        configure(uiView)
+    }
+
+    // Keeps all prop bridging in one place so SwiftUI updates don't churn the Ghostty surface identity.
+    private func configure(_ view: GhosttyTerminalView) {
+        view.onInput = onInput
+        view.onResize = onResize
+        view.onNativeAvailabilityChanged = onNativeAvailabilityChanged
+        view.terminalKey = terminalKey
+        view.fontSize = fontSize
+        view.appearanceScheme = colorScheme == .light ? "light" : "dark"
+        view.backgroundColorHex = theme.background
+        view.themeConfig = theme.ghosttyConfig
+        view.initialBuffer = buffer
+    }
+}

--- a/CodexMobile/CodexMobile/Views/Terminal/GhosttyTerminalView.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/GhosttyTerminalView.swift
@@ -1,0 +1,583 @@
+// FILE: GhosttyTerminalView.swift
+// Purpose: UIKit-backed Ghostty renderer that turns bridge SSH output into an interactive iOS terminal.
+// Layer: View Infrastructure
+// Exports: GhosttyTerminalView
+// Depends on: GhosttyKit, UIKit, QuartzCore
+
+import Foundation
+import GhosttyKit
+import QuartzCore
+import UIKit
+
+private enum GhosttyRuntime {
+    private static let lock = NSLock()
+    private static var initialized = false
+
+    // Ghostty's C runtime must be initialized once before any app/surface is created.
+    static func ensureInitialized() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if initialized {
+            return true
+        }
+
+        let result = ghostty_init(0, nil)
+        initialized = result == GHOSTTY_SUCCESS
+        return initialized
+    }
+}
+
+private final class TerminalInputField: UITextField {
+    var onDeleteBackward: (() -> Void)?
+
+    override func deleteBackward() {
+        onDeleteBackward?()
+        super.deleteBackward()
+    }
+}
+
+private enum TerminalAppearanceScheme: String {
+    case light
+    case dark
+
+    init(value: String) {
+        self = TerminalAppearanceScheme(rawValue: value) ?? .dark
+    }
+
+    var ghosttyColorScheme: ghostty_color_scheme_e {
+        switch self {
+        case .light:
+            return GHOSTTY_COLOR_SCHEME_LIGHT
+        case .dark:
+            return GHOSTTY_COLOR_SCHEME_DARK
+        }
+    }
+}
+
+private extension UIColor {
+    convenience init(hexString: String) {
+        let sanitized = hexString.replacingOccurrences(of: "#", with: "")
+        let value = Int(sanitized, radix: 16) ?? 0
+        self.init(
+            red: CGFloat((value >> 16) & 0xFF) / 255,
+            green: CGFloat((value >> 8) & 0xFF) / 255,
+            blue: CGFloat(value & 0xFF) / 255,
+            alpha: 1
+        )
+    }
+}
+
+final class GhosttyTerminalView: UIView, UITextFieldDelegate {
+    private static let minimumVerticalScrollStepPoints: CGFloat = 18
+    private static let verticalScrollStepMultiplier: CGFloat = 1.15
+    private static let terminalResetSequence = Data("\u{1B}c".utf8)
+
+    private let terminalViewport = UIView()
+    private let inputField = TerminalInputField()
+    private let focusTapGesture = UITapGestureRecognizer()
+    private let scrollPanGesture = UIPanGestureRecognizer()
+    private var lastViewportSize: CGSize = .zero
+    private var lastContentScale: CGFloat = 0
+    private var lastReportedGrid: (cols: Int, rows: Int)?
+    private var lastAppliedBuffer = Data()
+    private var pendingVerticalScrollPoints: CGFloat = 0
+    private var app: ghostty_app_t?
+    private var surface: ghostty_surface_t?
+    private var isCreatingSurface = false
+    private var surfaceCreationFailed = false
+    private var appearance = TerminalAppearanceScheme.dark
+    private var backgroundColorValue = UIColor(hexString: "#0a0a0a")
+
+    var onInput: ((Data) -> Void)?
+    var onResize: ((Int, Int) -> Void)?
+    var onNativeAvailabilityChanged: ((Bool) -> Void)?
+
+    var terminalKey: String = "" {
+        didSet {
+            accessibilityIdentifier = "remodex-terminal-\(terminalKey)"
+        }
+    }
+
+    var initialBuffer: Data = Data() {
+        didSet {
+            guard oldValue != initialBuffer else { return }
+            applyRemoteBuffer(initialBuffer)
+        }
+    }
+
+    var fontSize: CGFloat = 10 {
+        didSet {
+            guard oldValue != fontSize else { return }
+            inputField.font = UIFont.monospacedSystemFont(ofSize: max(fontSize, 13), weight: .regular)
+            refreshSurface()
+        }
+    }
+
+    var appearanceScheme: String = TerminalAppearanceScheme.dark.rawValue {
+        didSet {
+            guard oldValue != appearanceScheme else { return }
+            appearance = TerminalAppearanceScheme(value: appearanceScheme)
+            refreshSurface()
+        }
+    }
+
+    var themeConfig: String = "" {
+        didSet {
+            guard oldValue != themeConfig else { return }
+            refreshSurface()
+        }
+    }
+
+    var backgroundColorHex: String = "#0a0a0a" {
+        didSet {
+            backgroundColorValue = UIColor(hexString: backgroundColorHex)
+            applyTheme()
+        }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureViewHierarchy()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureViewHierarchy()
+    }
+
+    deinit {
+        destroySurface()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateContentScale()
+
+        let viewportSize = terminalViewport.bounds.size
+        if surface == nil {
+            createSurfaceIfPossible()
+        }
+
+        guard viewportSize != lastViewportSize || contentScaleFactor != lastContentScale else {
+            return
+        }
+
+        lastViewportSize = viewportSize
+        lastContentScale = contentScaleFactor
+        resizeSurface()
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        guard window != nil else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.requestKeyboardFocus()
+        }
+    }
+
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        if !string.isEmpty {
+            emitInput(Data(string.utf8))
+        }
+        return false
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        emitInput(Data("\n".utf8))
+        textField.text = ""
+        return false
+    }
+
+    // MARK: - Setup
+
+    private func configureViewHierarchy() {
+        applyTheme()
+        clipsToBounds = true
+        contentScaleFactor = UIScreen.main.scale
+
+        terminalViewport.clipsToBounds = true
+        terminalViewport.contentScaleFactor = contentScaleFactor
+        terminalViewport.translatesAutoresizingMaskIntoConstraints = false
+        terminalViewport.isUserInteractionEnabled = true
+
+        inputField.delegate = self
+        inputField.backgroundColor = .clear
+        inputField.textColor = .clear
+        inputField.tintColor = .clear
+        inputField.font = UIFont.monospacedSystemFont(ofSize: max(fontSize, 13), weight: .regular)
+        inputField.autocorrectionType = .no
+        inputField.autocapitalizationType = .none
+        inputField.spellCheckingType = .no
+        inputField.smartDashesType = .no
+        inputField.smartQuotesType = .no
+        inputField.returnKeyType = .send
+        inputField.keyboardType = .asciiCapable
+        inputField.enablesReturnKeyAutomatically = false
+        inputField.translatesAutoresizingMaskIntoConstraints = false
+        inputField.alpha = 0.02
+        inputField.isAccessibilityElement = false
+        inputField.accessibilityElementsHidden = true
+        inputField.addTarget(self, action: #selector(handleInputEditingDidBegin), for: .editingDidBegin)
+        inputField.onDeleteBackward = { [weak self] in
+            self?.emitInput(Data([0x7F]))
+        }
+
+        focusTapGesture.addTarget(self, action: #selector(handleViewportTap))
+        terminalViewport.addGestureRecognizer(focusTapGesture)
+        scrollPanGesture.addTarget(self, action: #selector(handleViewportPan(_:)))
+        scrollPanGesture.maximumNumberOfTouches = 1
+        scrollPanGesture.cancelsTouchesInView = false
+        terminalViewport.addGestureRecognizer(scrollPanGesture)
+
+        addSubview(terminalViewport)
+        addSubview(inputField)
+
+        NSLayoutConstraint.activate([
+            terminalViewport.leadingAnchor.constraint(equalTo: leadingAnchor),
+            terminalViewport.trailingAnchor.constraint(equalTo: trailingAnchor),
+            terminalViewport.topAnchor.constraint(equalTo: topAnchor),
+            terminalViewport.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            inputField.trailingAnchor.constraint(equalTo: trailingAnchor),
+            inputField.topAnchor.constraint(equalTo: bottomAnchor, constant: 8),
+            inputField.widthAnchor.constraint(equalToConstant: 1),
+            inputField.heightAnchor.constraint(equalToConstant: 1),
+        ])
+    }
+
+    // MARK: - Input
+
+    @objc private func handleViewportTap() {
+        requestKeyboardFocus()
+    }
+
+    @objc private func handleViewportPan(_ gesture: UIPanGestureRecognizer) {
+        guard let surface else { return }
+
+        let location = gesture.location(in: terminalViewport)
+        ghostty_surface_mouse_pos(
+            surface,
+            Double(location.x * contentScaleFactor),
+            Double(location.y * contentScaleFactor),
+            GHOSTTY_MODS_NONE
+        )
+
+        switch gesture.state {
+        case .began:
+            pendingVerticalScrollPoints = 0
+            gesture.setTranslation(.zero, in: terminalViewport)
+        case .changed:
+            let translation = gesture.translation(in: terminalViewport)
+            let stepSize = max(fontSize * Self.verticalScrollStepMultiplier, Self.minimumVerticalScrollStepPoints)
+            let totalVerticalPoints = pendingVerticalScrollPoints + translation.y
+            let verticalSteps = Int(totalVerticalPoints / stepSize)
+            pendingVerticalScrollPoints = totalVerticalPoints - (CGFloat(verticalSteps) * stepSize)
+
+            guard verticalSteps != 0 else {
+                gesture.setTranslation(.zero, in: terminalViewport)
+                return
+            }
+
+            ghostty_surface_mouse_scroll(surface, 0, Double(verticalSteps), 0)
+            redrawSurface()
+            gesture.setTranslation(.zero, in: terminalViewport)
+        default:
+            pendingVerticalScrollPoints = 0
+            gesture.setTranslation(.zero, in: terminalViewport)
+        }
+    }
+
+    @objc private func handleInputEditingDidBegin() {
+        textInputModeDidChange()
+    }
+
+    private func requestKeyboardFocus() {
+        guard window != nil else { return }
+        inputField.becomeFirstResponder()
+        textInputModeDidChange()
+    }
+
+    private func emitInput(_ data: Data) {
+        guard !data.isEmpty else { return }
+        onInput?(data)
+    }
+
+    private func textInputModeDidChange() {
+        guard let app else { return }
+        ghostty_app_keyboard_changed(app)
+    }
+
+    // MARK: - Ghostty Surface
+
+    private func createSurfaceIfPossible() {
+        guard surface == nil, app == nil, !isCreatingSurface, !surfaceCreationFailed else { return }
+        guard terminalViewport.bounds.width > 0, terminalViewport.bounds.height > 0 else { return }
+        guard GhosttyRuntime.ensureInitialized() else {
+            markSurfaceCreationFailed()
+            return
+        }
+
+        isCreatingSurface = true
+        defer { isCreatingSurface = false }
+
+        var runtimeConfig = ghostty_runtime_config_s(
+            userdata: Unmanaged.passUnretained(self).toOpaque(),
+            supports_selection_clipboard: false,
+            wakeup_cb: { _ in },
+            action_cb: { _, _, _ in false },
+            read_clipboard_cb: { _, _, _ in false },
+            confirm_read_clipboard_cb: { _, _, _, _ in },
+            write_clipboard_cb: { _, _, _, _, _ in },
+            close_surface_cb: { _, _ in }
+        )
+
+        guard let config = ghostty_config_new() else {
+            markSurfaceCreationFailed()
+            return
+        }
+        loadThemeConfig(into: config)
+        ghostty_config_finalize(config)
+        defer { ghostty_config_free(config) }
+
+        guard let createdApp = ghostty_app_new(&runtimeConfig, config) else {
+            markSurfaceCreationFailed()
+            return
+        }
+
+        var surfaceConfig = ghostty_surface_config_new()
+        surfaceConfig.platform_tag = GHOSTTY_PLATFORM_IOS
+        surfaceConfig.platform.ios.uiview = Unmanaged.passUnretained(terminalViewport).toOpaque()
+        surfaceConfig.userdata = Unmanaged.passUnretained(self).toOpaque()
+        surfaceConfig.scale_factor = Double(contentScaleFactor)
+        surfaceConfig.font_size = Float(fontSize)
+        surfaceConfig.context = GHOSTTY_SURFACE_CONTEXT_WINDOW
+        surfaceConfig.use_custom_io = true
+
+        guard let createdSurface = ghostty_surface_new(createdApp, &surfaceConfig) else {
+            ghostty_app_free(createdApp)
+            markSurfaceCreationFailed()
+            return
+        }
+
+        app = createdApp
+        surface = createdSurface
+        onNativeAvailabilityChanged?(true)
+        ghostty_app_set_color_scheme(createdApp, appearance.ghosttyColorScheme)
+        ghostty_surface_set_color_scheme(createdSurface, appearance.ghosttyColorScheme)
+        setupWriteCallback()
+        resizeSurface()
+        feedBuffer(initialBuffer)
+    }
+
+    private func resetSurface() {
+        destroySurface()
+        lastAppliedBuffer = Data()
+        lastViewportSize = .zero
+        lastContentScale = 0
+        lastReportedGrid = nil
+        surfaceCreationFailed = false
+        setNeedsLayout()
+    }
+
+    private func markSurfaceCreationFailed() {
+        surfaceCreationFailed = true
+        onNativeAvailabilityChanged?(false)
+    }
+
+    private func refreshSurface() {
+        resetSurface()
+        createSurfaceIfPossible()
+    }
+
+    private func destroySurface() {
+        if let surface {
+            ghostty_surface_set_write_callback(surface, nil, nil)
+            ghostty_surface_free(surface)
+        }
+        if let app {
+            ghostty_app_free(app)
+        }
+        surface = nil
+        app = nil
+    }
+
+    private func applyRemoteBuffer(_ buffer: Data) {
+        guard surface != nil else {
+            createSurfaceIfPossible()
+            return
+        }
+
+        if Data(buffer.prefix(lastAppliedBuffer.count)) == lastAppliedBuffer {
+            let suffix = Data(buffer.dropFirst(lastAppliedBuffer.count))
+            feedData(suffix)
+            lastAppliedBuffer = buffer
+            return
+        }
+
+        replaceRenderedBuffer(with: buffer)
+    }
+
+    private func feedBuffer(_ buffer: Data) {
+        guard !buffer.isEmpty else { return }
+        feedData(buffer)
+        lastAppliedBuffer = buffer
+    }
+
+    private func replaceRenderedBuffer(with buffer: Data) {
+        guard surface != nil else {
+            lastAppliedBuffer = Data()
+            createSurfaceIfPossible()
+            feedBuffer(buffer)
+            return
+        }
+
+        feedData(Self.terminalResetSequence)
+        lastAppliedBuffer = Data()
+        feedBuffer(buffer)
+    }
+
+    private func feedData(_ data: Data) {
+        guard let surface, !data.isEmpty else { return }
+
+        data.withUnsafeBytes { buffer in
+            guard let pointer = buffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+                return
+            }
+            ghostty_surface_feed_data(surface, pointer, buffer.count)
+        }
+
+        redrawSurface()
+    }
+
+    private func setupWriteCallback() {
+        guard let surface else { return }
+
+        let userdata = Unmanaged.passUnretained(self).toOpaque()
+        ghostty_surface_set_write_callback(surface, { userdata, data, len in
+            guard let userdata, let data, len > 0 else { return }
+            let view = Unmanaged<GhosttyTerminalView>.fromOpaque(userdata).takeUnretainedValue()
+            let bytes = Data(bytes: data, count: len)
+
+            DispatchQueue.main.async {
+                view.onInput?(bytes)
+            }
+        }, userdata)
+    }
+
+    private func resizeSurface() {
+        guard let surface else {
+            emitEstimatedResize()
+            return
+        }
+
+        let scale = contentScaleFactor
+        let width = UInt32(max(floor(terminalViewport.bounds.width * scale), 1))
+        let height = UInt32(max(floor(terminalViewport.bounds.height * scale), 1))
+
+        terminalViewport.contentScaleFactor = scale
+        ghostty_surface_set_content_scale(surface, Double(scale), Double(scale))
+        ghostty_surface_set_size(surface, width, height)
+        ghostty_surface_set_occlusion(surface, window != nil)
+        configureIOSurfaceLayers()
+        redrawSurface()
+        emitGhosttyResize()
+    }
+
+    private func redrawSurface() {
+        guard let surface else { return }
+        ghostty_surface_refresh(surface)
+        ghostty_surface_draw(surface)
+        markIOSurfaceLayersForDisplay()
+        emitGhosttyResize()
+    }
+
+    private func emitGhosttyResize() {
+        guard let surface else {
+            emitEstimatedResize()
+            return
+        }
+
+        let size = ghostty_surface_size(surface)
+        emitResize(cols: max(1, Int(size.columns)), rows: max(1, Int(size.rows)))
+    }
+
+    private func emitEstimatedResize() {
+        guard bounds.width > 0, bounds.height > 0 else { return }
+
+        let cellWidth = max(fontSize * 0.62, 1)
+        let cellHeight = max(fontSize * 1.35, 1)
+        emitResize(
+            cols: max(20, min(400, Int(bounds.width / cellWidth))),
+            rows: max(5, min(200, Int(bounds.height / cellHeight)))
+        )
+    }
+
+    private func emitResize(cols: Int, rows: Int) {
+        guard lastReportedGrid?.cols != cols || lastReportedGrid?.rows != rows else {
+            return
+        }
+
+        lastReportedGrid = (cols, rows)
+        onResize?(cols, rows)
+    }
+
+    private func updateContentScale() {
+        let scale = window?.screen.scale ?? UIScreen.main.scale
+        if contentScaleFactor != scale {
+            contentScaleFactor = scale
+        }
+    }
+
+    private func configureIOSurfaceLayers() {
+        let targetBounds = CGRect(origin: .zero, size: terminalViewport.bounds.size)
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        terminalViewport.layer.sublayers?.forEach { sublayer in
+            sublayer.frame = targetBounds
+            sublayer.contentsScale = contentScaleFactor
+        }
+        CATransaction.commit()
+    }
+
+    private func markIOSurfaceLayersForDisplay() {
+        terminalViewport.layer.setNeedsDisplay()
+        terminalViewport.layer.sublayers?.forEach { layer in
+            layer.setNeedsDisplay()
+        }
+    }
+
+    private func applyTheme() {
+        backgroundColor = backgroundColorValue
+        terminalViewport.backgroundColor = backgroundColorValue
+    }
+
+    private func loadThemeConfig(into config: ghostty_config_t) {
+        guard let path = writeThemeConfigFile() else { return }
+        path.withCString { cString in
+            ghostty_config_load_file(config, cString)
+        }
+    }
+
+    private func writeThemeConfigFile() -> String? {
+        guard !themeConfig.isEmpty else { return nil }
+        let configContents = themeConfig
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("remodex-terminal-theme-\(appearance.rawValue).ghostty")
+
+        do {
+            if let existing = try? String(contentsOf: url, encoding: .utf8), existing == configContents {
+                return url.path
+            }
+
+            try configContents.write(to: url, atomically: true, encoding: .utf8)
+            return url.path
+        } catch {
+            return nil
+        }
+    }
+}

--- a/CodexMobile/CodexMobile/Views/Terminal/TerminalConnectionEditorFields.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/TerminalConnectionEditorFields.swift
@@ -1,0 +1,173 @@
+// FILE: TerminalConnectionEditorFields.swift
+// Purpose: Reusable form rows and inputs for the SSH connection editor sheet.
+// Layer: View Component
+// Exports: TerminalEditorSection, TerminalConnectionStringField, TerminalTextField
+// Depends on: SwiftUI, UIKit, RemodexTerminalPrivateKeyStore
+
+import SwiftUI
+import UIKit
+
+struct TerminalEditorSection<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(.primary)
+            content
+        }
+    }
+}
+
+struct TerminalConnectionStringField: View {
+    @Binding var connection: String
+
+    var body: some View {
+        HStack(spacing: 14) {
+            HStack(spacing: 4) {
+                Text("ssh")
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 13, weight: .semibold))
+            }
+            .font(.system(size: 15, weight: .medium))
+            .foregroundStyle(.secondary)
+
+            TextField("user@hostname", text: $connection)
+                .font(.system(size: 15, weight: .medium))
+                .keyboardType(.URL)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+        }
+        .padding(.horizontal, 22)
+        .frame(height: 64)
+        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 24))
+    }
+}
+
+struct TerminalRoundedTextField: View {
+    let placeholder: String
+    @Binding var text: String
+
+    var body: some View {
+        TextField(placeholder, text: $text)
+            .font(.system(size: 15, weight: .medium))
+            .textInputAutocapitalization(.words)
+            .autocorrectionDisabled()
+            .padding(.horizontal, 22)
+            .frame(height: 64)
+            .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 24))
+    }
+}
+
+struct TerminalEditorRow: View {
+    let title: String
+    let value: String
+    var showsChevron = false
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(title)
+                .font(.system(size: 15))
+                .foregroundStyle(.primary)
+            Spacer(minLength: 8)
+            Text(value)
+                .font(.system(size: 15))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            if showsChevron {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .frame(minHeight: 46)
+    }
+}
+
+struct TerminalPrivateKeyEditor: View {
+    @Binding var privateKey: String
+    @Binding var passphrase: String
+    @State private var isShowingKey = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Text("Private key")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+                Button(isShowingKey ? "Hide" : "Paste/Edit", action: toggleKeyVisibility)
+                    .font(.system(size: 11, weight: .semibold))
+                    .buttonStyle(.plain)
+            }
+
+            if isShowingKey || !RemodexTerminalPrivateKeyStore.hasPrivateKey(privateKey) {
+                TextEditor(text: $privateKey)
+                    .font(.system(size: 11, design: .monospaced))
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .frame(minHeight: 124)
+                    .padding(8)
+                    .scrollContentBackground(.hidden)
+                    .background(Color(.tertiarySystemBackground), in: RoundedRectangle(cornerRadius: 8))
+            } else {
+                TerminalPrivateKeySavedRow()
+            }
+
+            SecureField("Passphrase (optional)", text: $passphrase)
+                .font(.system(size: 11, design: .monospaced))
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .padding(.horizontal, 10)
+                .frame(height: 36)
+                .background(Color(.tertiarySystemBackground), in: RoundedRectangle(cornerRadius: 8))
+        }
+    }
+
+    private func toggleKeyVisibility() {
+        withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) {
+            isShowingKey.toggle()
+        }
+    }
+}
+
+private struct TerminalPrivateKeySavedRow: View {
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "checkmark.seal.fill")
+                .foregroundStyle(.green)
+            Text("Private key saved")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 36)
+        .background(Color(.tertiarySystemBackground), in: RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+struct TerminalTextField: View {
+    let title: String
+    @Binding var text: String
+    var placeholder: String = ""
+    var keyboardType: UIKeyboardType = .default
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+            TextField(placeholder.isEmpty ? title : placeholder, text: $text)
+                .font(.system(size: 11, design: .monospaced))
+                .keyboardType(keyboardType)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .padding(.horizontal, 10)
+                .frame(height: 36)
+                .background(Color(.tertiarySystemBackground), in: RoundedRectangle(cornerRadius: 8))
+        }
+    }
+}

--- a/CodexMobile/CodexMobile/Views/Terminal/TerminalConnectionEditorSheet.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/TerminalConnectionEditorSheet.swift
@@ -1,0 +1,211 @@
+// FILE: TerminalConnectionEditorSheet.swift
+// Purpose: Owns the SSH connection editor sheet and its form sections.
+// Layer: View Component
+// Exports: TerminalConnectionEditorSheet
+// Depends on: SwiftUI, UIKit, RemodexTerminalModels, RemodexTerminalPrivateKeyStore
+
+import SwiftUI
+import UIKit
+
+struct TerminalConnectionEditorSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Binding var profile: RemodexTerminalProfile
+    @Binding var connection: String
+    @Binding var privateKey: String
+    @Binding var passphrase: String
+
+    let canSave: Bool
+    let onSave: () -> Void
+    let onResetKnownHost: () -> Void
+
+    @State private var isShowingAdvanced = false
+    @State private var isShowingKeyEditor = false
+    @State private var isConfirmingKnownHostReset = false
+
+    private var keyLabel: String {
+        RemodexTerminalPrivateKeyStore.hasPrivateKey(privateKey) ? "Imported" : "Import"
+    }
+
+    private var advancedLabel: String {
+        profile.port == 22 && profile.cwd.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? "Default"
+            : "Custom"
+    }
+
+    private var isAdvancedVisible: Bool {
+        isShowingAdvanced
+            || profile.port != 22
+            || !profile.cwd.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var portBinding: Binding<String> {
+        Binding(
+            get: { String(profile.port) },
+            set: { value in
+                if let parsedPort = Int(value) {
+                    profile.port = max(1, min(65535, parsedPort))
+                }
+            }
+        )
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 22) {
+                    TerminalEditorSection(title: "Connection") {
+                        TerminalConnectionStringField(connection: $connection)
+                    }
+
+                    TerminalEditorSection(title: "Nickname") {
+                        TerminalRoundedTextField(
+                            placeholder: "Nickname",
+                            text: $profile.nickname
+                        )
+                    }
+
+                    TerminalAuthenticationSection(
+                        keyLabel: keyLabel,
+                        privateKey: $privateKey,
+                        passphrase: $passphrase,
+                        isShowingKeyEditor: $isShowingKeyEditor
+                    )
+
+                    TerminalSSHSection(
+                        profile: $profile,
+                        portBinding: portBinding,
+                        isShowingAdvanced: $isShowingAdvanced,
+                        isConfirmingKnownHostReset: $isConfirmingKnownHostReset,
+                        advancedLabel: advancedLabel,
+                        isAdvancedVisible: isAdvancedVisible
+                    )
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 22)
+            }
+            .navigationTitle("New Server")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Connect", action: onSave)
+                        .font(.system(size: 15, weight: .bold))
+                        .disabled(!canSave)
+                }
+            }
+            .confirmationDialog(
+                "Reset saved SSH host key?",
+                isPresented: $isConfirmingKnownHostReset,
+                titleVisibility: .visible
+            ) {
+                Button("Reset Host Key", role: .destructive, action: onResetKnownHost)
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("The next connection to this host will trust the key it presents.")
+            }
+        }
+    }
+}
+
+private struct TerminalAuthenticationSection: View {
+    let keyLabel: String
+    @Binding var privateKey: String
+    @Binding var passphrase: String
+    @Binding var isShowingKeyEditor: Bool
+
+    var body: some View {
+        TerminalEditorSection(title: "Authentication") {
+            VStack(spacing: 0) {
+                TerminalEditorRow(title: "Method", value: "SSH Key")
+                Divider()
+                Button(action: toggleKeyEditor) {
+                    TerminalEditorRow(
+                        title: "SSH Key",
+                        value: keyLabel,
+                        showsChevron: true
+                    )
+                }
+                .buttonStyle(.plain)
+
+                if isShowingKeyEditor || !RemodexTerminalPrivateKeyStore.hasPrivateKey(privateKey) {
+                    TerminalPrivateKeyEditor(privateKey: $privateKey, passphrase: $passphrase)
+                        .padding(.top, 14)
+                }
+            }
+            .padding(16)
+            .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 18))
+        }
+    }
+
+    private func toggleKeyEditor() {
+        withAnimation(.spring(response: 0.28, dampingFraction: 0.9)) {
+            isShowingKeyEditor.toggle()
+        }
+    }
+}
+
+private struct TerminalSSHSection: View {
+    @Binding var profile: RemodexTerminalProfile
+    let portBinding: Binding<String>
+    @Binding var isShowingAdvanced: Bool
+    @Binding var isConfirmingKnownHostReset: Bool
+    let advancedLabel: String
+    let isAdvancedVisible: Bool
+
+    var body: some View {
+        TerminalEditorSection(title: "SSH") {
+            VStack(spacing: 0) {
+                Button(action: toggleAdvanced) {
+                    TerminalEditorRow(
+                        title: "Advanced Configuration",
+                        value: advancedLabel,
+                        showsChevron: true
+                    )
+                }
+                .buttonStyle(.plain)
+
+                if isAdvancedVisible {
+                    Divider()
+                    HStack(spacing: 12) {
+                        TerminalTextField(
+                            title: "Port",
+                            text: portBinding,
+                            placeholder: "22",
+                            keyboardType: .numberPad
+                        )
+                        TerminalTextField(
+                            title: "Working directory",
+                            text: $profile.cwd,
+                            placeholder: "/Users/name"
+                        )
+                    }
+                    .padding(.top, 14)
+                }
+
+                Divider()
+                Button {
+                    isConfirmingKnownHostReset = true
+                } label: {
+                    TerminalEditorRow(
+                        title: "Known Host",
+                        value: "Reset"
+                    )
+                }
+                .buttonStyle(.plain)
+                .disabled(profile.host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+            .padding(16)
+            .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 18))
+        }
+    }
+
+    private func toggleAdvanced() {
+        withAnimation(.spring(response: 0.28, dampingFraction: 0.9)) {
+            isShowingAdvanced.toggle()
+        }
+    }
+}

--- a/CodexMobile/CodexMobile/Views/Terminal/TerminalFallbackSurface.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/TerminalFallbackSurface.swift
@@ -1,0 +1,134 @@
+// FILE: TerminalFallbackSurface.swift
+// Purpose: Text-based terminal fallback used when the native Ghostty renderer cannot initialize.
+// Layer: View Component
+// Exports: TerminalFallbackSurface
+// Depends on: SwiftUI, RemodexTerminalModels, RemodexTerminalTheme
+
+import SwiftUI
+
+struct TerminalFallbackSurface: View {
+    let snapshot: RemodexTerminalSnapshot
+    let fontSize: CGFloat
+    let theme: RemodexTerminalTheme
+    let isRunning: Bool
+    let onInput: (String) -> Void
+    let onResize: (Int, Int) -> Void
+
+    @State private var input = ""
+
+    private var statusLabel: String {
+        isRunning ? "Native terminal unavailable. Using text fallback." : "Open terminal to start a shell."
+    }
+
+    private var renderedBuffer: String {
+        let text = String(decoding: snapshot.bufferData, as: UTF8.self)
+        return text.isEmpty ? "$ " : text
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            VStack(spacing: 0) {
+                TerminalFallbackBuffer(
+                    statusLabel: statusLabel,
+                    renderedBuffer: renderedBuffer,
+                    fontSize: fontSize,
+                    theme: theme
+                )
+
+                TerminalFallbackInputBar(
+                    input: $input,
+                    theme: theme,
+                    isRunning: isRunning,
+                    onSubmit: sendInput,
+                    onInterrupt: { onInput("\u{3}") }
+                )
+            }
+            .background(Color(hexString: theme.background))
+            .onAppear {
+                emitResize(for: proxy.size)
+            }
+            .onChange(of: proxy.size) { _, size in
+                emitResize(for: size)
+            }
+        }
+    }
+
+    private func sendInput() {
+        guard !input.isEmpty else { return }
+        onInput("\(input)\n")
+        input = ""
+    }
+
+    private func emitResize(for size: CGSize) {
+        let cellWidth = max(fontSize * 0.62, 1)
+        let cellHeight = max(fontSize * 1.35, 1)
+        onResize(
+            max(20, min(400, Int(size.width / cellWidth))),
+            max(5, min(200, Int(size.height / cellHeight)))
+        )
+    }
+}
+
+private struct TerminalFallbackBuffer: View {
+    let statusLabel: String
+    let renderedBuffer: String
+    let fontSize: CGFloat
+    let theme: RemodexTerminalTheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(statusLabel)
+                .font(.system(size: 11))
+                .foregroundStyle(Color(hexString: theme.mutedForeground))
+
+            ScrollView(.vertical, showsIndicators: false) {
+                Text(renderedBuffer)
+                    .font(.system(size: fontSize, design: .monospaced))
+                    .foregroundStyle(Color(hexString: theme.foreground))
+                    .lineSpacing(max(0, round(fontSize * 0.35) - 1))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+                    .padding(.bottom, 12)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+}
+
+private struct TerminalFallbackInputBar: View {
+    @Binding var input: String
+
+    let theme: RemodexTerminalTheme
+    let isRunning: Bool
+    let onSubmit: () -> Void
+    let onInterrupt: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            TextField("type and press return", text: $input)
+                .font(.system(size: 13, design: .monospaced))
+                .foregroundStyle(Color(hexString: theme.foreground))
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .disabled(!isRunning)
+                .onSubmit(onSubmit)
+
+            Button("Ctrl-C", action: onInterrupt)
+                .font(.system(size: 11, weight: .bold))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(Color(hexString: theme.border), in: RoundedRectangle(cornerRadius: 8))
+                .foregroundStyle(Color(hexString: theme.foreground))
+                .disabled(!isRunning)
+                .opacity(isRunning ? 1 : 0.35)
+        }
+        .padding(8)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(Color(hexString: theme.border))
+                .frame(height: 1)
+        }
+    }
+}

--- a/CodexMobile/CodexMobile/Views/Terminal/TerminalOptionsMenu.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/TerminalOptionsMenu.swift
@@ -40,6 +40,10 @@ struct TerminalOptionsMenu: View {
                     .font(.system(size: 12, weight: .bold))
                     .foregroundStyle(Color(hexString: statusTone.text))
             }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .adaptiveGlass(.regular, in: Capsule())
+            .contentShape(Capsule())
         }
         .accessibilityLabel("Terminal options")
     }

--- a/CodexMobile/CodexMobile/Views/Terminal/TerminalOptionsMenu.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/TerminalOptionsMenu.swift
@@ -1,0 +1,115 @@
+// FILE: TerminalOptionsMenu.swift
+// Purpose: Encapsulates terminal status, session, font-size, and connection actions.
+// Layer: View Component
+// Exports: TerminalOptionsMenu
+// Depends on: SwiftUI, TerminalUIModels
+
+import SwiftUI
+
+struct TerminalOptionsMenu: View {
+    let statusLabel: String
+    let errorDetail: String?
+    let statusTone: TerminalStatusTone
+    let fontSize: Double
+    let sessions: [TerminalMenuSessionItem]
+    let activeTerminalId: String
+    let isRunning: Bool
+    let hasConnectionConfiguration: Bool
+    let canClear: Bool
+    let canResetKnownHost: Bool
+    let onSelectSession: (String) -> Void
+    let onOpenNewTerminal: () -> Void
+    let onToggleConnection: () -> Void
+    let onOpenConnectionEditor: () -> Void
+    let onClear: () -> Void
+    let onResetKnownHost: () -> Void
+    let onAdjustFontSize: (Double) -> Void
+
+    var body: some View {
+        Menu {
+            statusSection
+            textSizeSection
+            sessionSection
+            connectionSection
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "circle.fill")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(Color(hexString: statusTone.tint))
+                Text(statusLabel)
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(Color(hexString: statusTone.text))
+            }
+        }
+        .accessibilityLabel("Terminal options")
+    }
+
+    private var statusSection: some View {
+        Section {
+            Text(statusLabel)
+            if let errorDetail {
+                Text(errorDetail)
+            }
+        }
+    }
+
+    private var textSizeSection: some View {
+        Section("Text size") {
+            Button("A- \(String(format: "%.1f", nextSmallerFontSize)) pt") {
+                onAdjustFontSize(-remodexTerminalFontSizeStep)
+            }
+            .disabled(fontSize <= remodexTerminalMinFontSize)
+
+            Button("A+ \(String(format: "%.1f", nextLargerFontSize)) pt") {
+                onAdjustFontSize(remodexTerminalFontSizeStep)
+            }
+            .disabled(fontSize >= remodexTerminalMaxFontSize)
+        }
+    }
+
+    private var sessionSection: some View {
+        Section {
+            ForEach(sessions) { session in
+                Button {
+                    onSelectSession(session.terminalId)
+                } label: {
+                    Label(
+                        session.displayLabel,
+                        systemImage: session.terminalId == activeTerminalId ? "checkmark" : "terminal"
+                    )
+                }
+            }
+
+            Button(action: onOpenNewTerminal) {
+                Label("Open new terminal", systemImage: "plus")
+            }
+        }
+    }
+
+    private var connectionSection: some View {
+        Section {
+            Button(
+                isRunning ? "Disconnect" : "Connect",
+                systemImage: isRunning ? "xmark" : "terminal",
+                action: onToggleConnection
+            )
+            .disabled(!hasConnectionConfiguration && !isRunning)
+
+            Button("SSH connection", systemImage: "lock.shield", action: onOpenConnectionEditor)
+
+            Button("Clear", systemImage: "trash", action: onClear)
+                .disabled(!canClear)
+
+            Button("Reset host key", systemImage: "key", action: onResetKnownHost)
+                .disabled(!canResetKnownHost)
+        }
+    }
+
+    private var nextSmallerFontSize: Double {
+        max(remodexTerminalMinFontSize, fontSize - remodexTerminalFontSizeStep)
+    }
+
+    private var nextLargerFontSize: Double {
+        min(remodexTerminalMaxFontSize, fontSize + remodexTerminalFontSizeStep)
+    }
+}

--- a/CodexMobile/CodexMobile/Views/Terminal/TerminalRouteChrome.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/TerminalRouteChrome.swift
@@ -2,9 +2,36 @@
 // Purpose: Navigation title, accessory key bar, and empty-state chrome for the terminal route.
 // Layer: View Component
 // Exports: TerminalRouteTitle, TerminalRouteAccessoryBar, TerminalRouteUnavailableView
-// Depends on: SwiftUI, RemodexTerminalTheme, TerminalUIModels
+// Depends on: SwiftUI, RemodexTerminalTheme, TerminalUIModels, AdaptiveGlassModifier
 
 import SwiftUI
+
+// MARK: - Glass back button
+
+/// Replacement for the system back chevron, rendered as a glass circle so it
+/// reads against the now-transparent terminal nav bar.
+struct TerminalGlassBackButton: View {
+    let theme: RemodexTerminalTheme
+    let action: () -> Void
+
+    var body: some View {
+        Button {
+            HapticFeedback.shared.triggerImpactFeedback(style: .light)
+            action()
+        } label: {
+            Image(systemName: "chevron.backward")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(Color(hexString: theme.foreground))
+                .frame(width: 36, height: 36)
+                .adaptiveGlass(.regular, in: Circle())
+        }
+        .buttonStyle(.plain)
+        .contentShape(Circle())
+        .accessibilityLabel("Back")
+    }
+}
+
+// MARK: - Navigation title
 
 struct TerminalRouteTitle: View {
     let topLine: String
@@ -28,85 +55,463 @@ struct TerminalRouteTitle: View {
     }
 }
 
+// MARK: - Accessory bar
+
+/// Bottom accessory rail above the keyboard.
+///
+/// Layout: `[ compact scrollable clusters ]  [ keyboard-dismiss circle ]  [ DPad controller ]`
+/// The bar background is transparent — the terminal background reads through, and each cluster /
+/// circle has its own native Liquid Glass material (with `.thinMaterial` fallback on iOS < 26).
 struct TerminalRouteAccessoryBar: View {
+    let clusters: [TerminalToolbarCluster]
+    let pendingModifier: TerminalPendingModifier?
+    let theme: RemodexTerminalTheme
+    let isEnabled: Bool
+    let onAction: (TerminalToolbarAction) -> Void
+    let onSelectModifier: (TerminalPendingModifier) -> Void
+    let onDismissKeyboard: () -> Void
+    let onDirectionalInput: (String) -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(clusters) { cluster in
+                        TerminalRouteKeyCluster(
+                            actions: cluster.actions,
+                            pendingModifier: pendingModifier,
+                            theme: theme,
+                            isEnabled: isEnabled,
+                            onAction: onAction,
+                            onSelectModifier: onSelectModifier
+                        )
+                        .id(cluster.id)
+                    }
+                }
+                .padding(.horizontal, 1)
+                .padding(.vertical, 3)
+            }
+            .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
+
+            TerminalRouteCircleAction(
+                systemImage: "keyboard.chevron.compact.down",
+                accessibilityLabel: "Dismiss keyboard",
+                theme: theme,
+                isEnabled: true,
+                action: onDismissKeyboard
+            )
+
+            TerminalRouteDPadControl(
+                theme: theme,
+                isEnabled: isEnabled,
+                onInput: onDirectionalInput
+            )
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .frame(minHeight: remodexTerminalAccessoryHeight)
+        .background(Color.clear)
+    }
+}
+
+// MARK: - Key cluster (capsule glass)
+
+/// A run of related keys rendered as a single capsule of glass with vertical hairline dividers
+/// between adjacent keys. Touch targets are full-height segments so the cluster reads as one
+/// pill from the screenshot's reference design but each segment still gets independent taps.
+private struct TerminalRouteKeyCluster: View {
     let actions: [TerminalToolbarAction]
     let pendingModifier: TerminalPendingModifier?
     let theme: RemodexTerminalTheme
     let isEnabled: Bool
     let onAction: (TerminalToolbarAction) -> Void
+    let onSelectModifier: (TerminalPendingModifier) -> Void
+
+    private var dividerColor: Color {
+        Color(hexString: theme.foreground).opacity(0.12)
+    }
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 6) {
-                ForEach(actions) { action in
-                    TerminalRouteKeyButton(
-                        action: action,
-                        isActive: action.modifier == pendingModifier,
-                        theme: theme,
-                        isEnabled: isEnabled,
-                        onAction: onAction
-                    )
+        HStack(spacing: 0) {
+            ForEach(Array(actions.enumerated()), id: \.element.id) { index, action in
+                TerminalRouteKeySegment(
+                    action: action,
+                    isActive: action.modifier == pendingModifier && action.isModifier,
+                    theme: theme,
+                    isEnabled: isEnabled,
+                    onAction: onAction,
+                    onSelectModifier: onSelectModifier
+                )
+
+                if index < actions.count - 1 {
+                    Rectangle()
+                        .fill(dividerColor)
+                        .frame(width: 1, height: 20)
                 }
             }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .frame(minHeight: remodexTerminalAccessoryHeight)
         }
-        .background(Color(hexString: theme.background))
-        .overlay(alignment: .top) {
-            Rectangle()
-                .fill(Color(hexString: theme.border))
-                .frame(height: 1)
-        }
+        .frame(height: 38)
+        .adaptiveGlass(.regular, in: Capsule())
+        .contentShape(Capsule())
     }
 }
 
-private struct TerminalRouteKeyButton: View {
+// MARK: - Single key segment
+
+private struct TerminalRouteKeySegment: View {
     let action: TerminalToolbarAction
     let isActive: Bool
     let theme: RemodexTerminalTheme
     let isEnabled: Bool
     let onAction: (TerminalToolbarAction) -> Void
+    let onSelectModifier: (TerminalPendingModifier) -> Void
+
+    @State private var isShowingModifierPicker = false
 
     private var activeAccent: Color {
         Color(hexString: theme.palette.indices.contains(10) ? theme.palette[10] : theme.foreground)
     }
 
     private var textColor: Color {
-        isActive ? activeAccent : Color(hexString: theme.foreground)
+        if !isEnabled { return Color(hexString: theme.foreground).opacity(0.35) }
+        return isActive ? activeAccent : Color(hexString: theme.foreground)
     }
 
-    private var backgroundColor: Color {
-        isActive ? activeAccent.opacity(0.18) : Color(hexString: theme.foreground).opacity(0.07)
-    }
-
-    private var borderColor: Color {
-        isActive ? activeAccent.opacity(0.32) : Color(hexString: theme.border)
+    private var segmentWidth: CGFloat {
+        if action.label.count <= 1 { return 32 }
+        if action.label.count <= 3 { return 40 }
+        if action.label.contains(" ") { return 52 }
+        return 44
     }
 
     var body: some View {
         Button {
+            HapticFeedback.shared.triggerImpactFeedback(style: .light)
             onAction(action)
         } label: {
             Text(action.label)
-                .font(.system(size: 12, weight: .bold))
-                .textCase(action.isModifier ? .uppercase : nil)
+                .font(.system(size: 12, weight: .semibold, design: .monospaced))
                 .foregroundStyle(textColor)
-                .frame(minWidth: action.label.count > 1 ? 46 : 38)
-                .padding(.horizontal, 11)
-                .padding(.vertical, 8)
-                .background(backgroundColor, in: RoundedRectangle(cornerRadius: 12))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(borderColor, lineWidth: 1)
-                }
+                .frame(width: segmentWidth)
+                .frame(maxHeight: .infinity)
+                .padding(.horizontal, 2)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .disabled(!isEnabled)
-        .opacity(isEnabled ? 1 : 0.35)
         .accessibilityLabel(action.label)
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.35)
+                .onEnded { _ in
+                    guard action.modifier != nil, isEnabled else { return }
+                    HapticFeedback.shared.triggerImpactFeedback(style: .medium)
+                    isShowingModifierPicker = true
+                }
+        )
+        .popover(isPresented: $isShowingModifierPicker, attachmentAnchor: .point(.top), arrowEdge: .bottom) {
+            TerminalModifierPicker(
+                selectedModifier: action.modifier ?? .ctrl,
+                theme: theme,
+                onSelect: { modifier in
+                    onSelectModifier(modifier)
+                    isShowingModifierPicker = false
+                }
+            )
+            .presentationCompactAdaptation(.popover)
+        }
     }
 }
+
+private struct TerminalModifierPicker: View {
+    let selectedModifier: TerminalPendingModifier
+    let theme: RemodexTerminalTheme
+    let onSelect: (TerminalPendingModifier) -> Void
+
+    var body: some View {
+        VStack(spacing: 6) {
+            ForEach(TerminalPendingModifier.allCases, id: \.self) { modifier in
+                Button {
+                    HapticFeedback.shared.triggerImpactFeedback(style: .light)
+                    onSelect(modifier)
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: modifier.menuSymbolName)
+                            .font(.system(size: 16, weight: .semibold))
+                            .frame(width: 24)
+                        Text(modifier.menuTitle)
+                            .font(.system(size: 18, weight: .semibold))
+                            .frame(width: 54, alignment: .trailing)
+                    }
+                    .foregroundStyle(modifier == selectedModifier
+                        ? Color(hexString: theme.foreground)
+                        : Color(hexString: theme.foreground).opacity(0.62))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 9)
+                    .background(
+                        modifier == selectedModifier
+                            ? Color(hexString: theme.palette.indices.contains(10) ? theme.palette[10] : theme.foreground).opacity(0.18)
+                            : Color.clear,
+                        in: Capsule()
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(10)
+        .frame(width: 190)
+        .adaptiveGlass(.regular, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+    }
+}
+
+// MARK: - Circle action (glass)
+
+private struct TerminalRouteCircleAction: View {
+    let systemImage: String
+    let accessibilityLabel: String
+    let theme: RemodexTerminalTheme
+    let isEnabled: Bool
+    var isHighlighted: Bool = false
+    let action: () -> Void
+
+    private var iconColor: Color {
+        if !isEnabled { return Color(hexString: theme.foreground).opacity(0.35) }
+        if isHighlighted {
+            let accent = theme.palette.indices.contains(10) ? theme.palette[10] : theme.foreground
+            return Color(hexString: accent)
+        }
+        return Color(hexString: theme.foreground)
+    }
+
+    var body: some View {
+        Button {
+            HapticFeedback.shared.triggerImpactFeedback(style: .light)
+            action()
+        } label: {
+            Image(systemName: systemImage)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(iconColor)
+                .frame(width: 40, height: 40)
+                .adaptiveGlass(.regular, in: Circle())
+        }
+        .buttonStyle(.plain)
+        .contentShape(Circle())
+        .disabled(!isEnabled)
+        .accessibilityLabel(accessibilityLabel)
+    }
+}
+
+// MARK: - Circular DPad controller
+
+private enum TerminalDPadDirection {
+    case up
+    case down
+    case left
+    case right
+
+    var input: String {
+        switch self {
+        case .up: return "\u{1B}[A"
+        case .down: return "\u{1B}[B"
+        case .left: return "\u{1B}[D"
+        case .right: return "\u{1B}[C"
+        }
+    }
+
+    var repeatIntervalNanoseconds: UInt64 {
+        switch self {
+        case .up, .down:
+            return 105_000_000
+        case .left, .right:
+            return 80_000_000
+        }
+    }
+
+    var accessibilityLabel: String {
+        switch self {
+        case .up: return "Up"
+        case .down: return "Down"
+        case .left: return "Left"
+        case .right: return "Right"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .up: return "chevron.up"
+        case .down: return "chevron.down"
+        case .left: return "chevron.left"
+        case .right: return "chevron.right"
+        }
+    }
+}
+
+private struct TerminalRouteDPadControl: View {
+    let theme: RemodexTerminalTheme
+    let isEnabled: Bool
+    let onInput: (String) -> Void
+
+    @State private var activeDirection: TerminalDPadDirection?
+    @State private var repeatTask: Task<Void, Never>?
+    @State private var pressGeneration = 0
+    @State private var joystickOffset: CGSize = .zero
+
+    private var foregroundColor: Color {
+        isEnabled ? Color(hexString: theme.foreground) : Color(hexString: theme.foreground).opacity(0.35)
+    }
+
+    private var activeAccent: Color {
+        Color(hexString: theme.palette.indices.contains(10) ? theme.palette[10] : theme.foreground)
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack {
+                Circle()
+                    .stroke(Color(hexString: theme.foreground).opacity(0.18), lineWidth: 1)
+
+                DPadArrows(
+                    activeDirection: activeDirection,
+                    foreground: foregroundColor,
+                    activeForeground: Color(hexString: theme.background),
+                    accent: activeAccent
+                )
+
+                Circle()
+                    .fill(Color(hexString: theme.background).opacity(0.68))
+                    .frame(width: 16, height: 16)
+                    .overlay {
+                        Circle()
+                            .stroke(activeDirection == nil ? foregroundColor.opacity(0.22) : activeAccent.opacity(0.72), lineWidth: 1)
+                    }
+                    .offset(joystickOffset)
+                    .animation(.interactiveSpring(response: 0.16, dampingFraction: 0.78), value: joystickOffset)
+            }
+            .frame(width: proxy.size.width, height: proxy.size.height)
+            .adaptiveGlass(.regular, in: Circle())
+            .contentShape(Circle())
+            .gesture(
+                DragGesture(minimumDistance: 8, coordinateSpace: .local)
+                    .onChanged { value in
+                        guard isEnabled else {
+                            endPress()
+                            return
+                        }
+                        guard let direction = direction(for: value.location, in: proxy.size) else {
+                            // Returning to the center dead-zone releases the joystick.
+                            endPress()
+                            return
+                        }
+                        joystickOffset = offset(for: value.location, in: proxy.size)
+                        beginPress(direction)
+                    }
+                    .onEnded { _ in
+                        endPress()
+                    }
+            )
+            .opacity(isEnabled ? 1 : 0.45)
+            .accessibilityLabel("Arrow key controller")
+            .accessibilityHint("Drag from the center and hold a direction to send terminal arrow keys")
+        }
+        .frame(width: 50, height: 50)
+        .onDisappear {
+            endPress()
+        }
+        .onChange(of: isEnabled) { _, enabled in
+            if !enabled {
+                endPress()
+            }
+        }
+    }
+
+    private func direction(for location: CGPoint, in size: CGSize) -> TerminalDPadDirection? {
+        let center = CGPoint(x: size.width / 2, y: size.height / 2)
+        let dx = location.x - center.x
+        let dy = location.y - center.y
+        let distance = hypot(dx, dy)
+        guard distance > 13 else { return nil }
+        if abs(dx) > abs(dy) {
+            return dx < 0 ? .left : .right
+        }
+        return dy < 0 ? .up : .down
+    }
+
+    private func offset(for location: CGPoint, in size: CGSize) -> CGSize {
+        let center = CGPoint(x: size.width / 2, y: size.height / 2)
+        let dx = location.x - center.x
+        let dy = location.y - center.y
+        let distance = max(1, hypot(dx, dy))
+        let maxOffset: CGFloat = 9
+        let scale = min(maxOffset / distance, 1)
+        return CGSize(width: dx * scale, height: dy * scale)
+    }
+
+    private func beginPress(_ direction: TerminalDPadDirection) {
+        guard activeDirection != direction else { return }
+        repeatTask?.cancel()
+        activeDirection = direction
+        pressGeneration += 1
+        let generation = pressGeneration
+        send(direction, haptic: true)
+
+        repeatTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 320_000_000)
+            while !Task.isCancelled,
+                  activeDirection == direction,
+                  pressGeneration == generation {
+                send(direction, haptic: false)
+                try? await Task.sleep(nanoseconds: direction.repeatIntervalNanoseconds)
+            }
+        }
+    }
+
+    private func endPress() {
+        pressGeneration += 1
+        repeatTask?.cancel()
+        repeatTask = nil
+        withAnimation(.easeOut(duration: 0.12)) {
+            activeDirection = nil
+            joystickOffset = .zero
+        }
+    }
+
+    private func send(_ direction: TerminalDPadDirection, haptic: Bool) {
+        if haptic {
+            HapticFeedback.shared.triggerImpactFeedback(style: .light)
+        }
+        onInput(direction.input)
+    }
+}
+
+private struct DPadArrows: View {
+    let activeDirection: TerminalDPadDirection?
+    let foreground: Color
+    let activeForeground: Color
+    let accent: Color
+
+    var body: some View {
+        ZStack {
+            arrow(.up).offset(y: -14)
+            arrow(.down).offset(y: 14)
+            arrow(.left).offset(x: -14)
+            arrow(.right).offset(x: 14)
+        }
+        .font(.system(size: 8, weight: .bold))
+    }
+
+    private func arrow(_ direction: TerminalDPadDirection) -> some View {
+        ZStack {
+            Circle()
+                .fill(activeDirection == direction ? accent.opacity(0.72) : Color.white.opacity(0.08))
+                .frame(width: 16, height: 16)
+
+            Image(systemName: direction.symbolName)
+                .foregroundStyle(activeDirection == direction ? activeForeground : foreground.opacity(0.82))
+        }
+    }
+}
+
+// MARK: - Empty / unavailable state
 
 struct TerminalRouteUnavailableView: View {
     let title: String

--- a/CodexMobile/CodexMobile/Views/Terminal/TerminalRouteChrome.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/TerminalRouteChrome.swift
@@ -1,0 +1,141 @@
+// FILE: TerminalRouteChrome.swift
+// Purpose: Navigation title, accessory key bar, and empty-state chrome for the terminal route.
+// Layer: View Component
+// Exports: TerminalRouteTitle, TerminalRouteAccessoryBar, TerminalRouteUnavailableView
+// Depends on: SwiftUI, RemodexTerminalTheme, TerminalUIModels
+
+import SwiftUI
+
+struct TerminalRouteTitle: View {
+    let topLine: String
+    let bottomLine: String
+    let theme: RemodexTerminalTheme
+
+    var body: some View {
+        VStack(spacing: 1) {
+            Text(topLine)
+                .font(.system(size: 13, weight: .bold))
+                .foregroundStyle(Color(hexString: theme.foreground))
+                .lineLimit(1)
+
+            Text(bottomLine)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(Color(hexString: theme.mutedForeground))
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .frame(maxWidth: 240)
+    }
+}
+
+struct TerminalRouteAccessoryBar: View {
+    let actions: [TerminalToolbarAction]
+    let pendingModifier: TerminalPendingModifier?
+    let theme: RemodexTerminalTheme
+    let isEnabled: Bool
+    let onAction: (TerminalToolbarAction) -> Void
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(actions) { action in
+                    TerminalRouteKeyButton(
+                        action: action,
+                        isActive: action.modifier == pendingModifier,
+                        theme: theme,
+                        isEnabled: isEnabled,
+                        onAction: onAction
+                    )
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .frame(minHeight: remodexTerminalAccessoryHeight)
+        }
+        .background(Color(hexString: theme.background))
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(Color(hexString: theme.border))
+                .frame(height: 1)
+        }
+    }
+}
+
+private struct TerminalRouteKeyButton: View {
+    let action: TerminalToolbarAction
+    let isActive: Bool
+    let theme: RemodexTerminalTheme
+    let isEnabled: Bool
+    let onAction: (TerminalToolbarAction) -> Void
+
+    private var activeAccent: Color {
+        Color(hexString: theme.palette.indices.contains(10) ? theme.palette[10] : theme.foreground)
+    }
+
+    private var textColor: Color {
+        isActive ? activeAccent : Color(hexString: theme.foreground)
+    }
+
+    private var backgroundColor: Color {
+        isActive ? activeAccent.opacity(0.18) : Color(hexString: theme.foreground).opacity(0.07)
+    }
+
+    private var borderColor: Color {
+        isActive ? activeAccent.opacity(0.32) : Color(hexString: theme.border)
+    }
+
+    var body: some View {
+        Button {
+            onAction(action)
+        } label: {
+            Text(action.label)
+                .font(.system(size: 12, weight: .bold))
+                .textCase(action.isModifier ? .uppercase : nil)
+                .foregroundStyle(textColor)
+                .frame(minWidth: action.label.count > 1 ? 46 : 38)
+                .padding(.horizontal, 11)
+                .padding(.vertical, 8)
+                .background(backgroundColor, in: RoundedRectangle(cornerRadius: 12))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(borderColor, lineWidth: 1)
+                }
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
+        .opacity(isEnabled ? 1 : 0.35)
+        .accessibilityLabel(action.label)
+    }
+}
+
+struct TerminalRouteUnavailableView: View {
+    let title: String
+    let detail: String
+    let theme: RemodexTerminalTheme
+    let action: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "terminal")
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(Color(hexString: theme.foreground))
+
+            Text(title)
+                .font(.system(size: 15, weight: .bold))
+                .foregroundStyle(Color(hexString: theme.foreground))
+
+            Text(detail)
+                .font(.system(size: 12))
+                .foregroundStyle(Color(hexString: theme.mutedForeground))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 28)
+
+            Button("SSH connection", action: action)
+                .font(.system(size: 12, weight: .bold))
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 4)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(hexString: theme.background))
+    }
+}

--- a/CodexMobile/CodexMobile/Views/Terminal/TerminalScreen.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/TerminalScreen.swift
@@ -1,0 +1,588 @@
+// FILE: TerminalScreen.swift
+// Purpose: Full-page Ghostty SSH terminal route modeled after t3code-mobile's terminal screen.
+// Layer: View
+// Exports: TerminalScreen
+// Depends on: CodexService, GhosttyTerminalSurface, RemodexTerminalModels
+
+import Foundation
+import SwiftUI
+
+struct TerminalScreen: View {
+    @Environment(CodexService.self) private var codex
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var draftProfile = RemodexTerminalProfileStore.load()
+    @State private var connectionDraft = RemodexTerminalProfileStore.load().connectionString
+    @State private var privateKeyDraft = RemodexTerminalPrivateKeyStore.loadPrivateKey()
+    @State private var passphraseDraft = RemodexTerminalPrivateKeyStore.loadPassphrase()
+    @State private var isShowingConnectionEditor = false
+    @State private var activeTerminalId = CodexService.defaultTerminalId
+    @State private var bootstrappedTerminalIds = Set<String>()
+    @State private var userClosedTerminalIds = Set<String>()
+    @State private var isNativeTerminalAvailable = true
+    @State private var actionErrorMessage: String?
+    @State private var didApplyPreferredWorkingDirectory = false
+    @State private var pendingModifier: TerminalPendingModifier?
+    @AppStorage("codex.terminal.fontSize") private var terminalFontSize = remodexTerminalDefaultFontSize
+
+    let preferredWorkingDirectory: String?
+
+    private var theme: RemodexTerminalTheme {
+        RemodexTerminalTheme.resolved(for: colorScheme)
+    }
+
+    private var hostPlatform: TerminalHostPlatform {
+        TerminalHostPlatform.infer(
+            from: [
+                codex.trustedPairPresentation?.systemName,
+                codex.trustedPairPresentation?.name,
+                draftProfile.displayTarget,
+            ]
+            .compactMap { $0 }
+            .joined(separator: " ")
+        )
+    }
+
+    private var profileResolvedFromConnection: RemodexTerminalProfile {
+        var profile = draftProfile
+        profile.applyConnectionString(connectionDraft)
+        return profile.normalizedForSave
+    }
+
+    private var hasConnectionConfiguration: Bool {
+        let profile = profileResolvedFromConnection
+        return !profile.host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !profile.username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && RemodexTerminalPrivateKeyStore.hasPrivateKey(privateKeyDraft)
+    }
+
+    private var isRunning: Bool {
+        activeSnapshot.status == .running || activeSnapshot.status == .starting
+    }
+
+    private var terminalKey: String {
+        "\(activeTerminalId):\(activeSnapshot.instanceId ?? "idle")"
+    }
+
+    private var activeSnapshot: RemodexTerminalSnapshot {
+        codex.terminalSnapshot(for: activeTerminalId)
+    }
+
+    private var currentWorkingDirectory: String {
+        firstNonEmpty([
+            activeSnapshot.cwd,
+            profileResolvedFromConnection.cwd,
+            preferredWorkingDirectory,
+        ]) ?? ""
+    }
+
+    private var terminalHostTitle: String {
+        firstNonEmpty([
+            profileResolvedFromConnection.nickname,
+            codex.trustedPairPresentation?.name,
+            profileResolvedFromConnection.displayTarget,
+        ]) ?? "Terminal"
+    }
+
+    private var navigationTopLine: String {
+        let topLine = [
+            terminalHostTitle,
+            projectDisplayName(for: currentWorkingDirectory),
+        ]
+        .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+        .joined(separator: " · ")
+
+        return topLine.isEmpty ? "Terminal" : topLine
+    }
+
+    private var navigationBottomLine: String {
+        firstNonEmpty([
+            currentWorkingDirectory,
+            profileResolvedFromConnection.connectionString,
+            "SSH terminal",
+        ]) ?? "SSH terminal"
+    }
+
+    private var statusLabel: String {
+        switch activeSnapshot.status {
+        case .running:
+            return "Running"
+        case .starting:
+            return "Starting"
+        case .error:
+            return "Error"
+        case .exited:
+            return "Exited"
+        case .closed:
+            return "Closed"
+        case .idle:
+            return "Idle"
+        }
+    }
+
+    private var terminalErrorDetail: String? {
+        let value = actionErrorMessage ?? activeSnapshot.errorMessage
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private var statusTone: TerminalStatusTone {
+        switch activeSnapshot.status {
+        case .running:
+            return TerminalStatusTone(tint: "#34d399", text: "#a3a3a3")
+        case .starting:
+            return TerminalStatusTone(tint: "#f59e0b", text: "#a3a3a3")
+        case .error:
+            return TerminalStatusTone(tint: "#ef4444", text: "#fca5a5")
+        case .idle, .closed, .exited:
+            return TerminalStatusTone(tint: "#ef4444", text: "#a3a3a3")
+        }
+    }
+
+    private var terminalToolbarActions: [TerminalToolbarAction] {
+        let modifierActions: [TerminalToolbarAction]
+        switch hostPlatform {
+        case .mac:
+            modifierActions = [
+                TerminalToolbarAction(kind: .modifier(.meta), key: "cmd", label: "cmd"),
+                TerminalToolbarAction(kind: .modifier(.ctrl), key: "ctrl", label: "ctrl"),
+            ]
+        case .linux, .windows, .unknown:
+            modifierActions = [
+                TerminalToolbarAction(kind: .modifier(.ctrl), key: "ctrl", label: "ctrl"),
+                TerminalToolbarAction(kind: .modifier(.meta), key: "alt", label: "alt"),
+            ]
+        }
+
+        return [
+            TerminalToolbarAction(kind: .send("\u{1B}"), key: "esc", label: "esc"),
+        ] + modifierActions + [
+            TerminalToolbarAction(kind: .send("\t"), key: "tab", label: "tab"),
+            TerminalToolbarAction(kind: .send("\u{1B}[A"), key: "up", label: "↑"),
+            TerminalToolbarAction(kind: .send("\u{1B}[B"), key: "down", label: "↓"),
+            TerminalToolbarAction(kind: .send("\u{1B}[D"), key: "left", label: "←"),
+            TerminalToolbarAction(kind: .send("\u{1B}[C"), key: "right", label: "→"),
+            TerminalToolbarAction(kind: .send("~"), key: "tilde", label: "~"),
+            TerminalToolbarAction(kind: .send("|"), key: "pipe", label: "|"),
+            TerminalToolbarAction(kind: .send("/"), key: "slash", label: "/"),
+            TerminalToolbarAction(kind: .send("-"), key: "dash", label: "-"),
+        ]
+    }
+
+    private var terminalMenuSessions: [TerminalMenuSessionItem] {
+        var snapshots = codex.knownTerminalSnapshots()
+        if !snapshots.contains(where: { $0.terminalId == activeTerminalId }) {
+            snapshots.append(activeSnapshot)
+        }
+
+        return snapshots.filter { snapshot in
+            snapshot.terminalId == activeTerminalId || snapshot.status.isRunning
+        }.map { snapshot in
+            TerminalMenuSessionItem(
+                terminalId: snapshot.terminalId,
+                displayLabel: terminalDisplayLabel(snapshot.terminalId),
+                status: snapshot.status,
+                cwd: snapshot.cwd
+            )
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            Color(hexString: theme.background)
+                .ignoresSafeArea()
+
+            terminalRouteBody
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Color(hexString: theme.background), for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbarColorScheme(colorScheme, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                TerminalRouteTitle(
+                    topLine: navigationTopLine,
+                    bottomLine: navigationBottomLine,
+                    theme: theme
+                )
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                TerminalOptionsMenu(
+                    statusLabel: statusLabel,
+                    errorDetail: terminalErrorDetail,
+                    statusTone: statusTone,
+                    fontSize: terminalFontSize,
+                    sessions: terminalMenuSessions,
+                    activeTerminalId: activeTerminalId,
+                    isRunning: isRunning,
+                    hasConnectionConfiguration: hasConnectionConfiguration,
+                    canClear: !activeSnapshot.bufferData.isEmpty,
+                    canResetKnownHost: !profileResolvedFromConnection.host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                    onSelectSession: selectTerminalSession,
+                    onOpenNewTerminal: openNewTerminalFromMenu,
+                    onToggleConnection: toggleTerminalConnection,
+                    onOpenConnectionEditor: showConnectionEditor,
+                    onClear: clearTerminal,
+                    onResetKnownHost: resetKnownHost,
+                    onAdjustFontSize: adjustFontSize
+                )
+            }
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            if hasConnectionConfiguration {
+                TerminalRouteAccessoryBar(
+                    actions: terminalToolbarActions,
+                    pendingModifier: pendingModifier,
+                    theme: theme,
+                    isEnabled: activeSnapshot.status == .running,
+                    onAction: handleToolbarActionPress
+                )
+            }
+        }
+        .sheet(isPresented: $isShowingConnectionEditor) {
+            TerminalConnectionEditorSheet(
+                profile: $draftProfile,
+                connection: $connectionDraft,
+                privateKey: $privateKeyDraft,
+                passphrase: $passphraseDraft,
+                canSave: hasConnectionConfiguration,
+                onSave: {
+                    Task { @MainActor in
+                        await saveConnectionAndOpen()
+                    }
+                },
+                onResetKnownHost: resetKnownHost
+            )
+            .presentationDetents([.large])
+            .presentationDragIndicator(.visible)
+        }
+        .task(id: activeTerminalId) {
+            await bootstrapTerminalRoute()
+        }
+        .onChange(of: preferredWorkingDirectory) { _, _ in
+            didApplyPreferredWorkingDirectory = false
+            applyPreferredWorkingDirectoryIfNeeded()
+        }
+    }
+
+    @ViewBuilder
+    private var terminalRouteBody: some View {
+        if !hasConnectionConfiguration {
+            TerminalRouteUnavailableView(
+                title: "Terminal unavailable",
+                detail: "SSH connection and key are required before opening a shell.",
+                theme: theme,
+                action: showConnectionEditor
+            )
+        } else {
+            if isNativeTerminalAvailable {
+                GhosttyTerminalSurface(
+                    terminalKey: terminalKey,
+                    buffer: activeSnapshot.bufferData,
+                    fontSize: CGFloat(terminalFontSize),
+                    colorScheme: colorScheme,
+                    theme: theme,
+                    onInput: handleTerminalDataInput,
+                    onResize: resizeTerminal,
+                    onNativeAvailabilityChanged: { isAvailable in
+                        isNativeTerminalAvailable = isAvailable
+                    }
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(8)
+            } else {
+                TerminalFallbackSurface(
+                    snapshot: activeSnapshot,
+                    fontSize: CGFloat(terminalFontSize),
+                    theme: theme,
+                    isRunning: isRunning,
+                    onInput: handleTerminalTextInput,
+                    onResize: resizeTerminal
+                )
+            }
+        }
+    }
+
+    private func bootstrapTerminalRoute() async {
+        if restoreRunningTerminalIfNeeded() {
+            return
+        }
+        applyPreferredWorkingDirectoryIfNeeded()
+        connectionDraft = draftProfile.connectionString
+        try? await codex.refreshTerminalSnapshot()
+
+        guard hasConnectionConfiguration else {
+            isShowingConnectionEditor = true
+            return
+        }
+        guard !bootstrappedTerminalIds.contains(activeTerminalId),
+              !userClosedTerminalIds.contains(activeTerminalId) else { return }
+        guard !isRunning else {
+            bootstrappedTerminalIds.insert(activeTerminalId)
+            return
+        }
+
+        bootstrappedTerminalIds.insert(activeTerminalId)
+        await openTerminal()
+    }
+
+    private func restoreRunningTerminalIfNeeded() -> Bool {
+        guard activeTerminalId == CodexService.defaultTerminalId else { return false }
+        let runningSnapshots = codex.knownTerminalSnapshots().filter { $0.status.isRunning }
+        guard let preferredSnapshot = runningSnapshots.first(where: { $0.terminalId == CodexService.defaultTerminalId })
+            ?? runningSnapshots.first else {
+            return false
+        }
+        guard preferredSnapshot.terminalId != activeTerminalId else {
+            return false
+        }
+        activeTerminalId = preferredSnapshot.terminalId
+        return true
+    }
+
+    private func selectTerminalSession(_ terminalId: String) {
+        activeTerminalId = terminalId
+    }
+
+    private func openNewTerminalFromMenu() {
+        Task { @MainActor in
+            await openNewTerminal()
+        }
+    }
+
+    private func toggleTerminalConnection() {
+        Task { @MainActor in
+            if isRunning {
+                await closeTerminal()
+            } else {
+                userClosedTerminalIds.remove(activeTerminalId)
+                await openTerminal()
+            }
+        }
+    }
+
+    private func showConnectionEditor() {
+        isShowingConnectionEditor = true
+    }
+
+    private func saveConnectionAndOpen() async {
+        isShowingConnectionEditor = false
+        userClosedTerminalIds.remove(activeTerminalId)
+        bootstrappedTerminalIds.insert(activeTerminalId)
+        await openTerminal()
+    }
+
+    private func openNewTerminal() async {
+        let nextTerminalId = nextOpenTerminalId()
+        draftProfile.applyPreferredWorkingDirectoryOverride(currentWorkingDirectory)
+        activeTerminalId = nextTerminalId
+        userClosedTerminalIds.remove(nextTerminalId)
+        bootstrappedTerminalIds.insert(nextTerminalId)
+        actionErrorMessage = nil
+        await openTerminal()
+    }
+
+    private func openTerminal() async {
+        draftProfile = profileResolvedFromConnection
+        let selectedCWD = activeSnapshot.cwd.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !selectedCWD.isEmpty {
+            draftProfile.cwd = selectedCWD
+        }
+        guard hasConnectionConfiguration else {
+            isShowingConnectionEditor = true
+            return
+        }
+
+        actionErrorMessage = nil
+        RemodexTerminalProfileStore.save(draftProfile)
+        RemodexTerminalPrivateKeyStore.savePrivateKey(privateKeyDraft)
+        RemodexTerminalPrivateKeyStore.savePassphrase(passphraseDraft)
+
+        do {
+            try await codex.openTerminal(
+                terminalId: activeTerminalId,
+                profile: draftProfile,
+                cols: activeSnapshot.cols,
+                rows: activeSnapshot.rows
+            )
+        } catch {
+            actionErrorMessage = terminalErrorText(error)
+        }
+    }
+
+    private func closeTerminal() async {
+        userClosedTerminalIds.insert(activeTerminalId)
+        actionErrorMessage = nil
+        do {
+            try await codex.closeTerminal(terminalId: activeTerminalId)
+        } catch {
+            actionErrorMessage = terminalErrorText(error)
+        }
+    }
+
+    private func resetKnownHost() {
+        let profile = profileResolvedFromConnection.normalizedForSave
+        guard !profile.host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return
+        }
+        RemodexSSHKnownHostStore.delete(host: profile.host, port: profile.port)
+        actionErrorMessage = nil
+    }
+
+    private func clearTerminal() {
+        actionErrorMessage = nil
+        Task { @MainActor in
+            do {
+                try await codex.clearTerminalBuffer(terminalId: activeTerminalId)
+            } catch {
+                actionErrorMessage = terminalErrorText(error)
+            }
+        }
+    }
+
+    private func applyPreferredWorkingDirectoryIfNeeded() {
+        guard !didApplyPreferredWorkingDirectory else { return }
+        didApplyPreferredWorkingDirectory = true
+        draftProfile.applyPreferredWorkingDirectoryOverride(preferredWorkingDirectory)
+        let trimmedCWD = draftProfile.cwd.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedCWD.isEmpty,
+              activeSnapshot.status == .running,
+              activeSnapshot.cwd != trimmedCWD else {
+            return
+        }
+        Task { @MainActor in
+            do {
+                try await codex.changeTerminalWorkingDirectory(trimmedCWD, terminalId: activeTerminalId)
+            } catch {
+                actionErrorMessage = terminalErrorText(error)
+            }
+        }
+    }
+
+    private func handleTerminalDataInput(_ data: Data) {
+        guard !data.isEmpty else { return }
+        guard let text = String(data: data, encoding: .utf8) else {
+            writeInput(data)
+            return
+        }
+        handleTerminalTextInput(text)
+    }
+
+    private func handleTerminalTextInput(_ text: String) {
+        guard !text.isEmpty else { return }
+
+        let outputText: String
+        switch pendingModifier {
+        case .ctrl:
+            pendingModifier = nil
+            outputText = Self.applyCtrlModifier(text)
+        case .meta:
+            pendingModifier = nil
+            outputText = "\u{1B}\(text)"
+        case nil:
+            outputText = text
+        }
+
+        writeInput(Data(outputText.utf8))
+    }
+
+    private func handleToolbarActionPress(_ action: TerminalToolbarAction) {
+        switch action.kind {
+        case .modifier(let modifier):
+            pendingModifier = pendingModifier == modifier ? nil : modifier
+        case .send(let data):
+            handleTerminalTextInput(data)
+        }
+    }
+
+    private func writeInput(_ data: Data) {
+        guard activeSnapshot.status == .running else { return }
+        Task { @MainActor in
+            try? await codex.writeTerminalInput(data, terminalId: activeTerminalId)
+        }
+    }
+
+    private func resizeTerminal(cols: Int, rows: Int) {
+        Task { @MainActor in
+            try? await codex.resizeTerminal(terminalId: activeTerminalId, cols: cols, rows: rows)
+        }
+    }
+
+    private func adjustFontSize(_ delta: Double) {
+        terminalFontSize = min(
+            remodexTerminalMaxFontSize,
+            max(remodexTerminalMinFontSize, terminalFontSize + delta)
+        )
+    }
+
+    private func terminalErrorText(_ error: Error) -> String {
+        if case CodexServiceError.rpcError(let rpcError) = error {
+            return rpcError.message
+        }
+        if let localizedError = error as? LocalizedError,
+           let description = localizedError.errorDescription {
+            return description
+        }
+        return error.localizedDescription
+    }
+
+    private func firstNonEmpty(_ values: [String?]) -> String? {
+        for value in values {
+            let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return nil
+    }
+
+    private func projectDisplayName(for path: String) -> String? {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return URL(fileURLWithPath: trimmed).lastPathComponent
+    }
+
+    private func terminalDisplayLabel(_ terminalId: String) -> String {
+        let index = terminalIndex(terminalId)
+        guard index > 1 else { return "Terminal" }
+        return "Terminal \(index)"
+    }
+
+    private func nextOpenTerminalId() -> String {
+        let existingIndexes = terminalMenuSessions.map { terminalIndex($0.terminalId) }
+        let nextIndex = (existingIndexes.max() ?? 0) + 1
+        return "term-\(max(1, nextIndex))"
+    }
+
+    private func terminalIndex(_ terminalId: String) -> Int {
+        guard terminalId.hasPrefix("term-"),
+              let value = Int(terminalId.dropFirst(5)) else {
+            return 1
+        }
+        return value
+    }
+
+    private static func applyCtrlModifier(_ input: String) -> String {
+        guard let firstCharacter = input.first else {
+            return input
+        }
+
+        let lowerCharacter = Character(firstCharacter.lowercased())
+        if let scalar = lowerCharacter.unicodeScalars.first,
+           lowerCharacter >= "a",
+           lowerCharacter <= "z" {
+            return String(UnicodeScalar(scalar.value - 96) ?? scalar)
+        }
+
+        switch firstCharacter {
+        case "@": return "\u{0}"
+        case "[": return "\u{1B}"
+        case "\\": return "\u{1C}"
+        case "]": return "\u{1D}"
+        case "^": return "\u{1E}"
+        case "_": return "\u{1F}"
+        case "?": return "\u{7F}"
+        default: return input
+        }
+    }
+}

--- a/CodexMobile/CodexMobile/Views/Terminal/TerminalScreen.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/TerminalScreen.swift
@@ -22,6 +22,8 @@ struct TerminalScreen: View {
     @State private var actionErrorMessage: String?
     @State private var didApplyPreferredWorkingDirectory = false
     @State private var pendingModifier: TerminalPendingModifier?
+    @State private var selectedModifier: TerminalPendingModifier = .ctrl
+    @Environment(\.dismiss) private var dismissRoute
     @AppStorage("codex.terminal.fontSize") private var terminalFontSize = remodexTerminalDefaultFontSize
 
     let preferredWorkingDirectory: String?
@@ -139,33 +141,34 @@ struct TerminalScreen: View {
         }
     }
 
-    private var terminalToolbarActions: [TerminalToolbarAction] {
-        let modifierActions: [TerminalToolbarAction]
-        switch hostPlatform {
-        case .mac:
-            modifierActions = [
-                TerminalToolbarAction(kind: .modifier(.meta), key: "cmd", label: "cmd"),
-                TerminalToolbarAction(kind: .modifier(.ctrl), key: "ctrl", label: "ctrl"),
-            ]
-        case .linux, .windows, .unknown:
-            modifierActions = [
-                TerminalToolbarAction(kind: .modifier(.ctrl), key: "ctrl", label: "ctrl"),
-                TerminalToolbarAction(kind: .modifier(.meta), key: "alt", label: "alt"),
-            ]
-        }
-
-        return [
+    private var modifierClusterActions: [TerminalToolbarAction] {
+        [
             TerminalToolbarAction(kind: .send("\u{1B}"), key: "esc", label: "esc"),
-        ] + modifierActions + [
+            TerminalToolbarAction(
+                kind: .modifier(selectedModifier),
+                key: "modifier-selector",
+                label: selectedModifier.selectorLabel
+            ),
             TerminalToolbarAction(kind: .send("\t"), key: "tab", label: "tab"),
-            TerminalToolbarAction(kind: .send("\u{1B}[A"), key: "up", label: "↑"),
-            TerminalToolbarAction(kind: .send("\u{1B}[B"), key: "down", label: "↓"),
-            TerminalToolbarAction(kind: .send("\u{1B}[D"), key: "left", label: "←"),
-            TerminalToolbarAction(kind: .send("\u{1B}[C"), key: "right", label: "→"),
+        ]
+    }
+
+    private var symbolClusterActions: [TerminalToolbarAction] {
+        [
             TerminalToolbarAction(kind: .send("~"), key: "tilde", label: "~"),
             TerminalToolbarAction(kind: .send("|"), key: "pipe", label: "|"),
             TerminalToolbarAction(kind: .send("/"), key: "slash", label: "/"),
-            TerminalToolbarAction(kind: .send("-"), key: "dash", label: "-"),
+        ]
+    }
+
+    private var terminalToolbarClusters: [TerminalToolbarCluster] {
+        [
+            TerminalToolbarCluster(id: "modifiers", actions: modifierClusterActions),
+            TerminalToolbarCluster(id: "symbols", actions: symbolClusterActions),
+            TerminalToolbarCluster(
+                id: "extras",
+                actions: [TerminalToolbarAction(kind: .send("-"), key: "dash", label: "-")]
+            ),
         ]
     }
 
@@ -195,10 +198,17 @@ struct TerminalScreen: View {
             terminalRouteBody
         }
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color(hexString: theme.background), for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
+        .navigationBarBackButtonHidden(true)
+        // Use the system bar (translucent over the black terminal background) instead
+        // of an opaque tinted bar — the glass back button and status pill float on top.
+        .toolbarBackground(.hidden, for: .navigationBar)
         .toolbarColorScheme(colorScheme, for: .navigationBar)
         .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                TerminalGlassBackButton(theme: theme) {
+                    dismissRoute()
+                }
+            }
             ToolbarItem(placement: .principal) {
                 TerminalRouteTitle(
                     topLine: navigationTopLine,
@@ -231,11 +241,14 @@ struct TerminalScreen: View {
         .safeAreaInset(edge: .bottom, spacing: 0) {
             if hasConnectionConfiguration {
                 TerminalRouteAccessoryBar(
-                    actions: terminalToolbarActions,
+                    clusters: terminalToolbarClusters,
                     pendingModifier: pendingModifier,
                     theme: theme,
                     isEnabled: activeSnapshot.status == .running,
-                    onAction: handleToolbarActionPress
+                    onAction: handleToolbarActionPress,
+                    onSelectModifier: selectModifier,
+                    onDismissKeyboard: dismissSystemKeyboard,
+                    onDirectionalInput: sendDirectionalInput
                 )
             }
         }
@@ -473,12 +486,15 @@ struct TerminalScreen: View {
 
         let outputText: String
         switch pendingModifier {
+        case .cmd, .alt:
+            pendingModifier = nil
+            outputText = "\u{1B}\(text)"
+        case .shift:
+            pendingModifier = nil
+            outputText = text
         case .ctrl:
             pendingModifier = nil
             outputText = Self.applyCtrlModifier(text)
-        case .meta:
-            pendingModifier = nil
-            outputText = "\u{1B}\(text)"
         case nil:
             outputText = text
         }
@@ -493,6 +509,36 @@ struct TerminalScreen: View {
         case .send(let data):
             handleTerminalTextInput(data)
         }
+    }
+
+    private func selectModifier(_ modifier: TerminalPendingModifier) {
+        selectedModifier = modifier
+        pendingModifier = modifier
+    }
+
+    // Project-wide pattern (see ContentView.swift:985): nil-target resignFirstResponder
+    // walks the responder chain so we don't need a reference to the offscreen UITextField
+    // that GhosttyTerminalView uses as its first responder.
+    private func dismissSystemKeyboard() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil,
+            from: nil,
+            for: nil
+        )
+    }
+
+    private func sendDirectionalInput(_ text: String) {
+        guard !text.isEmpty else { return }
+        let outputText: String
+        if let modifier = pendingModifier,
+           let modifiedArrow = Self.modifiedArrowSequence(text, modifier: modifier) {
+            pendingModifier = nil
+            outputText = modifiedArrow
+        } else {
+            outputText = text
+        }
+        writeInput(Data(outputText.utf8))
     }
 
     private func writeInput(_ data: Data) {
@@ -582,7 +628,13 @@ struct TerminalScreen: View {
         case "^": return "\u{1E}"
         case "_": return "\u{1F}"
         case "?": return "\u{7F}"
-        default: return input
+            default: return input
         }
+    }
+
+    private static func modifiedArrowSequence(_ input: String, modifier: TerminalPendingModifier) -> String? {
+        guard input.hasPrefix("\u{1B}[") else { return nil }
+        guard let final = input.last, ["A", "B", "C", "D"].contains(final) else { return nil }
+        return "\u{1B}[1;\(modifier.csiModifierParameter)\(final)"
     }
 }

--- a/CodexMobile/CodexMobile/Views/Terminal/TerminalUIModels.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/TerminalUIModels.swift
@@ -1,0 +1,95 @@
+// FILE: TerminalUIModels.swift
+// Purpose: Shared presentation constants and small value types for the SSH terminal route.
+// Layer: View Model
+// Exports: TerminalPendingModifier, TerminalHostPlatform, TerminalToolbarAction, TerminalStatusTone
+// Depends on: SwiftUI, RemodexTerminalModels
+
+import SwiftUI
+
+let remodexTerminalDefaultFontSize = 10.0
+let remodexTerminalFontSizeStep = 0.5
+let remodexTerminalMinFontSize = 6.0
+let remodexTerminalMaxFontSize = 14.0
+let remodexTerminalAccessoryHeight: CGFloat = 52
+
+enum TerminalPendingModifier: Equatable {
+    case ctrl
+    case meta
+}
+
+enum TerminalHostPlatform {
+    case mac
+    case linux
+    case windows
+    case unknown
+
+    static func infer(from value: String?) -> TerminalHostPlatform {
+        let lowercased = value?.lowercased() ?? ""
+        if lowercased.contains("mac")
+            || lowercased.contains("macbook")
+            || lowercased.contains("mac mini")
+            || lowercased.contains("imac")
+            || lowercased.contains("darwin") {
+            return .mac
+        }
+        if lowercased.contains("windows") || lowercased.contains("win") {
+            return .windows
+        }
+        if lowercased.contains("linux")
+            || lowercased.contains("ubuntu")
+            || lowercased.contains("debian") {
+            return .linux
+        }
+        return .unknown
+    }
+}
+
+struct TerminalStatusTone {
+    let tint: String
+    let text: String
+}
+
+struct TerminalMenuSessionItem: Identifiable {
+    let terminalId: String
+    let displayLabel: String
+    let status: RemodexTerminalStatus
+    let cwd: String
+
+    var id: String { terminalId }
+}
+
+enum TerminalToolbarActionKind {
+    case send(String)
+    case modifier(TerminalPendingModifier)
+}
+
+struct TerminalToolbarAction: Identifiable {
+    let kind: TerminalToolbarActionKind
+    let key: String
+    let label: String
+
+    var id: String { key }
+
+    var modifier: TerminalPendingModifier? {
+        if case .modifier(let modifier) = kind {
+            return modifier
+        }
+        return nil
+    }
+
+    var isModifier: Bool {
+        modifier != nil
+    }
+}
+
+extension Color {
+    init(hexString: String) {
+        let sanitized = hexString.replacingOccurrences(of: "#", with: "")
+        let value = Int(sanitized, radix: 16) ?? 0
+        self.init(
+            red: Double((value >> 16) & 0xFF) / 255,
+            green: Double((value >> 8) & 0xFF) / 255,
+            blue: Double(value & 0xFF) / 255
+        )
+    }
+}

--- a/CodexMobile/CodexMobile/Views/Terminal/TerminalUIModels.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/TerminalUIModels.swift
@@ -12,9 +12,47 @@ let remodexTerminalMinFontSize = 6.0
 let remodexTerminalMaxFontSize = 14.0
 let remodexTerminalAccessoryHeight: CGFloat = 52
 
-enum TerminalPendingModifier: Equatable {
+enum TerminalPendingModifier: CaseIterable, Equatable, Hashable {
+    case cmd
+    case shift
+    case alt
     case ctrl
-    case meta
+
+    var selectorLabel: String {
+        switch self {
+        case .cmd: return "cmd ^"
+        case .shift: return "shift ^"
+        case .alt: return "alt ^"
+        case .ctrl: return "ctrl ^"
+        }
+    }
+
+    var menuTitle: String {
+        switch self {
+        case .cmd: return "cmd"
+        case .shift: return "shift"
+        case .alt: return "alt"
+        case .ctrl: return "ctrl"
+        }
+    }
+
+    var menuSymbolName: String {
+        switch self {
+        case .cmd: return "command"
+        case .shift: return "shift"
+        case .alt: return "option"
+        case .ctrl: return "control"
+        }
+    }
+
+    var csiModifierParameter: Int {
+        switch self {
+        case .shift: return 2
+        case .alt: return 3
+        case .ctrl: return 5
+        case .cmd: return 9
+        }
+    }
 }
 
 enum TerminalHostPlatform {
@@ -80,6 +118,14 @@ struct TerminalToolbarAction: Identifiable {
     var isModifier: Bool {
         modifier != nil
     }
+}
+
+// A horizontally-grouped run of keys rendered inside a single glass capsule.
+// Clusters keep semantically-related keys (modifiers, symbols, arrows) visually together
+// so the bar reads like the iOS system keyboard pill row from the reference design.
+struct TerminalToolbarCluster: Identifiable {
+    let id: String
+    let actions: [TerminalToolbarAction]
 }
 
 extension Color {

--- a/CodexMobile/CodexMobile/Views/Turn/Core/TurnToolbarContent.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Core/TurnToolbarContent.swift
@@ -33,6 +33,7 @@ struct TurnToolbarContent: ToolbarContent {
     var onTapMacHandoff: (() -> Void)?
     var onTapWorktreeHandoff: (() -> Void)?
     var onTapNewChat: (() -> Void)?
+    var onTapTerminal: (() -> Void)?
     var onTapRepoDiff: (() -> Void)?
     let onGitAction: (TurnGitActionKind) -> Void
 
@@ -47,6 +48,7 @@ struct TurnToolbarContent: ToolbarContent {
             && !isCreatingGitWorktree
             && !isThreadActionLoading
         let canTapNewChat = onTapNewChat != nil && !isThreadActionLoading
+        let canTapTerminal = onTapTerminal != nil
 
         ToolbarItem(placement: .principal) {
             VStack(alignment: .leading, spacing: 1) {
@@ -110,6 +112,17 @@ struct TurnToolbarContent: ToolbarContent {
                         }
                     }
                     .disabled(!canTapNewChat)
+
+                    Button {
+                        HapticFeedback.shared.triggerImpactFeedback(style: .light)
+                        onTapTerminal?()
+                    } label: {
+                        HStack(spacing: 10) {
+                            ResizableThreadActionSymbol(systemName: "terminal", pointSize: 13)
+                            Text("Open Terminal Here")
+                        }
+                    }
+                    .disabled(!canTapTerminal)
                 } label: {
                     TurnMacHandoffToolbarLabel(isLoading: isThreadActionLoading)
                 }

--- a/CodexMobile/CodexMobile/Views/Turn/Core/TurnView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Core/TurnView.swift
@@ -11,6 +11,7 @@ import UIKit
 struct TurnView: View {
     let thread: CodexThread
     let isWakingMacDisplayRecovery: Bool
+    var onOpenTerminal: ((String?) -> Void)? = nil
 
     @Environment(CodexService.self) private var codex
     @Environment(SubscriptionService.self) private var subscriptions
@@ -210,6 +211,9 @@ struct TurnView: View {
                 onTapMacHandoff: onTapMacHandoff,
                 onTapWorktreeHandoff: onTapWorktreeHandoff,
                 onTapNewChat: onTapNewChat,
+                onTapTerminal: onOpenTerminal == nil ? nil : {
+                    onOpenTerminal?(gitWorkingDirectory)
+                },
                 onTapRepoDiff: onTapRepoDiff,
                 onGitAction: { action in
                     handleGitActionSelection(

--- a/phodex-bridge/package-lock.json
+++ b/phodex-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remodex",
-  "version": "1.5.1",
+  "version": "1.5.2-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remodex",
-      "version": "1.5.1",
+      "version": "1.5.2-beta.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/phodex-bridge/package.json
+++ b/phodex-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remodex",
-  "version": "1.5.1",
+  "version": "1.5.2-beta.0",
   "description": "Local bridge between Codex and the Remodex mobile app. Run `remodex up` to start.",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Adds an on-device SSH terminal flow backed by `Citadel` and bundled `GhosttyKit`, with terminal lifecycle, resize, input, and snapshot state managed in `CodexService`.
- Introduces terminal UI surfaces and navigation from the sidebar and active turn view, including connection editor, route chrome, fallback rendering, and options menu.
- Extends secure storage and account capability parsing to persist SSH profile, private key, passphrase, known hosts, and terminal feature flags.
- Updates the app project and SwiftPM dependencies to include the new terminal stack and supporting packages.

## Testing
- Not run
- Reviewed the code paths that wire `ContentView` -> `TerminalScreen` navigation and `CodexService` terminal state handling.
- Reviewed the new secure-store keys and capability decoding changes for backward-compatible defaults.