### PR TITLE
Add lock screen widget for Remodex projects control

### DIFF
--- a/CodexMobile/CodexMobile/CodexMobileApp.swift
+++ b/CodexMobile/CodexMobile/CodexMobileApp.swift
@@ -6,6 +6,10 @@
 import RevenueCat
 import SwiftUI
 
+extension Notification.Name {
+    static let remodexOpenProjects = Notification.Name("remodex.openProjects")
+}
+
 @MainActor
 @main
 struct CodexMobileApp: App {
@@ -38,7 +42,11 @@ struct CodexMobileApp: App {
                 }
                 .onOpenURL { url in
                     Task { @MainActor in
-                        guard CodexService.legacyGPTLoginCallbackEnabled else {
+                        if handleAppOpenURL(url) {
+                            return
+                        }
+                        guard CodexService.legacyGPTLoginCallbackEnabled,
+                              codexService.isExpectedGPTLoginCallbackURL(url) else {
                             return
                         }
                         await codexService.handleGPTLoginCallbackURL(url)
@@ -56,6 +64,22 @@ struct CodexMobileApp: App {
                     TurnCacheManager.resetAll()
                 }
         }
+    }
+
+    private func handleAppOpenURL(_ url: URL) -> Bool {
+        guard url.scheme?.caseInsensitiveCompare("phodex") == .orderedSame else {
+            return false
+        }
+
+        let host = url.host?.lowercased()
+        let path = url.path.lowercased()
+        guard host == "open",
+              path.isEmpty || path == "/" || path == "/projects" else {
+            return false
+        }
+
+        NotificationCenter.default.post(name: .remodexOpenProjects, object: nil)
+        return true
     }
 
     // Configures RevenueCat once at launch using the client-safe public SDK key.

--- a/CodexMobile/CodexMobile/ContentView.swift
+++ b/CodexMobile/CodexMobile/ContentView.swift
@@ -146,6 +146,9 @@ struct ContentView: View {
                 syncSelectedThread(with: threads)
                 scheduleSidebarPrewarmIfNeeded()
             }
+            .onReceive(NotificationCenter.default.publisher(for: .remodexOpenProjects)) { _ in
+                presentProjectListFromExternalOpen()
+            }
             .onChange(of: scenePhase) { _, phase in
                 debugSidebarLog("scenePhase changed phase=\(String(describing: phase))")
                 codex.setForegroundState(phase != .background)
@@ -1041,6 +1044,24 @@ struct ContentView: View {
             closeSidebar()
         }
         isShowingSettingsCover = true
+    }
+
+    private func presentProjectListFromExternalOpen() {
+        isOpeningNewChatFromSidebar = false
+        isSearchActive = false
+        selectedThread = nil
+        codex.activeThreadId = nil
+
+        if shouldPresentSidebarAsNavigation {
+            navigationPath.removeAll()
+            requestSidebarFreshSyncIfNeeded()
+            return
+        }
+
+        requestSidebarFreshSyncIfNeeded()
+        if !isSidebarOpen {
+            setSidebar(open: true)
+        }
     }
 
     // Prevents a close-swipe release from also activating whichever sidebar row was under the finger.

--- a/CodexMobile/RemodexWidget/RemodexControlCenterWidget.swift
+++ b/CodexMobile/RemodexWidget/RemodexControlCenterWidget.swift
@@ -9,20 +9,19 @@ import AppIntents
 import SwiftUI
 import WidgetKit
 
+private let remodexProjectsURL = URL(string: "phodex://open/projects")!
+
 @available(iOS 18.0, *)
 struct RemodexLaunchControl: ControlWidget {
-    static let kind = "com.emanueledipietro.Remodex.RemodexWidget.LaunchControl.v9"
+    static let kind = "com.emanueledipietro.Remodex.RemodexWidget.ProjectsControl.v10"
 
     var body: some ControlWidgetConfiguration {
         StaticControlConfiguration(kind: Self.kind) {
-            ControlWidgetButton(action: RemodexLaunchIntent()) {
-                // Control Center only accepts symbol images. This custom SF
-                // Symbol uses the unmodified SF Symbols template from
-                // SwiftDraw; manual scaling can make iOS render it as blank.
-                Label("Remodex", image: "remodex_symbol_medium")
+            ControlWidgetButton(action: OpenURLIntent(remodexProjectsURL)) {
+                Label("Remodex Projects", image: "remodex_control_symbol")
             }
         }
-        .displayName("Remodex")
-        .description("Launch Remodex from Control Center.")
+        .displayName("Remodex Projects")
+        .description("Open the Remodex project list from the lock screen.")
     }
 }


### PR DESCRIPTION
## Summary

Adds a small iOS lock screen / Controls Gallery launcher for Remodex that opens directly to the project list/sidebar view.

Fixes #135.

## What changed

- Updates the Remodex control widget to use the existing widget-safe Remodex symbol asset.
- Routes the control through `phodex://open/projects`.
- Handles that deep link in the app by clearing active thread navigation and presenting the project list/sidebar.

## Scope

This stays intentionally narrow: no live widget data, no thread previews, no connection state, and no background network work in the widget.

## Validation

- Rebased on latest `upstream/main`.
- Built and launched `CodexMobile` on the `iPhone 17 Pro Max` simulator with XcodeBuildMCP.
- Build succeeded; remaining warnings are pre-existing Swift isolation warnings outside this change.

## Screenshot

<details>
<summary>iPhone simulator screenshots</summary>

<img width="466" height="206" alt="Screenshot 2026-05-18 at 12 11 25 AM" src="https://github.com/user-attachments/assets/497b5af3-be4c-4f6d-b72e-3c768699808a" />
<img width="416" height="278" alt="Screenshot 2026-05-18 at 12 11 09 AM" src="https://github.com/user-attachments/assets/26ba491f-7626-447f-98b6-9a7f441f1ead" />

</details>
