### PR TITLE
Honor REMODEX_ALLOWED_ROOTS env var for project picker

### DIFF
--- a/phodex-bridge/src/project-handler.js
+++ b/phodex-bridge/src/project-handler.js
@@ -493,9 +493,16 @@ function isPathAllowed(candidatePath, options = {}) {
 }
 
 function allowedProjectRoots(options = {}) {
+  const envRoots = (process.env.REMODEX_ALLOWED_ROOTS || "")
+    .split(":")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
   const roots = Array.isArray(options.allowedRoots) && options.allowedRoots.length
     ? options.allowedRoots
-    : [resolveHomeDir(options)];
+    : envRoots.length
+      ? envRoots
+      : [resolveHomeDir(options)];
 
   return [...new Set(roots.flatMap((rootPath) => {
     const resolvedRoot = path.resolve(rootPath);


### PR DESCRIPTION
## Summary

The phodex-bridge project picker currently hardcodes the iOS file browser root to `os.homedir()`. For Linux self-host setups (especially under a non-default account such as `root`, where `os.homedir()` resolves to `/root`), the picker therefore cannot reach the user's actual project directories.

This change adds an opt-in env var **`REMODEX_ALLOWED_ROOTS`** that, when set, overrides the default. Paths are colon-separated, matching the `$PATH` convention.

When `REMODEX_ALLOWED_ROOTS` is unset or empty, behavior is **unchanged** — still falls back to `resolveHomeDir(options)`.

## Why this is useful

`Docs/self-hosting.md` explicitly invites Linux/VPS self-host setups. Without this hook, the iOS file picker on those installs only shows the runtime user's home dir, which is rarely where projects live (e.g. on Debian root-managed installs they are usually under `/home/<user>` or `/opt`).

## Diff

```js
function allowedProjectRoots(options = {}) {
  const envRoots = (process.env.REMODEX_ALLOWED_ROOTS || "")
    .split(":")
    .map((entry) => entry.trim())
    .filter(Boolean);

  const roots = Array.isArray(options.allowedRoots) && options.allowedRoots.length
    ? options.allowedRoots
    : envRoots.length
      ? envRoots
      : [resolveHomeDir(options)];
  ...
}
```

5 lines added, 1 line moved into a ternary. No new imports.

## Example usage

```sh
REMODEX_ALLOWED_ROOTS=/home:/srv remodex up
# or in a systemd unit
Environment=REMODEX_ALLOWED_ROOTS=/home
```

The existing `options.allowedRoots` precedence is preserved (callers can still inject roots programmatically and the env var only fills in when no explicit roots are provided), so existing tests and Mac defaults are unaffected.

## Test plan

- [x] Default behavior (no env var): file picker still resolves to `os.homedir()` — verified locally
- [x] Env var set (`REMODEX_ALLOWED_ROOTS=/home`): picker shows `/home` and descendants
- [x] Env var with multiple roots (`/home:/srv`): both visible
- [x] Empty env var (`REMODEX_ALLOWED_ROOTS=""`): falls back to homedir as before

## Notes

- I'm aware CONTRIBUTING.md prefers an issue first for non-trivial changes. The diff is 5 lines, fully backward-compatible, and only adds an opt-in env var — I felt it was small enough to come straight as a PR. Happy to convert into an issue first if you'd prefer.
- Colon was chosen for `$PATH`-style consistency on Unix. If you'd rather use `path.delimiter` for cross-platform symmetry (Windows would then use `;`) I can amend in a heartbeat.