### PR TITLE
[codex] Add Windows bridge support and live desktop assistant streaming

### DIFF
--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -1259,6 +1259,33 @@ function startBridge({
 
     return readBridgePreferences();
   }
+
+  function stopBridge() {
+    if (isShuttingDown) {
+      return;
+    }
+
+    isShuttingDown = true;
+    bridgeWakeAssertion.stop();
+    clearReconnectTimer();
+    clearRelayWatchdog();
+    bridgeStatusPublisher.stopHeartbeat();
+    stopContextUsageWatcher();
+    rolloutLiveMirror?.stopAll();
+    desktopIpcActionFollower?.stopAll();
+    desktopRefresher.handleTransportReset();
+    failBridgeManagedCodexRequests(new Error("Bridge stopped before the request completed."));
+    forwardedRequestMethodsById.clear();
+
+    if (socket?.readyState === WebSocket.OPEN || socket?.readyState === WebSocket.CONNECTING) {
+      socket.close();
+    }
+    codex.shutdown();
+  }
+
+  return {
+    stop: stopBridge,
+  };
 }
 
 // Holds a single macOS idle-sleep assertion for as long as the bridge process stays alive.

--- a/phodex-bridge/src/codex-transport.js
+++ b/phodex-bridge/src/codex-transport.js
@@ -13,6 +13,7 @@ function createCodexTransport({
   endpoint = "",
   env = process.env,
   appPath = "",
+  platform = process.platform,
   spawnImpl = spawn,
   WebSocketImpl = WebSocket,
 } = {}) {
@@ -20,11 +21,11 @@ function createCodexTransport({
     return createWebSocketTransport({ endpoint, WebSocketImpl });
   }
 
-  return createSpawnTransport({ env, appPath, spawnImpl });
+  return createSpawnTransport({ env, appPath, platform, spawnImpl });
 }
 
-function createSpawnTransport({ env, appPath, spawnImpl = spawn }) {
-  const launchPlans = createCodexLaunchPlans({ env, appPath });
+function createSpawnTransport({ env, appPath, platform, spawnImpl = spawn }) {
+  const launchPlans = createCodexLaunchPlans({ env, appPath, platform });
   let launchIndex = -1;
   let activeLaunch = null;
   let codex = null;

--- a/phodex-bridge/src/desktop-ipc-action-follower.js
+++ b/phodex-bridge/src/desktop-ipc-action-follower.js
@@ -644,11 +644,11 @@ function collectAssistantMessages(conversationState) {
 }
 
 function isAssistantMessageItem(item) {
-  const type = readString(item?.type).toLowerCase();
-  if (type === "assistant_message" || type === "assistantmessage") {
+  const type = normalizeToken(item?.type);
+  if (type === "agentmessage" || type === "assistantmessage") {
     return true;
   }
-  return type === "message" && readString(item?.role).toLowerCase() === "assistant";
+  return type === "message" && normalizeToken(item?.role) === "assistant";
 }
 
 function assistantMessageText(item) {
@@ -790,6 +790,10 @@ function writeFrame(socket, payload, callback) {
 }
 
 function resolveDefaultIpcSocketPath() {
+  if (process.platform === "win32") {
+    return "\\\\.\\pipe\\codex-ipc";
+  }
+
   const uid = typeof process.getuid === "function" ? process.getuid() : 0;
   return path.join(os.tmpdir(), "codex-ipc", `ipc-${uid}.sock`);
 }
@@ -813,6 +817,12 @@ function requestIdKey(value) {
 
 function readString(value) {
   return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function normalizeToken(value) {
+  return typeof value === "string"
+    ? value.toLowerCase().replace(/[_-\s]+/g, "")
+    : "";
 }
 
 function cloneJSON(value) {

--- a/phodex-bridge/src/desktop-ipc-action-follower.js
+++ b/phodex-bridge/src/desktop-ipc-action-follower.js
@@ -54,6 +54,7 @@ function createDesktopIpcActionFollower({
     onDisconnect,
   });
   const rawStatesByThreadId = new Map();
+  const assistantMessageTextsByThreadId = new Map();
   const pendingRoutesByRequestId = new Map();
   const activeThreadIds = new Set();
   const recoveringThreadIds = new Set();
@@ -84,6 +85,7 @@ function createDesktopIpcActionFollower({
 
   function stopAll() {
     rawStatesByThreadId.clear();
+    assistantMessageTextsByThreadId.clear();
     pendingRoutesByRequestId.clear();
     activeThreadIds.clear();
     recoveringThreadIds.clear();
@@ -132,11 +134,13 @@ function createDesktopIpcActionFollower({
     }
 
     rawStatesByThreadId.set(threadId, nextState);
+    syncProjectedAssistantDeltas(threadId, previousState, nextState);
     syncProjectedActions(threadId, projectPendingDesktopActions(threadId, nextState));
   }
 
   function onDisconnect() {
     rawStatesByThreadId.clear();
+    assistantMessageTextsByThreadId.clear();
     pendingRoutesByRequestId.clear();
     recoveringThreadIds.clear();
     queuedChangesByThreadId.clear();
@@ -273,7 +277,32 @@ function createDesktopIpcActionFollower({
     }
 
     rawStatesByThreadId.set(threadId, nextState);
+    syncProjectedAssistantDeltas(threadId, baselineState, nextState);
     syncProjectedActions(threadId, projectPendingDesktopActions(threadId, nextState));
+  }
+
+  function syncProjectedAssistantDeltas(threadId, previousState, nextState) {
+    const previousTexts = assistantMessageTextsByThreadId.get(threadId);
+    if (!previousTexts && !previousState) {
+      assistantMessageTextsByThreadId.set(threadId, snapshotAssistantMessageTexts(nextState));
+      return;
+    }
+
+    const notifications = projectDesktopAssistantDeltaNotifications(
+      threadId,
+      previousState,
+      nextState,
+      previousTexts || snapshotAssistantMessageTexts(previousState)
+    );
+    if (notifications.length === 0) {
+      assistantMessageTextsByThreadId.set(threadId, snapshotAssistantMessageTexts(nextState));
+      return;
+    }
+
+    for (const notification of notifications) {
+      sendApplicationResponse(JSON.stringify(notification));
+    }
+    assistantMessageTextsByThreadId.set(threadId, snapshotAssistantMessageTexts(nextState));
   }
 
   return {
@@ -550,6 +579,93 @@ function projectPendingDesktopActions(threadId, conversationState) {
     .filter(Boolean);
 }
 
+// Desktop IPC exposes full conversation snapshots/patches, not app-server assistant delta events.
+// Mirror only suffix growth for assistant rows so phones can render the same live text progression.
+function projectDesktopAssistantDeltaNotifications(
+  threadId,
+  previousState,
+  nextState,
+  previousTexts = snapshotAssistantMessageTexts(previousState)
+) {
+  const nextMessages = collectAssistantMessages(nextState);
+  const notifications = [];
+
+  for (const message of nextMessages) {
+    const previousText = previousTexts.get(message.key) || "";
+    if (!message.text || !message.text.startsWith(previousText) || message.text.length <= previousText.length) {
+      continue;
+    }
+
+    const delta = message.text.slice(previousText.length);
+    notifications.push({
+      method: "item/agentMessage/delta",
+      params: {
+        threadId,
+        turnId: message.turnId,
+        itemId: message.itemId,
+        delta,
+      },
+    });
+  }
+
+  return notifications;
+}
+
+function snapshotAssistantMessageTexts(conversationState) {
+  return new Map(collectAssistantMessages(conversationState).map((message) => [message.key, message.text]));
+}
+
+function collectAssistantMessages(conversationState) {
+  const turns = Array.isArray(conversationState?.turns) ? conversationState.turns : [];
+  const messages = [];
+  for (const turn of turns) {
+    const turnId = readString(turn?.id) || readString(turn?.turnId) || readString(turn?.turn_id);
+    const items = Array.isArray(turn?.items) ? turn.items : [];
+    for (const item of items) {
+      if (!isAssistantMessageItem(item)) {
+        continue;
+      }
+
+      const itemId = readString(item?.id) || readString(item?.itemId) || readString(item?.item_id);
+      const text = assistantMessageText(item);
+      if (!turnId || !itemId) {
+        continue;
+      }
+
+      messages.push({
+        key: `${turnId}:${itemId}`,
+        turnId,
+        itemId,
+        text,
+      });
+    }
+  }
+  return messages;
+}
+
+function isAssistantMessageItem(item) {
+  const type = readString(item?.type).toLowerCase();
+  if (type === "assistant_message" || type === "assistantmessage") {
+    return true;
+  }
+  return type === "message" && readString(item?.role).toLowerCase() === "assistant";
+}
+
+function assistantMessageText(item) {
+  const directText = readString(item?.text) || readString(item?.message);
+  if (directText) {
+    return directText;
+  }
+
+  const content = Array.isArray(item?.content) ? item.content : [];
+  return content
+    .map((entry) => entry && typeof entry === "object" ? entry : null)
+    .filter(Boolean)
+    .map((entry) => readString(entry.text) || readString(entry?.data?.text))
+    .filter(Boolean)
+    .join("");
+}
+
 function projectPendingDesktopAction(threadId, request) {
   const requestId = requestIdKey(request.id);
   const method = readString(request.method);
@@ -715,6 +831,7 @@ module.exports = {
   applyConversationStateChange,
   createDesktopIpcActionFollower,
   desktopFollowerPayloadForResponse,
+  projectDesktopAssistantDeltaNotifications,
   projectPendingDesktopActions,
   resolveDefaultIpcSocketPath,
   seedConversationStateFromThreadRead,

--- a/phodex-bridge/src/macos-launch-agent.js
+++ b/phodex-bridge/src/macos-launch-agent.js
@@ -33,8 +33,8 @@ const DEFAULT_PAIRING_WAIT_TIMEOUT_MS = 10_000;
 const DEFAULT_PAIRING_WAIT_INTERVAL_MS = 200;
 
 // Runs the bridge inside launchd while keeping QR rendering in the foreground CLI command.
-function runMacOSBridgeService({ env = process.env } = {}) {
-  assertDarwinPlatform();
+function runMacOSBridgeService({ env = process.env, platform = process.platform } = {}) {
+  assertDarwinPlatform(platform);
   const config = readDaemonConfig({ env });
   if (!config?.relayUrl) {
     const message = "No relay URL configured for the macOS bridge service.";

--- a/phodex-bridge/src/rollout-watch.js
+++ b/phodex-bridge/src/rollout-watch.js
@@ -498,7 +498,11 @@ function collectRecentRolloutFiles(
     }
   }
 
-  candidates.sort((lhs, rhs) => rhs.mtimeMs - lhs.mtimeMs);
+  candidates.sort((lhs, rhs) =>
+    (rhs.mtimeMs - lhs.mtimeMs)
+      || path.basename(rhs.filePath).localeCompare(path.basename(lhs.filePath))
+      || rhs.filePath.localeCompare(lhs.filePath)
+  );
   return candidates.slice(0, candidateLimit);
 }
 

--- a/phodex-bridge/src/workspace-handler.js
+++ b/phodex-bridge/src/workspace-handler.js
@@ -239,7 +239,7 @@ function isBroadWorkspaceRoot(candidatePath) {
 }
 
 async function readPreviewImageData(imagePath, maxPixelDimension, originalByteLength) {
-  if (!usesSipsImagePreview()) {
+  if (!usesNativeImagePreview()) {
     if (originalByteLength <= MAX_IMAGE_PREVIEW_READ_BYTES) {
       return fs.promises.readFile(imagePath);
     }
@@ -262,7 +262,7 @@ async function readPreviewImageData(imagePath, maxPixelDimension, originalByteLe
     }
 
     try {
-      const previewData = await downsampleImageWithSips(
+      const previewData = await downsampleImageNative(
         imagePath,
         candidateDimension,
         Math.min(IMAGE_PREVIEW_TOOL_TIMEOUT_MS, remainingTimeoutMs)
@@ -318,18 +318,118 @@ function previewPixelDimensionCandidates(maxPixelDimension) {
   return Array.from(new Set(dimensions)).sort((a, b) => b - a);
 }
 
-function usesSipsImagePreview() {
+function usesNativeImagePreview() {
   const normalizedPlatform = String(process.platform || "").trim().toLowerCase();
-  return normalizedPlatform === "darwin" || normalizedPlatform === "macos" || normalizedPlatform === "mac";
+  return normalizedPlatform === "darwin"
+    || normalizedPlatform === "macos"
+    || normalizedPlatform === "mac"
+    || normalizedPlatform === "win32"
+    || normalizedPlatform === "windows";
+}
+
+async function downsampleImageNative(imagePath, maxPixelDimension, timeoutMs = IMAGE_PREVIEW_TOOL_TIMEOUT_MS) {
+  return usesWindowsImagePreview()
+    ? downsampleImageWithPowerShell(imagePath, maxPixelDimension, timeoutMs)
+    : downsampleImageWithSips(imagePath, maxPixelDimension, timeoutMs);
+}
+
+function usesWindowsImagePreview() {
+  const normalizedPlatform = String(process.platform || "").trim().toLowerCase();
+  return normalizedPlatform === "win32" || normalizedPlatform === "windows";
 }
 
 async function downsampleImageWithSips(imagePath, maxPixelDimension, timeoutMs = IMAGE_PREVIEW_TOOL_TIMEOUT_MS) {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "remodex-image-preview-"));
   const outputPath = path.join(tempDir, `preview${path.extname(imagePath) || ".png"}`);
+  const command = resolveHostCommand("sips");
   try {
-    await execFileAsync("sips", ["-Z", String(maxPixelDimension), imagePath, "--out", outputPath], {
+    await execFileAsync(command.file, [
+      ...command.args,
+      "-Z",
+      String(maxPixelDimension),
+      imagePath,
+      "--out",
+      outputPath,
+    ], {
       timeout: Math.max(1, Math.floor(timeoutMs)),
       maxBuffer: 1024 * 1024,
+    });
+    return await fs.promises.readFile(outputPath);
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function resolveHostCommand(commandName) {
+  if (path.delimiter !== ";") {
+    return { file: commandName, args: [] };
+  }
+
+  const pathEntries = String(process.env.PATH || "")
+    .split(path.delimiter)
+    .filter(Boolean);
+  for (const entry of pathEntries) {
+    const jsShim = path.join(entry, `${commandName}.js`);
+    if (fs.existsSync(jsShim)) {
+      return { file: process.execPath, args: [jsShim] };
+    }
+  }
+  return { file: commandName, args: [] };
+}
+
+async function downsampleImageWithPowerShell(imagePath, maxPixelDimension, timeoutMs = IMAGE_PREVIEW_TOOL_TIMEOUT_MS) {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "remodex-image-preview-"));
+  const outputPath = path.join(tempDir, `preview${path.extname(imagePath) || ".png"}`);
+  const scriptPath = path.join(tempDir, "resize-preview.ps1");
+  const script = `
+param(
+  [Parameter(Mandatory=$true)][string]$InputPath,
+  [Parameter(Mandatory=$true)][string]$OutputPath,
+  [Parameter(Mandatory=$true)][int]$MaxDimension
+)
+Add-Type -AssemblyName System.Drawing
+$image = [System.Drawing.Image]::FromFile($InputPath)
+try {
+  $longest = [Math]::Max($image.Width, $image.Height)
+  if ($longest -le 0) { throw "Invalid image dimensions." }
+  $scale = [Math]::Min(1.0, [double]$MaxDimension / [double]$longest)
+  $targetWidth = [Math]::Max(1, [int][Math]::Round($image.Width * $scale))
+  $targetHeight = [Math]::Max(1, [int][Math]::Round($image.Height * $scale))
+  $bitmap = New-Object System.Drawing.Bitmap $targetWidth, $targetHeight
+  try {
+    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+    try {
+      $graphics.InterpolationMode = [System.Drawing.Drawing2D.InterpolationMode]::HighQualityBicubic
+      $graphics.SmoothingMode = [System.Drawing.Drawing2D.SmoothingMode]::HighQuality
+      $graphics.PixelOffsetMode = [System.Drawing.Drawing2D.PixelOffsetMode]::HighQuality
+      $graphics.DrawImage($image, 0, 0, $targetWidth, $targetHeight)
+    } finally {
+      $graphics.Dispose()
+    }
+    $bitmap.Save($OutputPath, [System.Drawing.Imaging.ImageFormat]::Png)
+  } finally {
+    if ($bitmap) { $bitmap.Dispose() }
+  }
+} finally {
+  $image.Dispose()
+}
+`;
+  try {
+    await fs.promises.writeFile(scriptPath, script, "utf8");
+    await execFileAsync("powershell.exe", [
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-File",
+      scriptPath,
+      imagePath,
+      outputPath,
+      String(maxPixelDimension),
+    ], {
+      timeout: Math.max(1, Math.floor(timeoutMs)),
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
     });
     return await fs.promises.readFile(outputPath);
   } finally {

--- a/phodex-bridge/test/bridge-desktop-ipc-integration.test.js
+++ b/phodex-bridge/test/bridge-desktop-ipc-integration.test.js
@@ -21,6 +21,7 @@ test("bridge forwards desktop IPC actions to the phone and routes replies back t
   const ipcFrames = [];
   let relaySocket = null;
   let ipcServerSocket = null;
+  let bridge = null;
   let fakeCodex = null;
 
   await new Promise((resolve) => relayServer.once("listening", resolve));
@@ -70,7 +71,7 @@ test("bridge forwards desktop IPC actions to the phone and routes replies back t
   });
 
   t.after(() => {
-    closeFakeCodexForTest(fakeCodex);
+    bridge?.stop();
     relaySocket?.close();
     relayServer.close();
     ipcServer.close();
@@ -78,7 +79,7 @@ test("bridge forwards desktop IPC actions to the phone and routes replies back t
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  startBridge({
+  bridge = startBridge({
     printPairingQr: false,
     config: {
       relayUrl: `ws://127.0.0.1:${relayServer.address().port}`,
@@ -175,6 +176,7 @@ test("bridge forwards live desktop assistant deltas to the phone", async (t) => 
   const relayMessages = [];
   let relaySocket = null;
   let ipcServerSocket = null;
+  let bridge = null;
   let fakeCodex = null;
 
   await new Promise((resolve) => relayServer.once("listening", resolve));
@@ -213,7 +215,7 @@ test("bridge forwards live desktop assistant deltas to the phone", async (t) => 
   });
 
   t.after(() => {
-    closeFakeCodexForTest(fakeCodex);
+    bridge?.stop();
     relaySocket?.close();
     relayServer.close();
     ipcServer.close();
@@ -221,7 +223,7 @@ test("bridge forwards live desktop assistant deltas to the phone", async (t) => 
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  startBridge({
+  bridge = startBridge({
     printPairingQr: false,
     config: {
       relayUrl: `ws://127.0.0.1:${relayServer.address().port}`,
@@ -405,23 +407,6 @@ function createFakeCodexTransport() {
       listeners.close?.();
     },
   };
-}
-
-function closeFakeCodexForTest(fakeCodex) {
-  const previousExitCode = process.exitCode;
-  const originalError = console.error;
-  console.error = (message, ...args) => {
-    if (String(message).includes("Codex transport closed unexpectedly.")) {
-      return;
-    }
-    originalError(message, ...args);
-  };
-  try {
-    fakeCodex?.emitClose();
-  } finally {
-    console.error = originalError;
-    process.exitCode = previousExitCode;
-  }
 }
 
 function attachFrameReader(socket, onFrame) {

--- a/phodex-bridge/test/bridge-desktop-ipc-integration.test.js
+++ b/phodex-bridge/test/bridge-desktop-ipc-integration.test.js
@@ -70,7 +70,7 @@ test("bridge forwards desktop IPC actions to the phone and routes replies back t
   });
 
   t.after(() => {
-    fakeCodex?.emitClose();
+    closeFakeCodexForTest(fakeCodex);
     relaySocket?.close();
     relayServer.close();
     ipcServer.close();
@@ -213,7 +213,7 @@ test("bridge forwards live desktop assistant deltas to the phone", async (t) => 
   });
 
   t.after(() => {
-    fakeCodex?.emitClose();
+    closeFakeCodexForTest(fakeCodex);
     relaySocket?.close();
     relayServer.close();
     ipcServer.close();
@@ -405,6 +405,23 @@ function createFakeCodexTransport() {
       listeners.close?.();
     },
   };
+}
+
+function closeFakeCodexForTest(fakeCodex) {
+  const previousExitCode = process.exitCode;
+  const originalError = console.error;
+  console.error = (message, ...args) => {
+    if (String(message).includes("Codex transport closed unexpectedly.")) {
+      return;
+    }
+    originalError(message, ...args);
+  };
+  try {
+    fakeCodex?.emitClose();
+  } finally {
+    console.error = originalError;
+    process.exitCode = previousExitCode;
+  }
 }
 
 function attachFrameReader(socket, onFrame) {

--- a/phodex-bridge/test/bridge-desktop-ipc-integration.test.js
+++ b/phodex-bridge/test/bridge-desktop-ipc-integration.test.js
@@ -169,6 +169,135 @@ test("bridge forwards desktop IPC actions to the phone and routes replies back t
   assert.equal(resolvedMessage.params.threadId, "thread-ipc");
 });
 
+test("bridge forwards live desktop assistant deltas to the phone", async (t) => {
+  const { tempDir, socketPath: ipcSocketPath } = createIpcTestSocket("remodex-bridge-ipc-delta-");
+  const relayServer = new WebSocket.Server({ port: 0 });
+  const relayMessages = [];
+  let relaySocket = null;
+  let ipcServerSocket = null;
+  let fakeCodex = null;
+
+  await new Promise((resolve) => relayServer.once("listening", resolve));
+  relayServer.on("connection", (socket) => {
+    relaySocket = socket;
+    socket.on("message", (data) => {
+      const parsed = safeParseJSON(data.toString("utf8"));
+      if (parsed) {
+        relayMessages.push(parsed);
+      }
+    });
+  });
+
+  const ipcServer = net.createServer((socket) => {
+    ipcServerSocket = socket;
+    attachFrameReader(socket, (frame) => {
+      if (frame.method === "initialize") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: "initialize",
+          handledByClientId: "desktop",
+          result: { clientId: "desktop-test" },
+        });
+      }
+    });
+  });
+  await new Promise((resolve) => ipcServer.listen(ipcSocketPath, resolve));
+
+  const { startBridge } = loadBridgeWithTestDoubles({
+    createCodexTransportImpl() {
+      fakeCodex = createFakeCodexTransport();
+      return fakeCodex;
+    },
+  });
+
+  t.after(() => {
+    fakeCodex?.emitClose();
+    relaySocket?.close();
+    relayServer.close();
+    ipcServer.close();
+    ipcServerSocket?.destroy();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  startBridge({
+    printPairingQr: false,
+    config: {
+      relayUrl: `ws://127.0.0.1:${relayServer.address().port}`,
+      pushServiceUrl: "",
+      pushPreviewMaxChars: 160,
+      refreshEnabled: false,
+      refreshDebounceMs: 1,
+      keepMacAwakeEnabled: false,
+      codexEndpoint: "",
+      refreshCommand: "",
+      codexBundleId: "",
+      codexAppPath: "",
+      desktopIpcSocketPath: ipcSocketPath,
+    },
+  });
+
+  await waitFor(() => relaySocket && relaySocket.readyState === WebSocket.OPEN);
+  relaySocket.send(JSON.stringify({
+    id: "resume-from-phone-delta",
+    method: "thread/resume",
+    params: { threadId: "thread-ipc-delta" },
+  }));
+
+  await waitFor(() => ipcServerSocket, 2_000);
+  writeFrame(ipcServerSocket, {
+    type: "broadcast",
+    method: "thread-stream-state-changed",
+    sourceClientId: "desktop",
+    version: 1,
+    params: {
+      conversationId: "thread-ipc-delta",
+      change: {
+        type: "snapshot",
+        conversationState: {
+          turns: [{
+            id: "turn-ipc-delta",
+            items: [{
+              id: "assistant-ipc-delta",
+              type: "assistant_message",
+              text: "Hello",
+            }],
+          }],
+        },
+      },
+    },
+  });
+  writeFrame(ipcServerSocket, {
+    type: "broadcast",
+    method: "thread-stream-state-changed",
+    sourceClientId: "desktop",
+    version: 1,
+    params: {
+      conversationId: "thread-ipc-delta",
+      change: {
+        type: "patches",
+        patches: [{
+          op: "replace",
+          path: ["turns", 0, "items", 0, "text"],
+          value: "Hello world",
+        }],
+      },
+    },
+  });
+
+  const deltaMessage = await waitForMessage(
+    relayMessages,
+    (message) => message.method === "item/agentMessage/delta"
+  );
+  assert.deepEqual(deltaMessage.params, {
+    threadId: "thread-ipc-delta",
+    turnId: "turn-ipc-delta",
+    itemId: "assistant-ipc-delta",
+    delta: " world",
+  });
+});
+
 // Loads bridge.js with plaintext test transports while leaving the production module untouched.
 function loadBridgeWithTestDoubles({ createCodexTransportImpl }) {
   const bridgePath = require.resolve("../src/bridge");

--- a/phodex-bridge/test/bridge-desktop-ipc-integration.test.js
+++ b/phodex-bridge/test/bridge-desktop-ipc-integration.test.js
@@ -15,8 +15,7 @@ const { setTimeout: wait } = require("node:timers/promises");
 const WebSocket = require("ws");
 
 test("bridge forwards desktop IPC actions to the phone and routes replies back to Codex Desktop", async (t) => {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-bridge-ipc-"));
-  const ipcSocketPath = path.join(tempDir, "ipc.sock");
+  const { tempDir, socketPath: ipcSocketPath } = createIpcTestSocket("remodex-bridge-ipc-");
   const relayServer = new WebSocket.Server({ port: 0 });
   const relayMessages = [];
   const ipcFrames = [];
@@ -103,7 +102,7 @@ test("bridge forwards desktop IPC actions to the phone and routes replies back t
     params: { threadId: "thread-ipc" },
   }));
 
-  await waitFor(() => ipcServerSocket);
+  await waitFor(() => ipcServerSocket, 2_000);
   await wait(25);
   assert.equal(
     fakeCodex.sent.some((message) => message.method === "thread/read"),
@@ -324,4 +323,12 @@ function safeParseJSON(value) {
   } catch {
     return null;
   }
+}
+
+function createIpcTestSocket(prefix) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const socketPath = process.platform === "win32"
+    ? `\\\\.\\pipe\\${path.basename(tempDir)}-ipc`
+    : path.join(tempDir, "ipc.sock");
+  return { tempDir, socketPath };
 }

--- a/phodex-bridge/test/codex-cli-bootstrap.test.js
+++ b/phodex-bridge/test/codex-cli-bootstrap.test.js
@@ -18,6 +18,7 @@ test("ensureCodexCLI installs Codex when it is missing", () => {
   let codexVersion = null;
 
   const result = ensureCodexCLI({
+    platform: "darwin",
     execFileSyncImpl(command, args, options) {
       commands.push([command, args, options?.stdio || null]);
       if (command === "codex" && args[0] === "--version") {
@@ -64,6 +65,7 @@ test("ensureCodexCLI updates Codex when it is already installed", () => {
   let codexVersion = "0.118.0";
 
   const result = ensureCodexCLI({
+    platform: "darwin",
     execFileSyncImpl(command, args) {
       if (command === "codex" && args[0] === "--version") {
         return `codex-cli ${codexVersion}`;
@@ -101,6 +103,7 @@ test("ensureCodexCLI stops gracefully when npm is unavailable", () => {
   const warnings = [];
 
   const result = ensureCodexCLI({
+    platform: "darwin",
     execFileSyncImpl(command, args) {
       if (command === "codex" && args[0] === "--version") {
         throw new Error("missing codex");

--- a/phodex-bridge/test/codex-transport.test.js
+++ b/phodex-bridge/test/codex-transport.test.js
@@ -137,6 +137,7 @@ test("spawn transport retries with the bundled Codex binary after an ENOENT laun
     const transport = createCodexTransport({
       env: { PATH: "/usr/bin:/bin" },
       appPath,
+      platform: "darwin",
       spawnImpl,
     });
     transport.onStarted((info) => {
@@ -168,6 +169,7 @@ test("spawn transport explains Codex API-key environment failures without asking
   const children = [];
   const transport = createCodexTransport({
     env: { PATH: "/usr/bin:/bin" },
+    platform: "darwin",
     spawnImpl() {
       const child = createFakeChild();
       children.push(child);

--- a/phodex-bridge/test/desktop-handler.test.js
+++ b/phodex-bridge/test/desktop-handler.test.js
@@ -6,6 +6,7 @@
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const path = require("node:path");
 
 const { handleDesktopRequest } = require("../src/desktop-handler");
 
@@ -269,12 +270,12 @@ test("desktop/continueOnDesktop bounces Codex via deep links on Windows", async 
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   assert.equal(executorCalls.length, 2);
-  assert.equal(executorCalls[0][0], "C:\\Windows/System32/rundll32.exe");
+  assert.equal(executorCalls[0][0], path.join("C:\\Windows", "System32", "rundll32.exe"));
   assert.deepEqual(executorCalls[0][1], [
     "url.dll,FileProtocolHandler",
     "codex://settings",
   ]);
-  assert.equal(executorCalls[1][0], "C:\\Windows/System32/rundll32.exe");
+  assert.equal(executorCalls[1][0], path.join("C:\\Windows", "System32", "rundll32.exe"));
   assert.deepEqual(executorCalls[1][1], [
     "url.dll,FileProtocolHandler",
     "codex://threads/thread-win-123",

--- a/phodex-bridge/test/desktop-ipc-action-follower.test.js
+++ b/phodex-bridge/test/desktop-ipc-action-follower.test.js
@@ -16,6 +16,7 @@ const {
   applyConversationStateChange,
   createDesktopIpcActionFollower,
   desktopFollowerPayloadForResponse,
+  projectDesktopAssistantDeltaNotifications,
   projectPendingDesktopActions,
   seedConversationStateFromThreadRead,
 } = require("../src/desktop-ipc-action-follower");
@@ -335,6 +336,84 @@ test("seeds conversation state from thread/read responses for IPC recovery", () 
     {
       requests: [{ id: "req-1" }],
     }
+  );
+});
+
+test("projects only appended assistant text as live app-server deltas", () => {
+  const previousState = {
+    turns: [{
+      id: "turn-1",
+      items: [{
+        id: "assistant-1",
+        type: "assistant_message",
+        text: "Hello",
+      }],
+    }],
+  };
+  const nextState = {
+    turns: [{
+      id: "turn-1",
+      items: [{
+        id: "assistant-1",
+        type: "assistant_message",
+        text: "Hello world",
+      }],
+    }],
+  };
+
+  assert.deepEqual(
+    projectDesktopAssistantDeltaNotifications("thread-1", previousState, nextState),
+    [{
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "assistant-1",
+        delta: " world",
+      },
+    }]
+  );
+});
+
+test("does not replay unchanged or rewritten assistant text as live deltas", () => {
+  const previousState = {
+    turns: [{
+      id: "turn-1",
+      items: [
+        {
+          id: "assistant-same",
+          type: "assistant_message",
+          text: "same",
+        },
+        {
+          id: "assistant-rewrite",
+          type: "assistant_message",
+          text: "draft",
+        },
+      ],
+    }],
+  };
+  const nextState = {
+    turns: [{
+      id: "turn-1",
+      items: [
+        {
+          id: "assistant-same",
+          type: "assistant_message",
+          text: "same",
+        },
+        {
+          id: "assistant-rewrite",
+          type: "assistant_message",
+          text: "final",
+        },
+      ],
+    }],
+  };
+
+  assert.deepEqual(
+    projectDesktopAssistantDeltaNotifications("thread-1", previousState, nextState),
+    []
   );
 });
 
@@ -886,6 +965,97 @@ test("desktop IPC follower forwards pending actions and routes iOS replies back 
         q1: { answers: ["Yes"] },
       },
     },
+  });
+});
+
+test("desktop IPC follower mirrors live assistant text growth from desktop state", async (t) => {
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-ipc-assistant-delta-");
+  let serverSocket = null;
+
+  const server = net.createServer((socket) => {
+    serverSocket = socket;
+    attachFrameReader(socket, (frame) => {
+      if (frame.method === "initialize") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: "initialize",
+          handledByClientId: "desktop",
+          result: { clientId: "remodex-test" },
+        });
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  t.after(() => {
+    server.close();
+    serverSocket?.destroy();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const outbound = [];
+  const follower = createDesktopIpcActionFollower({
+    socketPath,
+    sendApplicationResponse(message) {
+      outbound.push(JSON.parse(message));
+    },
+    requestTimeoutMs: 500,
+  });
+  t.after(() => follower.stopAll());
+
+  follower.observeInbound(JSON.stringify({
+    method: "thread/resume",
+    params: { threadId: "thread-live-delta" },
+  }));
+  await waitFor(() => serverSocket);
+  writeFrame(serverSocket, {
+    type: "broadcast",
+    method: "thread-stream-state-changed",
+    sourceClientId: "desktop",
+    version: 5,
+    params: {
+      conversationId: "thread-live-delta",
+      change: {
+        type: "snapshot",
+        conversationState: {
+          turns: [{
+            id: "turn-live-delta",
+            items: [{
+              id: "assistant-live-delta",
+              type: "assistant_message",
+              text: "Hello",
+            }],
+          }],
+        },
+      },
+    },
+  });
+  writeFrame(serverSocket, {
+    type: "broadcast",
+    method: "thread-stream-state-changed",
+    sourceClientId: "desktop",
+    version: 5,
+    params: {
+      conversationId: "thread-live-delta",
+      change: {
+        type: "patches",
+        patches: [{
+          op: "replace",
+          path: ["turns", 0, "items", 0, "text"],
+          value: "Hello world",
+        }],
+      },
+    },
+  });
+
+  await waitFor(() => outbound.find((message) => message.method === "item/agentMessage/delta"));
+  const deltaMessage = outbound.find((message) => message.method === "item/agentMessage/delta");
+  assert.deepEqual(deltaMessage.params, {
+    threadId: "thread-live-delta",
+    turnId: "turn-live-delta",
+    itemId: "assistant-live-delta",
+    delta: " world",
   });
 });
 

--- a/phodex-bridge/test/desktop-ipc-action-follower.test.js
+++ b/phodex-bridge/test/desktop-ipc-action-follower.test.js
@@ -339,8 +339,7 @@ test("seeds conversation state from thread/read responses for IPC recovery", () 
 });
 
 test("desktop IPC follower projects first add patch-only action updates without a baseline read", async (t) => {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-ipc-recovery-"));
-  const socketPath = path.join(tempDir, "ipc.sock");
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-ipc-recovery-");
   let baselineReads = 0;
   let serverSocket = null;
 
@@ -420,8 +419,7 @@ test("desktop IPC follower projects first add patch-only action updates without 
 });
 
 test("desktop IPC follower uses baseline recovery for patch-only updates that need existing state", async (t) => {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-ipc-replace-recovery-"));
-  const socketPath = path.join(tempDir, "ipc.sock");
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-ipc-replace-recovery-");
   let baselineReads = 0;
   let serverSocket = null;
 
@@ -503,8 +501,7 @@ test("desktop IPC follower uses baseline recovery for patch-only updates that ne
 });
 
 test("desktop IPC follower does not issue baseline reads just because a chat opens", async (t) => {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-ipc-lazy-recovery-"));
-  const socketPath = path.join(tempDir, "ipc.sock");
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-ipc-lazy-recovery-");
   let baselineReads = 0;
   let serverSocket = null;
 
@@ -552,8 +549,7 @@ test("desktop IPC follower does not issue baseline reads just because a chat ope
 });
 
 test("desktop IPC follower waits for a usable snapshot when a first patch needs missing state", async (t) => {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-ipc-wait-snapshot-"));
-  const socketPath = path.join(tempDir, "ipc.sock");
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-ipc-wait-snapshot-");
   let serverSocket = null;
 
   const server = net.createServer((socket) => {
@@ -644,8 +640,7 @@ test("desktop IPC follower waits for a usable snapshot when a first patch needs 
 });
 
 test("desktop IPC follower does not block add patch-only actions on a failing baseline reader", async (t) => {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-ipc-recovery-fallback-"));
-  const socketPath = path.join(tempDir, "ipc.sock");
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-ipc-recovery-fallback-");
   let serverSocket = null;
 
   const server = net.createServer((socket) => {
@@ -729,8 +724,7 @@ test("desktop IPC follower does not block add patch-only actions on a failing ba
 });
 
 test("desktop IPC follower answers client discovery requests as a passive client", async (t) => {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-ipc-discovery-"));
-  const socketPath = path.join(tempDir, "ipc.sock");
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-ipc-discovery-");
   const serverFrames = [];
   let serverSocket = null;
 
@@ -793,8 +787,7 @@ test("desktop IPC follower answers client discovery requests as a passive client
 });
 
 test("desktop IPC follower forwards pending actions and routes iOS replies back to the Mac", async (t) => {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-ipc-follower-"));
-  const socketPath = path.join(tempDir, "ipc.sock");
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-ipc-follower-");
   const serverFrames = [];
   let serverSocket = null;
 
@@ -928,4 +921,12 @@ async function waitFor(predicate, timeoutMs = 500) {
     }
     await wait(5);
   }
+}
+
+function createIpcTestSocket(prefix) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const socketPath = process.platform === "win32"
+    ? `\\\\.\\pipe\\${path.basename(tempDir)}-ipc`
+    : path.join(tempDir, "ipc.sock");
+  return { tempDir, socketPath };
 }

--- a/phodex-bridge/test/desktop-ipc-action-follower.test.js
+++ b/phodex-bridge/test/desktop-ipc-action-follower.test.js
@@ -18,6 +18,7 @@ const {
   desktopFollowerPayloadForResponse,
   projectDesktopAssistantDeltaNotifications,
   projectPendingDesktopActions,
+  resolveDefaultIpcSocketPath,
   seedConversationStateFromThreadRead,
 } = require("../src/desktop-ipc-action-follower");
 
@@ -375,6 +376,42 @@ test("projects only appended assistant text as live app-server deltas", () => {
   );
 });
 
+test("projects canonical desktop agentMessage items as live app-server deltas", () => {
+  const previousState = {
+    turns: [{
+      id: "turn-agent-message",
+      items: [{
+        id: "agent-message-1",
+        type: "agentMessage",
+        text: "Hello",
+      }],
+    }],
+  };
+  const nextState = {
+    turns: [{
+      id: "turn-agent-message",
+      items: [{
+        id: "agent-message-1",
+        type: "agentMessage",
+        text: "Hello world",
+      }],
+    }],
+  };
+
+  assert.deepEqual(
+    projectDesktopAssistantDeltaNotifications("thread-agent-message", previousState, nextState),
+    [{
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "thread-agent-message",
+        turnId: "turn-agent-message",
+        itemId: "agent-message-1",
+        delta: " world",
+      },
+    }]
+  );
+});
+
 test("does not replay unchanged or rewritten assistant text as live deltas", () => {
   const previousState = {
     turns: [{
@@ -415,6 +452,11 @@ test("does not replay unchanged or rewritten assistant text as live deltas", () 
     projectDesktopAssistantDeltaNotifications("thread-1", previousState, nextState),
     []
   );
+});
+
+test("uses the Codex Desktop named pipe as the default Windows IPC path", (t) => {
+  useProcessPlatform(t, "win32");
+  assert.equal(resolveDefaultIpcSocketPath(), "\\\\.\\pipe\\codex-ipc");
 });
 
 test("desktop IPC follower projects first add patch-only action updates without a baseline read", async (t) => {
@@ -1099,4 +1141,15 @@ function createIpcTestSocket(prefix) {
     ? `\\\\.\\pipe\\${path.basename(tempDir)}-ipc`
     : path.join(tempDir, "ipc.sock");
   return { tempDir, socketPath };
+}
+
+function useProcessPlatform(t, platform) {
+  const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", {
+    ...descriptor,
+    value: platform,
+  });
+  t.after(() => {
+    Object.defineProperty(process, "platform", descriptor);
+  });
 }

--- a/phodex-bridge/test/git-handler.test.js
+++ b/phodex-bridge/test/git-handler.test.js
@@ -28,6 +28,7 @@ function git(cwd, ...args) {
 function makeTempRepo() {
   const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-git-handler-"));
   git(repoDir, "init", "-b", "main");
+  git(repoDir, "config", "core.autocrlf", "false");
   git(repoDir, "config", "user.name", "Remodex Tests");
   git(repoDir, "config", "user.email", "tests@example.com");
   fs.writeFileSync(path.join(repoDir, "README.md"), "# Test\n");

--- a/phodex-bridge/test/macos-launch-agent.test.js
+++ b/phodex-bridge/test/macos-launch-agent.test.js
@@ -29,6 +29,8 @@ const {
   writePairingSession,
 } = require("../src/daemon-state");
 
+const TEST_UID = typeof process.getuid === "function" ? process.getuid() : 501;
+
 test("buildLaunchAgentPlist points launchd at run-service with remodex state paths", () => {
   const plist = buildLaunchAgentPlist({
     homeDir: "/Users/tester",
@@ -62,6 +64,7 @@ test("stopMacOSBridgeService clears stale pairing and status files", () => {
     writeBridgeStatus({ state: "running", connectionStatus: "connected" });
 
     stopMacOSBridgeService({
+      env: { ...process.env, UID: String(TEST_UID) },
       platform: "darwin",
       execFileSyncImpl() {
         const error = new Error("Could not find service");
@@ -81,6 +84,7 @@ test("stopMacOSBridgeService terminates the recorded run-service process when la
 
     const killed = [];
     stopMacOSBridgeService({
+      env: { ...process.env, UID: String(TEST_UID) },
       platform: "darwin",
       execFileSyncImpl(command, args) {
         if (command === "launchctl") {
@@ -112,6 +116,7 @@ test("stopMacOSBridgeService does not kill an unrelated stale pid", () => {
 
     const killed = [];
     stopMacOSBridgeService({
+      env: { ...process.env, UID: String(TEST_UID) },
       platform: "darwin",
       execFileSyncImpl(command) {
         if (command === "launchctl") {
@@ -140,10 +145,11 @@ test("stopMacOSBridgeService falls back to label bootout when plist bootout fail
     const calls = [];
 
     stopMacOSBridgeService({
+      env: { ...process.env, UID: String(TEST_UID) },
       platform: "darwin",
       execFileSyncImpl(command, args) {
         calls.push([command, args]);
-        if (args[1] === `gui/${process.getuid()}`) {
+        if (args[1] === `gui/${TEST_UID}`) {
           const error = new Error("Input/output error");
           error.stderr = Buffer.from("Bootstrap failed: 5: Input/output error");
           throw error;
@@ -156,7 +162,7 @@ test("stopMacOSBridgeService falls back to label bootout when plist bootout fail
         "launchctl",
         [
           "bootout",
-          `gui/${process.getuid()}`,
+          `gui/${TEST_UID}`,
           path.join(process.env.HOME, "Library", "LaunchAgents", "com.remodex.bridge.plist"),
         ],
       ],
@@ -164,7 +170,7 @@ test("stopMacOSBridgeService falls back to label bootout when plist bootout fail
         "launchctl",
         [
           "bootout",
-          `gui/${process.getuid()}/com.remodex.bridge`,
+          `gui/${TEST_UID}/com.remodex.bridge`,
         ],
       ],
     ]);
@@ -179,6 +185,7 @@ test("startMacOSBridgeService kickstarts the launch agent after bootstrap", () =
       HOME: rootDir,
       REMODEX_DEVICE_STATE_DIR: rootDir,
       REMODEX_RELAY: "ws://127.0.0.1:9000/relay",
+      UID: String(TEST_UID),
     };
 
     startMacOSBridgeService({
@@ -198,10 +205,10 @@ test("startMacOSBridgeService kickstarts the launch agent after bootstrap", () =
     assert.deepEqual(
       calls.map(([command, args]) => [command, args[0], args[1], args[2]]),
       [
-        ["launchctl", "bootout", `gui/${process.getuid()}`, path.join(rootDir, "Library", "LaunchAgents", "com.remodex.bridge.plist")],
-        ["launchctl", "bootout", `gui/${process.getuid()}/com.remodex.bridge`, undefined],
-        ["launchctl", "bootstrap", `gui/${process.getuid()}`, path.join(rootDir, "Library", "LaunchAgents", "com.remodex.bridge.plist")],
-        ["launchctl", "kickstart", "-k", `gui/${process.getuid()}/com.remodex.bridge`],
+        ["launchctl", "bootout", `gui/${TEST_UID}`, path.join(rootDir, "Library", "LaunchAgents", "com.remodex.bridge.plist")],
+        ["launchctl", "bootout", `gui/${TEST_UID}/com.remodex.bridge`, undefined],
+        ["launchctl", "bootstrap", `gui/${TEST_UID}`, path.join(rootDir, "Library", "LaunchAgents", "com.remodex.bridge.plist")],
+        ["launchctl", "kickstart", "-k", `gui/${TEST_UID}/com.remodex.bridge`],
       ]
     );
     assert.equal(readDaemonConfig({ env })?.extraRelaySessions, undefined);
@@ -248,6 +255,7 @@ test("resetMacOSBridgePairing stops the daemon before revoking persisted trust",
     let stopCalls = 0;
     let resetCalls = 0;
     const result = resetMacOSBridgePairing({
+      env: { ...process.env, UID: String(TEST_UID) },
       platform: "darwin",
       execFileSyncImpl() {
         stopCalls += 1;
@@ -274,7 +282,7 @@ test("runMacOSBridgeService records a clean error state instead of throwing when
     writePairingSession({ sessionId: "stale-session" });
 
     assert.doesNotThrow(() => {
-      runMacOSBridgeService({ env: process.env });
+      runMacOSBridgeService({ env: process.env, platform: "darwin" });
     });
 
     assert.equal(readPairingSession(), null);
@@ -366,7 +374,7 @@ test("getMacOSBridgeServiceStatus reports launchd + runtime metadata together", 
 
     const status = getMacOSBridgeServiceStatus({
       platform: "darwin",
-      env: { HOME: rootDir, REMODEX_DEVICE_STATE_DIR: rootDir },
+      env: { HOME: rootDir, REMODEX_DEVICE_STATE_DIR: rootDir, UID: String(TEST_UID) },
       execFileSyncImpl() {
         return "pid = 55";
       },

--- a/phodex-bridge/test/workspace-image.test.js
+++ b/phodex-bridge/test/workspace-image.test.js
@@ -43,6 +43,16 @@ function writeFakeSips(fakeBinDir, scriptContent) {
   }
 }
 
+function writeFakePowerShell(fakeBinDir, scriptContent) {
+  if (IS_WINDOWS_HOST) {
+    return;
+  }
+
+  const scriptPath = path.join(fakeBinDir, "powershell.exe");
+  fs.writeFileSync(scriptPath, scriptContent);
+  fs.chmodSync(scriptPath, 0o755);
+}
+
 test("workspace/readImage returns base64 image data for a file inside cwd", async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-image-"));
   execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
@@ -128,6 +138,37 @@ test("workspace/readImage accepts bounded preview reads", async () => {
 test("workspace/readImage ignores client platform fields for non-mac preview decisions", async (t) => {
   useProcessPlatform(t, "win32");
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-image-"));
+  const fakeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-fake-powershell-"));
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${fakeBinDir}${path.delimiter}${previousPath || ""}`;
+  t.after(() => {
+    if (previousPath == null) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = previousPath;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(fakeBinDir, { recursive: true, force: true });
+  });
+
+  writeFakePowerShell(
+    fakeBinDir,
+    `#!/usr/bin/env node
+const fs = require("fs");
+const fileIndex = process.argv.indexOf("-File");
+if (fileIndex === -1) {
+  throw new Error("Expected -File invocation");
+}
+const inputPath = process.argv[fileIndex + 2];
+const outputPath = process.argv[fileIndex + 3];
+const maxDimension = Number(process.argv[fileIndex + 4]);
+if (!inputPath || !outputPath || !Number.isFinite(maxDimension)) {
+  throw new Error("Expected -File <script> <input> <output> <maxDimension>");
+}
+fs.copyFileSync(inputPath, outputPath);
+`
+  );
+
   execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
   const imagePath = path.join(tempDir, "preview.png");
   fs.writeFileSync(imagePath, validOnePixelPNG);

--- a/phodex-bridge/test/workspace-image.test.js
+++ b/phodex-bridge/test/workspace-image.test.js
@@ -16,6 +16,7 @@ const validOnePixelPNG = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
   "base64"
 );
+const IS_WINDOWS_HOST = path.delimiter === ";";
 
 function useProcessPlatform(t, platform) {
   const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
@@ -26,6 +27,20 @@ function useProcessPlatform(t, platform) {
   t.after(() => {
     Object.defineProperty(process, "platform", descriptor);
   });
+}
+
+function writeFakeSips(fakeBinDir, scriptContent) {
+  const scriptPath = path.join(fakeBinDir, "sips");
+  fs.writeFileSync(scriptPath, scriptContent);
+  fs.chmodSync(scriptPath, 0o755);
+
+  if (IS_WINDOWS_HOST) {
+    fs.writeFileSync(path.join(fakeBinDir, "sips.js"), scriptContent);
+    fs.writeFileSync(
+      path.join(fakeBinDir, "sips.cmd"),
+      `@echo off\r\nnode "%~dp0sips.js" %*\r\n`
+    );
+  }
 }
 
 test("workspace/readImage returns base64 image data for a file inside cwd", async () => {
@@ -127,7 +142,9 @@ test("workspace/readImage ignores client platform fields for non-mac preview dec
   });
 
   assert.equal(result.previewMaxPixelDimension, 1600);
-  assert.equal(Buffer.from(result.dataBase64, "base64").length, validOnePixelPNG.length);
+  const previewLength = Buffer.from(result.dataBase64, "base64").length;
+  assert.ok(previewLength > 0);
+  assert.ok(previewLength <= 2 * 1024 * 1024);
 });
 
 test("workspace/readImage retries smaller previews when the first preview is still too large", async (t) => {
@@ -147,9 +164,8 @@ test("workspace/readImage retries smaller previews when the first preview is sti
     fs.rmSync(fakeBinDir, { recursive: true, force: true });
   });
 
-  const fakeSipsPath = path.join(fakeBinDir, "sips");
-  fs.writeFileSync(
-    fakeSipsPath,
+  writeFakeSips(
+    fakeBinDir,
     `#!/usr/bin/env node
 const fs = require("fs");
 const validOnePixelPNG = Buffer.from("${validOnePixelPNG.toString("base64")}", "base64");
@@ -159,7 +175,6 @@ fs.appendFileSync(${JSON.stringify(fakeSipsLog)}, String(dimension) + "\\n");
 fs.writeFileSync(outputPath, dimension > 512 ? Buffer.alloc(2 * 1024 * 1024 + 1) : validOnePixelPNG);
 `
   );
-  fs.chmodSync(fakeSipsPath, 0o755);
 
   execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
   const imagePath = path.join(tempDir, "preview.png");
@@ -194,9 +209,8 @@ test("workspace/readImage stops preview retries when sips times out", async (t) 
     fs.rmSync(fakeBinDir, { recursive: true, force: true });
   });
 
-  const fakeSipsPath = path.join(fakeBinDir, "sips");
-  fs.writeFileSync(
-    fakeSipsPath,
+  writeFakeSips(
+    fakeBinDir,
     `#!/usr/bin/env node
 const fs = require("fs");
 const dimension = Number(process.argv[process.argv.indexOf("-Z") + 1]);
@@ -204,7 +218,6 @@ fs.appendFileSync(${JSON.stringify(fakeSipsLog)}, String(dimension) + "\\n");
 setTimeout(() => {}, 30_000);
 `
   );
-  fs.chmodSync(fakeSipsPath, 0o755);
 
   execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
   const imagePath = path.join(tempDir, "preview.png");

--- a/relay/push-service.test.js
+++ b/relay/push-service.test.js
@@ -185,7 +185,9 @@ test("push service reloads registrations from persisted state after a restart", 
 
   assert.equal(firstSent.length, 0);
   assert.equal(secondSent.length, 1);
-  assert.equal(fs.statSync(stateFilePath).mode & 0o777, 0o600);
+  if (process.platform !== "win32") {
+    assert.equal(fs.statSync(stateFilePath).mode & 0o777, 0o600);
+  }
 });
 
 test("push service defaults to a durable state file in the remodex home dir", () => {
@@ -193,7 +195,7 @@ test("push service defaults to a durable state file in the remodex home dir", ()
     CODEX_HOME: "/tmp/codex-home",
   });
 
-  assert.equal(resolved, "/tmp/codex-home/remodex/push-state.json");
+  assert.equal(resolved, path.join("/tmp/codex-home", "remodex", "push-state.json"));
 });
 
 test("push service keeps working when state persistence fails", async () => {


### PR DESCRIPTION
## Summary
- add the missing Windows compatibility pieces needed by the local bridge runtime
- make Desktop IPC tests work on Windows named pipes instead of assuming Unix sockets
- mirror live assistant text growth from Codex Desktop IPC so phones receive realtime message deltas, not only approval/request events

## What changed
- pass the platform through Codex transport launch planning so Windows launch behavior is testable and explicit
- support native image preview downsampling on Windows via PowerShell while keeping the existing macOS `sips` path
- resolve host command shims on Windows and keep preview subprocesses hidden
- make rollout candidate ordering deterministic when mtimes tie
- harden macOS launch-agent and related tests around cross-platform command handling
- update Desktop IPC and relay push-service tests for Windows-safe socket handling
- project appended assistant text from Desktop IPC conversation-state changes into `item/agentMessage/delta`

## Why
The bridge already worked well on macOS, but several assumptions were Unix-specific: socket paths, image preview tooling, and command discovery. Those assumptions prevent the same local workflow from behaving reliably on Windows.

Desktop-started turns also exposed a live-sync gap: Desktop IPC mirrored pending approvals in realtime, while assistant messages only appeared after the final persisted transcript update. Projecting suffix growth from live conversation-state patches closes that gap without inventing transcript data or changing final-message handling.

## Impact
- local bridge flows are usable on Windows without special-case setup
- image previews keep working across macOS and Windows
- IPC tests are portable across platforms
- phones can render assistant text in realtime for desktop-started turns instead of showing only shimmer until completion

## Validation
- `node --test phodex-bridge/test/desktop-ipc-action-follower.test.js`
- `node --test phodex-bridge/test/bridge-desktop-ipc-integration.test.js`