### PR TITLE
feat: add Claude Code harness and provider model selector

### DIFF
--- a/CodexMobile/BuildSupport/CodexMobile-Info.plist
+++ b/CodexMobile/BuildSupport/CodexMobile-Info.plist
@@ -37,10 +37,10 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSCameraUsageDescription</key>
-	<string>Remodex needs camera access to let you take photos and attach them to your messages.</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
@@ -48,30 +48,30 @@
 		<key>NSAllowsArbitraryLoadsInLocalNetworking</key>
 		<true/>
 	</dict>
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>CodexMobile needs local network access to connect to your Codex app-server running on your Mac.</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>Remodex needs microphone access to record voice notes for ChatGPT transcription.</string>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_remodex-permission._tcp</string>
 	</array>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>CodexMobile needs photo library access to let you attach images to your messages.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Remodex needs camera access to let you take photos and attach them to your messages.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>CodexMobile needs local network access to connect to your Codex app-server running on your Mac.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Remodex needs microphone access to record voice notes for ChatGPT transcription.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Remodex needs photo library access to let you save rendered diagrams and attachments.</string>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>CodexMobile needs photo library access to let you attach images to your messages.</string>
 	<key>PHODEX_CHATGPT_CALLBACK_SCHEME</key>
 	<string>$(PHODEX_CHATGPT_CALLBACK_SCHEME)</string>
 	<key>PHODEX_DEFAULT_RELAY_URL</key>
 	<string>$(PHODEX_DEFAULT_RELAY_URL)</string>
-	<key>REVENUECAT_PUBLIC_API_KEY</key>
-	<string>$(REVENUECAT_PUBLIC_API_KEY)</string>
-	<key>REVENUECAT_ENTITLEMENT_NAME</key>
-	<string>$(REVENUECAT_ENTITLEMENT_NAME)</string>
 	<key>REVENUECAT_DEFAULT_OFFERING_ID</key>
 	<string>$(REVENUECAT_DEFAULT_OFFERING_ID)</string>
+	<key>REVENUECAT_ENTITLEMENT_NAME</key>
+	<string>$(REVENUECAT_ENTITLEMENT_NAME)</string>
+	<key>REVENUECAT_PUBLIC_API_KEY</key>
+	<string>$(REVENUECAT_PUBLIC_API_KEY)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>JetBrainsMono-Regular.ttf</string>

--- a/CodexMobile/CodexMobile/Models/CodexModelOption.swift
+++ b/CodexMobile/CodexMobile/Models/CodexModelOption.swift
@@ -9,6 +9,7 @@ import Foundation
 struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
     let id: String
     let model: String
+    let modelProvider: String
     let displayName: String
     let description: String
     let isDefault: Bool
@@ -19,6 +20,7 @@ struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
     init(
         id: String,
         model: String,
+        modelProvider: String = "codex",
         displayName: String,
         description: String,
         isDefault: Bool,
@@ -28,6 +30,7 @@ struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
     ) {
         self.id = id
         self.model = model
+        self.modelProvider = Self.normalizedProvider(modelProvider)
         self.displayName = displayName
         self.description = description
         self.isDefault = isDefault
@@ -41,6 +44,12 @@ struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
         case model
         case slug
         case name
+        case provider
+        case modelProvider
+        case modelProviderSnake = "model_provider"
+        case runtimeProvider
+        case runtimeProviderSnake = "runtime_provider"
+        case harness
         case displayName
         case displayNameSnake = "display_name"
         case description
@@ -68,6 +77,19 @@ struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
         let idValue = try container.decodeIfPresent(String.self, forKey: .id)
         let rawModel = modelValue ?? slugValue ?? idValue ?? ""
         let normalizedModel = rawModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let modelProviderValue = try container.decodeIfPresent(String.self, forKey: .modelProvider)
+        let modelProviderSnakeValue = try container.decodeIfPresent(String.self, forKey: .modelProviderSnake)
+        let providerValue = try container.decodeIfPresent(String.self, forKey: .provider)
+        let runtimeProviderValue = try container.decodeIfPresent(String.self, forKey: .runtimeProvider)
+        let runtimeProviderSnakeValue = try container.decodeIfPresent(String.self, forKey: .runtimeProviderSnake)
+        let harnessValue = try container.decodeIfPresent(String.self, forKey: .harness)
+        let rawProvider = modelProviderValue
+            ?? modelProviderSnakeValue
+            ?? providerValue
+            ?? runtimeProviderValue
+            ?? runtimeProviderSnakeValue
+            ?? harnessValue
+            ?? "codex"
 
         let rawID = idValue ?? slugValue ?? normalizedModel
 
@@ -105,6 +127,7 @@ struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
 
         id = normalizedID.isEmpty ? normalizedModel : normalizedID
         model = normalizedModel
+        modelProvider = Self.normalizedProvider(rawProvider)
         displayName = normalizedDisplayName.isEmpty ? normalizedModel : normalizedDisplayName
         description = rawDescription.trimmingCharacters(in: .whitespacesAndNewlines)
         isDefault = camelDefaultFlag ?? snakeDefaultFlag ?? false
@@ -161,12 +184,46 @@ struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
         try container.encode(model, forKey: .model)
+        try container.encode(modelProvider, forKey: .modelProvider)
         try container.encode(displayName, forKey: .displayName)
         try container.encode(description, forKey: .description)
         try container.encode(isDefault, forKey: .isDefault)
         try container.encode(supportsFastMode, forKey: .supportsFastMode)
         try container.encode(supportedReasoningEfforts, forKey: .supportedReasoningEfforts)
         try container.encodeIfPresent(defaultReasoningEffort, forKey: .defaultReasoningEffort)
+    }
+
+    var selectionKey: String {
+        Self.selectionKey(provider: modelProvider, modelId: id)
+    }
+
+    static func selectionKey(provider: String?, modelId: String?) -> String {
+        let normalizedProvider = normalizedProvider(provider)
+        let normalizedModelID = modelId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return normalizedModelID.isEmpty ? "\(normalizedProvider):" : "\(normalizedProvider):\(normalizedModelID)"
+    }
+
+    static func normalizedProvider(_ value: String?) -> String {
+        let normalized = value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        switch normalized {
+        case "claude-code", "claudecode":
+            return "claude"
+        case "":
+            return "codex"
+        default:
+            return normalized
+        }
+    }
+
+    static func splitSelectionKey(_ value: String?) -> (provider: String, modelId: String?) {
+        let normalized = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard let separatorIndex = normalized.firstIndex(of: ":") else {
+            return (normalizedProvider(nil), normalized.isEmpty ? nil : normalized)
+        }
+        let provider = String(normalized[..<separatorIndex])
+        let modelStart = normalized.index(after: separatorIndex)
+        let modelId = String(normalized[modelStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return (normalizedProvider(provider), modelId.isEmpty ? nil : modelId)
     }
 }
 

--- a/CodexMobile/CodexMobile/Services/CodexService+RuntimeConfig.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+RuntimeConfig.swift
@@ -18,7 +18,9 @@ private enum RuntimeConfigLoadingPolicy {
 }
 
 private enum RuntimeSelectionDefaults {
+    static let provider = "codex"
     static let modelId = "gpt-5.5"
+    static let selectionKey = CodexModelOption.selectionKey(provider: provider, modelId: modelId)
     static let reasoningEffort = "medium"
 
     static func reasoningEffort(for unresolvedModelId: String?) -> String? {
@@ -111,7 +113,7 @@ extension CodexService {
         if normalized?.isEmpty == false {
             selectedModelId = normalized
         } else {
-            selectedModelId = RuntimeSelectionDefaults.modelId
+            selectedModelId = RuntimeSelectionDefaults.selectionKey
             selectedReasoningEffort = RuntimeSelectionDefaults.reasoningEffort
         }
         hasPersistedSelectedModelId = true
@@ -186,6 +188,30 @@ extension CodexService {
         }
     }
 
+    func setThreadModelOverride(_ model: CodexModelOption, for threadId: String?) {
+        guard let normalizedThreadID = normalizedInterruptIdentifier(threadId) else {
+            return
+        }
+
+        mutateThreadRuntimeOverride(for: normalizedThreadID) { override in
+            override.modelId = model.id
+            override.modelProvider = model.modelProvider
+            override.overridesModel = true
+        }
+    }
+
+    func clearThreadModelOverride(for threadId: String?) {
+        guard let normalizedThreadID = normalizedInterruptIdentifier(threadId) else {
+            return
+        }
+
+        mutateThreadRuntimeOverride(for: normalizedThreadID) { override in
+            override.modelId = nil
+            override.modelProvider = nil
+            override.overridesModel = false
+        }
+    }
+
     func applyThreadRuntimeOverride(_ runtimeOverride: CodexThreadRuntimeOverride?, to threadId: String?) {
         guard let normalizedThreadID = normalizedInterruptIdentifier(threadId) else {
             return
@@ -210,10 +236,46 @@ extension CodexService {
         selectedModelOption(from: availableModels)
     }
 
+    func modelOption(forSelectionKey selectionKey: String?) -> CodexModelOption? {
+        let normalized = selectionKey?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !normalized.isEmpty else {
+            return nil
+        }
+        return availableModels.first(where: {
+            $0.selectionKey == normalized || $0.id == normalized || $0.model == normalized
+        })
+    }
+
+    func selectedModelOption(threadId: String?) -> CodexModelOption? {
+        if let threadOverride = threadRuntimeOverride(for: threadId),
+           threadOverride.overridesModel,
+           let modelId = threadOverride.modelId,
+           let directMatch = availableModels.first(where: {
+               $0.selectionKey == CodexModelOption.selectionKey(
+                   provider: threadOverride.modelProvider,
+                   modelId: modelId
+               )
+               || ($0.id == modelId && $0.modelProvider == CodexModelOption.normalizedProvider(threadOverride.modelProvider))
+               || ($0.model == modelId && $0.modelProvider == CodexModelOption.normalizedProvider(threadOverride.modelProvider))
+           }) {
+            return directMatch
+        }
+        if let normalizedThreadID = normalizedInterruptIdentifier(threadId),
+           let thread = threadByID[normalizedThreadID],
+           let threadModel = thread.model,
+           let directMatch = availableModels.first(where: {
+               $0.modelProvider == CodexModelOption.normalizedProvider(thread.modelProvider)
+                   && ($0.id == threadModel || $0.model == threadModel)
+           }) {
+            return directMatch
+        }
+        return selectedModelOption()
+    }
+
     // Composer chrome should not present the canonical fallback as a loaded user choice.
-    func visibleSelectedModelIDForComposer() -> String? {
-        if let selectedModel = selectedModelOption() {
-            return selectedModel.id
+    func visibleSelectedModelIDForComposer(threadId: String? = nil) -> String? {
+        if let selectedModel = selectedModelOption(threadId: threadId) {
+            return selectedModel.selectionKey
         }
 
         guard hasPersistedSelectedModelId else {
@@ -239,8 +301,8 @@ extension CodexService {
         selectedGitWriterModelOption(from: availableModels)
     }
 
-    func selectedModelSupportsServiceTier(_ serviceTier: CodexServiceTier) -> Bool {
-        selectedModelOption()?.supportsServiceTier(serviceTier) == true
+    func selectedModelSupportsServiceTier(_ serviceTier: CodexServiceTier, threadId: String? = nil) -> Bool {
+        selectedModelOption(threadId: threadId)?.supportsServiceTier(serviceTier) == true
     }
 
     func gitWriterModelIdentifier() -> String? {
@@ -248,7 +310,11 @@ extension CodexService {
     }
 
     func supportedReasoningEffortsForSelectedModel() -> [CodexReasoningEffortOption] {
-        selectedModelOption()?.supportedReasoningEfforts ?? []
+        supportedReasoningEffortsForSelectedModel(threadId: nil)
+    }
+
+    func supportedReasoningEffortsForSelectedModel(threadId: String?) -> [CodexReasoningEffortOption] {
+        selectedModelOption(threadId: threadId)?.supportedReasoningEfforts ?? []
     }
 
     func isThreadReasoningEffortOverridden(_ threadId: String?) -> Bool {
@@ -259,7 +325,7 @@ extension CodexService {
         }
 
         let supportedReasoningEfforts = Set(
-            supportedReasoningEffortsForSelectedModel().map(\.reasoningEffort)
+            supportedReasoningEffortsForSelectedModel(threadId: threadId).map(\.reasoningEffort)
         )
         return supportedReasoningEfforts.contains(selectedReasoning)
     }
@@ -269,8 +335,8 @@ extension CodexService {
     }
 
     func selectedReasoningEffortForSelectedModel(threadId: String? = nil) -> String? {
-        guard let model = selectedModelOption() else {
-            return RuntimeSelectionDefaults.reasoningEffort(for: selectedModelId)
+        guard let model = selectedModelOption(threadId: threadId) else {
+            return RuntimeSelectionDefaults.reasoningEffort(for: runtimeModelIdentifierForTurn(threadId: threadId))
                 ?? selectedReasoningEffort
                 ?? RuntimeSelectionDefaults.reasoningEffort
         }
@@ -304,8 +370,19 @@ extension CodexService {
         return model.supportedReasoningEfforts.first?.reasoningEffort
     }
 
-    func runtimeModelIdentifierForTurn() -> String? {
-        selectedModelOption()?.model ?? selectedModelId ?? RuntimeSelectionDefaults.modelId
+    func runtimeModelIdentifierForTurn(threadId: String? = nil) -> String? {
+        if let selectedModel = selectedModelOption(threadId: threadId) {
+            return selectedModel.model
+        }
+        let splitSelection = CodexModelOption.splitSelectionKey(selectedModelId)
+        return splitSelection.modelId ?? RuntimeSelectionDefaults.modelId
+    }
+
+    func runtimeModelProviderForTurn(threadId: String? = nil) -> String {
+        if let selectedModel = selectedModelOption(threadId: threadId) {
+            return selectedModel.modelProvider
+        }
+        return CodexModelOption.splitSelectionKey(selectedModelId).provider
     }
 
     func effectiveServiceTier(for threadId: String? = nil) -> CodexServiceTier? {
@@ -320,7 +397,7 @@ extension CodexService {
         guard let candidate else {
             return nil
         }
-        return selectedModelSupportsServiceTier(candidate) ? candidate : nil
+        return selectedModelSupportsServiceTier(candidate, threadId: threadId) ? candidate : nil
     }
 
     func runtimeServiceTierForTurn(threadId: String? = nil) -> String? {
@@ -488,7 +565,8 @@ private extension CodexService {
         }
 
         let normalizedSelection = selectedModelId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return normalizedSelection == RuntimeSelectionDefaults.modelId
+        return (normalizedSelection == RuntimeSelectionDefaults.modelId
+            || normalizedSelection == RuntimeSelectionDefaults.selectionKey)
             && (isBootstrappingConnectionSync || isLoadingModels)
     }
 
@@ -498,8 +576,11 @@ private extension CodexService {
         mutate: (inout CodexThreadRuntimeOverride) -> Void
     ) {
         var currentOverride = threadRuntimeOverridesByThreadID[threadId] ?? CodexThreadRuntimeOverride(
+            modelId: nil,
+            modelProvider: nil,
             reasoningEffort: nil,
             serviceTierRawValue: nil,
+            overridesModel: false,
             overridesReasoning: false,
             overridesServiceTier: false
         )
@@ -521,7 +602,9 @@ private extension CodexService {
         }
 
         if let selectedModelId,
-           let directMatch = models.first(where: { $0.id == selectedModelId || $0.model == selectedModelId }) {
+           let directMatch = models.first(where: {
+               $0.selectionKey == selectedModelId || $0.id == selectedModelId || $0.model == selectedModelId
+           }) {
             return directMatch
         }
 
@@ -538,26 +621,34 @@ private extension CodexService {
 
         let savedSelection = explicitModelId ?? selectedGitWriterModelId
         if let savedSelection,
-           let directMatch = models.first(where: { $0.id == savedSelection || $0.model == savedSelection }) {
+           let directMatch = models.first(where: {
+               $0.modelProvider == RuntimeSelectionDefaults.provider
+                   && ($0.selectionKey == savedSelection || $0.id == savedSelection || $0.model == savedSelection)
+           }) {
             return directMatch
         }
 
-        if let miniModel = models.first(where: { $0.id == "gpt-5.4-mini" || $0.model == "gpt-5.4-mini" }) {
+        if let miniModel = models.first(where: {
+            $0.modelProvider == RuntimeSelectionDefaults.provider
+                && ($0.id == "gpt-5.4-mini" || $0.model == "gpt-5.4-mini")
+        }) {
             return miniModel
         }
 
-        if let runtimeSelected = selectedModelOption(from: models) {
+        if let runtimeSelected = selectedModelOption(from: models),
+           runtimeSelected.modelProvider == RuntimeSelectionDefaults.provider {
             return runtimeSelected
         }
 
-        return fallbackModel(from: models)
+        return fallbackModel(from: models.filter { $0.modelProvider == RuntimeSelectionDefaults.provider })
     }
 
     func fallbackModel(from models: [CodexModelOption]) -> CodexModelOption? {
         // Prefer GPT-5.5 when the bridge advertises it; the rest of the app treats
         // it as the canonical default regardless of the bridge's `isDefault` flag.
         if let preferred = models.first(where: {
-            $0.id.lowercased() == "gpt-5.5" || $0.model.lowercased() == "gpt-5.5"
+            $0.modelProvider == RuntimeSelectionDefaults.provider
+                && ($0.id.lowercased() == "gpt-5.5" || $0.model.lowercased() == "gpt-5.5")
         }) {
             return preferred
         }
@@ -621,7 +712,7 @@ extension CodexService {
         }
 
         let resolvedModel = selectedModelOption(from: availableModels) ?? fallbackModel(from: availableModels)
-        selectedModelId = resolvedModel?.id
+        selectedModelId = resolvedModel?.selectionKey
         hasPersistedSelectedModelId = resolvedModel != nil
 
         if let resolvedModel {
@@ -651,7 +742,9 @@ extension CodexService {
 
         if let selectedGitWriterModelId,
            !availableModels.contains(where: {
-               $0.id == selectedGitWriterModelId || $0.model == selectedGitWriterModelId
+               $0.selectionKey == selectedGitWriterModelId
+                   || $0.id == selectedGitWriterModelId
+                   || $0.model == selectedGitWriterModelId
            }) {
             self.selectedGitWriterModelId = nil
         }

--- a/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
@@ -131,11 +131,18 @@ extension CodexService {
         let explicitServiceTier = runtimeOverride?.overridesServiceTier == true
             ? normalizedServiceTierForSelectedModel(runtimeOverride?.serviceTier)?.rawValue
             : runtimeServiceTierForTurn()
+        let explicitModelIdentifier = runtimeOverride?.overridesModel == true
+            ? runtimeOverride?.modelId
+            : runtimeModelIdentifierForTurn()
+        let explicitModelProvider = runtimeOverride?.overridesModel == true
+            ? CodexModelOption.normalizedProvider(runtimeOverride?.modelProvider)
+            : runtimeModelProviderForTurn()
         var includesServiceTier = explicitServiceTier != nil
 
         while true {
             let params = CodexThreadStartProjectBinding.makeThreadStartParams(
-                modelIdentifier: runtimeModelIdentifierForTurn(),
+                modelIdentifier: explicitModelIdentifier,
+                modelProvider: explicitModelProvider,
                 preferredProjectPath: normalizedPreferredProjectPath,
                 serviceTier: includesServiceTier ? explicitServiceTier : nil
             )
@@ -817,6 +824,7 @@ enum CodexThreadStartProjectBinding {
 
     static func makeThreadStartParams(
         modelIdentifier: String?,
+        modelProvider: String?,
         preferredProjectPath: String?,
         serviceTier: String?
     ) -> RPCObject {
@@ -824,6 +832,10 @@ enum CodexThreadStartProjectBinding {
 
         if let modelIdentifier {
             params["model"] = .string(modelIdentifier)
+        }
+        if let modelProvider,
+           !modelProvider.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            params["modelProvider"] = .string(modelProvider)
         }
 
         if let preferredProjectPath {
@@ -2068,9 +2080,10 @@ extension CodexService {
         ]
         // Keep the legacy top-level fields populated so plan-mode turns still honor
         // the user's selected model on runtimes that do not read collaboration settings.
-        if let modelIdentifier = runtimeModelIdentifierForTurn() {
+        if let modelIdentifier = runtimeModelIdentifierForTurn(threadId: threadId) {
             params["model"] = .string(modelIdentifier)
         }
+        params["modelProvider"] = .string(runtimeModelProviderForTurn(threadId: threadId))
         if let effort = selectedReasoningEffortForSelectedModel(threadId: threadId) {
             params["effort"] = .string(effort)
         }
@@ -2096,10 +2109,10 @@ extension CodexService {
             return nil
         }
 
-        let resolvedModel = runtimeModelIdentifierForTurn()
-            ?? selectedModelOption()?.model
+        let resolvedModel = runtimeModelIdentifierForTurn(threadId: threadId)
+            ?? selectedModelOption(threadId: threadId)?.model
             ?? availableModels.first?.model
-            ?? selectedModelId
+            ?? CodexModelOption.splitSelectionKey(selectedModelId).modelId
         guard let resolvedModel,
               !resolvedModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw CodexServiceError.invalidResponse(
@@ -2122,6 +2135,7 @@ extension CodexService {
             "mode": .string(mode.rawValue),
             "settings": .object([
                 "model": .string(resolvedModel),
+                "modelProvider": .string(runtimeModelProviderForTurn(threadId: threadId)),
                 "reasoning_effort": selectedReasoningEffortForSelectedModel(
                     threadId: threadId
                 ).map(JSONValue.string) ?? .null,

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -151,10 +151,52 @@ struct CodexBridgeUpdatePrompt: Identifiable, Equatable, Sendable {
 }
 
 struct CodexThreadRuntimeOverride: Codable, Equatable, Sendable {
+    var modelId: String?
+    var modelProvider: String?
     var reasoningEffort: String?
     var serviceTierRawValue: String?
+    var overridesModel: Bool
     var overridesReasoning: Bool
     var overridesServiceTier: Bool
+
+    init(
+        modelId: String? = nil,
+        modelProvider: String? = nil,
+        reasoningEffort: String? = nil,
+        serviceTierRawValue: String? = nil,
+        overridesModel: Bool = false,
+        overridesReasoning: Bool = false,
+        overridesServiceTier: Bool = false
+    ) {
+        self.modelId = modelId
+        self.modelProvider = modelProvider
+        self.reasoningEffort = reasoningEffort
+        self.serviceTierRawValue = serviceTierRawValue
+        self.overridesModel = overridesModel
+        self.overridesReasoning = overridesReasoning
+        self.overridesServiceTier = overridesServiceTier
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case modelId
+        case modelProvider
+        case reasoningEffort
+        case serviceTierRawValue
+        case overridesModel
+        case overridesReasoning
+        case overridesServiceTier
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        modelId = try container.decodeIfPresent(String.self, forKey: .modelId)
+        modelProvider = try container.decodeIfPresent(String.self, forKey: .modelProvider)
+        reasoningEffort = try container.decodeIfPresent(String.self, forKey: .reasoningEffort)
+        serviceTierRawValue = try container.decodeIfPresent(String.self, forKey: .serviceTierRawValue)
+        overridesModel = try container.decodeIfPresent(Bool.self, forKey: .overridesModel) ?? false
+        overridesReasoning = try container.decodeIfPresent(Bool.self, forKey: .overridesReasoning) ?? false
+        overridesServiceTier = try container.decodeIfPresent(Bool.self, forKey: .overridesServiceTier) ?? false
+    }
 
     var serviceTier: CodexServiceTier? {
         guard let serviceTierRawValue else {
@@ -164,7 +206,7 @@ struct CodexThreadRuntimeOverride: Codable, Equatable, Sendable {
     }
 
     var isEmpty: Bool {
-        !overridesReasoning && !overridesServiceTier
+        !overridesModel && !overridesReasoning && !overridesServiceTier
     }
 }
 

--- a/CodexMobile/CodexMobile/Views/Settings/SettingsRuntimeDefaultsCard.swift
+++ b/CodexMobile/CodexMobile/Views/Settings/SettingsRuntimeDefaultsCard.swift
@@ -17,9 +17,9 @@ struct SettingsRuntimeDefaultsCard: View {
         SettingsCard(title: "Runtime defaults") {
             Picker("Model", selection: runtimeModelSelection) {
                 Text("Auto").tag(runtimeAutoValue)
-                ForEach(runtimeModelOptions, id: \.id) { model in
+                ForEach(runtimeModelOptions, id: \.selectionKey) { model in
                     Text(TurnComposerMetaMapper.modelTitle(for: model))
-                        .tag(model.id)
+                        .tag(model.selectionKey)
                 }
             }
             .pickerStyle(.menu)
@@ -55,9 +55,9 @@ struct SettingsRuntimeDefaultsCard: View {
             .tint(settingsAccentColor)
 
             Picker("Git writer model", selection: gitWriterModelSelection) {
-                ForEach(gitWriterModelOptions, id: \.id) { model in
+                ForEach(gitWriterModelOptions, id: \.selectionKey) { model in
                     Text(TurnComposerMetaMapper.modelTitle(for: model))
-                        .tag(model.id)
+                        .tag(model.selectionKey)
                 }
             }
             .pickerStyle(.menu)
@@ -82,7 +82,7 @@ struct SettingsRuntimeDefaultsCard: View {
 
     private var runtimeModelSelection: Binding<String> {
         Binding(
-            get: { codex.selectedModelOption()?.id ?? runtimeAutoValue },
+            get: { codex.selectedModelOption()?.selectionKey ?? runtimeAutoValue },
             set: { selection in
                 codex.setSelectedModelId(selection == runtimeAutoValue ? nil : selection)
             }
@@ -117,12 +117,12 @@ struct SettingsRuntimeDefaultsCard: View {
     }
 
     private var gitWriterModelOptions: [CodexModelOption] {
-        TurnComposerMetaMapper.orderedModels(from: codex.availableModels)
+        TurnComposerMetaMapper.orderedModels(from: codex.availableModels.filter { $0.modelProvider == "codex" })
     }
 
     private var gitWriterModelSelection: Binding<String> {
         Binding(
-            get: { codex.selectedGitWriterModelOption()?.id ?? gitWriterModelOptions.first?.id ?? "" },
+            get: { codex.selectedGitWriterModelOption()?.selectionKey ?? gitWriterModelOptions.first?.selectionKey ?? "" },
             set: { codex.setSelectedGitWriterModelId($0.isEmpty ? nil : $0) }
         )
     }

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/ComposerBottomBar.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/ComposerBottomBar.swift
@@ -388,7 +388,9 @@ private struct ComposerRuntimeMenuControl: View, Equatable {
             composerMenuLabel(
                 modelPart: modelLabelPart,
                 effortPart: effortLabelPart,
-                leadingImageName: runtimeState.showsSpeedBadgeInModelMenu ? "bolt.fill" : nil
+                leadingImageName: runtimeState.showsSpeedBadgeInModelMenu
+                    ? "bolt.fill"
+                    : TurnComposerMetaMapper.providerIconName(for: runtimeState.selectedModelProvider)
             )
         } menu: {
             TurnComposerRuntimeUIKitMenuBuilder.makeMenu(
@@ -511,9 +513,9 @@ private struct AllModelsSheet: View {
                 } else {
                     List {
                         Section {
-                            ForEach(models, id: \.id) { model in
+                            ForEach(models, id: \.selectionKey) { model in
                                 Button {
-                                    onSelect(model.id)
+                                    onSelect(model.selectionKey)
                                 } label: {
                                     modelRow(for: model)
                                 }
@@ -538,9 +540,9 @@ private struct AllModelsSheet: View {
     private func modelRow(for model: CodexModelOption) -> some View {
         let title = TurnComposerMetaMapper.modelTitle(for: model)
         HStack(alignment: .top, spacing: 12) {
-            RemodexIcon.image(systemName: model.id == selectedModelID ? "checkmark.circle.fill" : "circle")
+            RemodexIcon.image(systemName: model.selectionKey == selectedModelID ? "checkmark.circle.fill" : "circle")
                 .font(.system(size: 18))
-                .foregroundStyle(model.id == selectedModelID ? Color.accentColor : Color(.tertiaryLabel))
+                .foregroundStyle(model.selectionKey == selectedModelID ? Color.accentColor : Color(.tertiaryLabel))
                 .padding(.top, 2)
 
             VStack(alignment: .leading, spacing: 2) {

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerHostView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerHostView.swift
@@ -100,12 +100,14 @@ struct TurnComposerHostView: View {
             voiceAudioLevels: voiceAudioLevels,
             voiceRecordingDuration: voiceRecordingDuration
         )
+        let runtimeThreadId = isEmptyThread ? nil : thread.id
         let runtimeState = TurnComposerRuntimeState.resolve(
             codex: codex,
+            threadId: runtimeThreadId,
             reasoningDisplayOptions: reasoningDisplayOptions
         )
-        let runtimeActions = TurnComposerRuntimeActions.resolve(codex: codex)
-        let selectedModelID = codex.visibleSelectedModelIDForComposer()
+        let runtimeActions = TurnComposerRuntimeActions.resolve(codex: codex, threadId: runtimeThreadId)
+        let selectedModelID = codex.visibleSelectedModelIDForComposer(threadId: runtimeThreadId)
         let isRuntimeSelectionLoading = codex.isRuntimeSelectionLoadingForComposer()
         let hasComposerWorkingDirectory = thread.gitWorkingDirectory != nil
             && !SidebarThreadGrouping.isRootlessChatThread(thread)

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerMetaMapper.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerMetaMapper.swift
@@ -8,26 +8,62 @@ import Foundation
 
 // Keeps TurnView lightweight by isolating menu formatting/sorting rules.
 enum TurnComposerMetaMapper {
+    // MARK: - Provider Mapping
+
+    static func providerTitle(for provider: String) -> String {
+        switch CodexModelOption.normalizedProvider(provider) {
+        case "claude":
+            return "Claude"
+        case "codex":
+            return "Codex"
+        default:
+            return provider
+                .split(separator: "-")
+                .map { $0.capitalized }
+                .joined(separator: " ")
+        }
+    }
+
+    static func providerIconName(for provider: String) -> String {
+        switch CodexModelOption.normalizedProvider(provider) {
+        case "claude":
+            return "textformat"
+        case "codex":
+            return "sparkles"
+        default:
+            return "cube"
+        }
+    }
+
     // ─── Model Mapping ────────────────────────────────────────────────
 
     // Returns models sorted using the explicit product order expected by the UI.
     static func orderedModels(from models: [CodexModelOption]) -> [CodexModelOption] {
         let preferredOrder: [String] = [
-            "gpt-5.5",
-            "gpt-5.4",
-            "gpt-5.3-codex",
-            "gpt-5.2-codex",
-            "gpt-5.1-codex-max",
-            "gpt-5.2",
-            "gpt-5.1-codex-mini",
+            "codex:gpt-5.5",
+            "codex:gpt-5.4",
+            "codex:gpt-5.4-mini",
+            "codex:gpt-5.3-codex",
+            "codex:gpt-5.3-codex-spark",
+            "codex:gpt-5.2",
+            "codex:gpt-5.2-codex",
+            "claude:claude-opus-4-7",
+            "claude:claude-opus-4-6",
+            "claude:claude-opus-4-5-20251101",
+            "claude:claude-sonnet-4-6",
+            "claude:claude-haiku-4-5-20251001",
         ]
         let rankByModel = Dictionary(uniqueKeysWithValues: preferredOrder.enumerated().map { index, value in
             (value, index)
         })
 
         return models.sorted { lhs, rhs in
-            let lhsRank = rankByModel[lhs.model.lowercased()] ?? Int.max
-            let rhsRank = rankByModel[rhs.model.lowercased()] ?? Int.max
+            let lhsRank = rankByModel[lhs.selectionKey.lowercased()]
+                ?? rankByModel[CodexModelOption.selectionKey(provider: lhs.modelProvider, modelId: lhs.model).lowercased()]
+                ?? Int.max
+            let rhsRank = rankByModel[rhs.selectionKey.lowercased()]
+                ?? rankByModel[CodexModelOption.selectionKey(provider: rhs.modelProvider, modelId: rhs.model).lowercased()]
+                ?? Int.max
             if lhsRank == rhsRank {
                 return modelTitle(for: lhs) > modelTitle(for: rhs)
             }
@@ -61,6 +97,16 @@ enum TurnComposerMetaMapper {
             return "GPT-5.2"
         case "gpt-5.1-codex-mini":
             return "GPT-5.1-Codex-Mini"
+        case "claude-opus-4-7":
+            return "Claude Opus 4.7"
+        case "claude-opus-4-6":
+            return "Claude Opus 4.6"
+        case "claude-opus-4-5-20251101", "claude-opus-4-5":
+            return "Claude Opus 4.5"
+        case "claude-sonnet-4-6":
+            return "Claude Sonnet 4.6"
+        case "claude-haiku-4-5-20251001", "claude-haiku-4-5":
+            return "Claude Haiku 4.5"
         default:
             let fallback = fallback?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             if !fallback.isEmpty {

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerRuntimeActions.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerRuntimeActions.swift
@@ -12,12 +12,37 @@ struct TurnComposerRuntimeActions {
     let selectReasoning: (String) -> Void
     let selectServiceTier: (CodexServiceTier?) -> Void
 
-    static func resolve(codex: CodexService) -> TurnComposerRuntimeActions {
+    static func resolve(codex: CodexService, threadId: String?) -> TurnComposerRuntimeActions {
         TurnComposerRuntimeActions(
-            selectModel: codex.setSelectedModelId,
-            selectAutomaticReasoning: { codex.setSelectedReasoningEffort(nil) },
-            selectReasoning: { effort in codex.setSelectedReasoningEffort(effort) },
-            selectServiceTier: codex.setSelectedServiceTier
+            selectModel: { selectionKey in
+                if let threadId,
+                   let model = codex.modelOption(forSelectionKey: selectionKey) {
+                    codex.setThreadModelOverride(model, for: threadId)
+                } else {
+                    codex.setSelectedModelId(selectionKey)
+                }
+            },
+            selectAutomaticReasoning: {
+                if let threadId {
+                    codex.clearThreadReasoningEffortOverride(for: threadId)
+                } else {
+                    codex.setSelectedReasoningEffort(nil)
+                }
+            },
+            selectReasoning: { effort in
+                if let threadId {
+                    codex.setThreadReasoningEffortOverride(effort, for: threadId)
+                } else {
+                    codex.setSelectedReasoningEffort(effort)
+                }
+            },
+            selectServiceTier: { serviceTier in
+                if let threadId {
+                    codex.setThreadServiceTierOverride(serviceTier, for: threadId)
+                } else {
+                    codex.setSelectedServiceTier(serviceTier)
+                }
+            }
         )
     }
 }

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerRuntimeState.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerRuntimeState.swift
@@ -13,6 +13,7 @@ struct TurnComposerRuntimeState: Equatable {
     let reasoningMenuDisabled: Bool
     let selectedServiceTier: CodexServiceTier?
     let supportsFastMode: Bool
+    let selectedModelProvider: String
 
     var selectedReasoningTitle: String {
         effectiveReasoningEffort.map(TurnComposerMetaMapper.reasoningTitle(for:)) ?? "Select reasoning"
@@ -32,15 +33,22 @@ struct TurnComposerRuntimeState: Equatable {
 
     static func resolve(
         codex: CodexService,
+        threadId: String?,
         reasoningDisplayOptions: [TurnComposerReasoningDisplayOption]
     ) -> TurnComposerRuntimeState {
+        let threadReasoningOverride = codex.threadRuntimeOverride(for: threadId)
+        let selectedReasoningEffort = threadReasoningOverride?.overridesReasoning == true
+            ? threadReasoningOverride?.reasoningEffort
+            : codex.selectedReasoningEffort
+
         return TurnComposerRuntimeState(
             reasoningDisplayOptions: reasoningDisplayOptions,
-            effectiveReasoningEffort: codex.selectedReasoningEffortForSelectedModel(),
-            selectedReasoningEffort: codex.selectedReasoningEffort,
-            reasoningMenuDisabled: reasoningDisplayOptions.isEmpty || codex.selectedModelOption() == nil,
-            selectedServiceTier: codex.effectiveServiceTier(),
-            supportsFastMode: codex.selectedModelSupportsServiceTier(.fast)
+            effectiveReasoningEffort: codex.selectedReasoningEffortForSelectedModel(threadId: threadId),
+            selectedReasoningEffort: selectedReasoningEffort,
+            reasoningMenuDisabled: reasoningDisplayOptions.isEmpty || codex.selectedModelOption(threadId: threadId) == nil,
+            selectedServiceTier: codex.effectiveServiceTier(for: threadId),
+            supportsFastMode: codex.selectedModelSupportsServiceTier(.fast, threadId: threadId),
+            selectedModelProvider: codex.runtimeModelProviderForTurn(threadId: threadId)
         )
     }
 }

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerRuntimeUIKitMenu.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerRuntimeUIKitMenu.swift
@@ -73,26 +73,7 @@ enum TurnComposerRuntimeUIKitMenuBuilder {
                 ]
             }
 
-            let featured = featuredOrderedModels(input)
-            var items: [UIMenuElement] = featured.map { model in
-                modelAction(model: model, input: input)
-            }
-
-            let hasOthers = input.orderedModelOptions.contains { model in
-                !featured.contains(where: { $0.id == model.id })
-            }
-            if hasOthers {
-                items.append(
-                    UIAction(
-                        title: "Other models…",
-                        image: RemodexIcon.menuUIImage(systemName: "ellipsis")
-                    ) { _ in
-                        HapticFeedback.shared.triggerImpactFeedback(style: .light)
-                        input.onRequestAllModelsSheet()
-                    }
-                )
-            }
-            return items
+            return providerMenus(input)
         }()
 
         // singleSelection paints the checkmark on the `.on` child for us.
@@ -100,7 +81,7 @@ enum TurnComposerRuntimeUIKitMenuBuilder {
             title: "Model",
             subtitle: subtitle,
             image: RemodexIcon.menuUIImage(systemName: "cube"),
-            options: [.singleSelection],
+            options: [],
             children: modelChildren
         )
     }
@@ -114,32 +95,41 @@ enum TurnComposerRuntimeUIKitMenuBuilder {
         return UIAction(
             title: title,
             image: image,
-            state: model.id == input.selectedModelID ? .on : .off
+            state: model.selectionKey == input.selectedModelID ? .on : .off
         ) { _ in
             HapticFeedback.shared.triggerImpactFeedback(style: .light)
-            input.runtimeActions.selectModel(model.id)
+            input.runtimeActions.selectModel(model.selectionKey)
         }
     }
 
-    private static func featuredOrderedModels(_ input: Input) -> [CodexModelOption] {
-        var seen = Set<String>()
-        var result: [CodexModelOption] = []
-
-        for model in input.orderedModelOptions {
-            let normalizedID = model.id.lowercased()
-            let normalizedModel = model.model.lowercased()
-            let isFeatured = input.featuredModelIdentifiers.contains(normalizedID)
-                || input.featuredModelIdentifiers.contains(normalizedModel)
-            guard isFeatured, seen.insert(model.id).inserted else { continue }
-            result.append(model)
+    private static func providerMenus(_ input: Input) -> [UIMenuElement] {
+        let grouped = Dictionary(grouping: input.orderedModelOptions, by: \.modelProvider)
+        let providers = grouped.keys.sorted { lhs, rhs in
+            providerRank(lhs) < providerRank(rhs)
         }
 
-        if let selectedID = input.selectedModelID,
-           seen.insert(selectedID).inserted,
-           let selected = input.orderedModelOptions.first(where: { $0.id == selectedID }) {
-            result.append(selected)
+        return providers.compactMap { provider in
+            guard let models = grouped[provider], !models.isEmpty else { return nil }
+            return UIMenu(
+                title: TurnComposerMetaMapper.providerTitle(for: provider),
+                image: RemodexIcon.menuUIImage(systemName: TurnComposerMetaMapper.providerIconName(for: provider)),
+                options: [.singleSelection],
+                children: models.map { model in
+                    modelAction(model: model, input: input)
+                }
+            )
         }
-        return result
+    }
+
+    private static func providerRank(_ provider: String) -> Int {
+        switch CodexModelOption.normalizedProvider(provider) {
+        case "codex":
+            return 0
+        case "claude":
+            return 1
+        default:
+            return 100
+        }
     }
 
     // MARK: - Intelligence (reasoning effort)

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerView.swift
@@ -662,7 +662,7 @@ private struct ComposerPreviewContent: View {
             hasWorkingDirectory: true,
             isWorktreeProject: false,
             orderedModelOptions: modelOptions,
-            selectedModelID: "gpt-5.5",
+            selectedModelID: "codex:gpt-5.5",
             selectedModelTitle: "GPT-5.5",
             isLoadingModels: false,
             isRuntimeSelectionLoading: false,
@@ -672,7 +672,8 @@ private struct ComposerPreviewContent: View {
                 selectedReasoningEffort: "high",
                 reasoningMenuDisabled: false,
                 selectedServiceTier: .fast,
-                supportsFastMode: true
+                supportsFastMode: true,
+                selectedModelProvider: "codex"
             ),
             runtimeActions: TurnComposerRuntimeActions(
                 selectModel: { _ in },

--- a/CodexMobile/CodexMobile/Views/Turn/Core/NewChatDraftView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Core/NewChatDraftView.swift
@@ -627,7 +627,7 @@ struct NewChatDraftView: View {
             return TurnComposerMetaMapper.modelTitle(for: selectedModel)
         }
 
-        return TurnComposerMetaMapper.modelTitle(forIdentifier: codex.selectedModelId)
+        return TurnComposerMetaMapper.modelTitle(forIdentifier: codex.runtimeModelIdentifierForTurn())
     }
 
     // Mirrors the regular TurnView mic state so empty drafts can record before a runtime thread exists.

--- a/CodexMobile/CodexMobile/Views/Turn/Core/TurnView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Core/TurnView.swift
@@ -1284,16 +1284,18 @@ struct TurnView: View {
 
     private var reasoningDisplayOptions: [TurnComposerReasoningDisplayOption] {
         TurnComposerMetaMapper.reasoningDisplayOptions(
-            from: codex.supportedReasoningEffortsForSelectedModel().map(\.reasoningEffort)
+            from: codex.supportedReasoningEffortsForSelectedModel(threadId: thread.id).map(\.reasoningEffort)
         )
     }
 
     private var selectedModelTitle: String {
-        if let selectedModel = codex.selectedModelOption() {
+        if let selectedModel = codex.selectedModelOption(threadId: thread.id) {
             return TurnComposerMetaMapper.modelTitle(for: selectedModel)
         }
 
-        return TurnComposerMetaMapper.modelTitle(forIdentifier: codex.selectedModelId)
+        return TurnComposerMetaMapper.modelTitle(
+            forIdentifier: codex.runtimeModelIdentifierForTurn(threadId: thread.id)
+        )
     }
 
     private var approvalForThread: CodexApprovalRequest? {

--- a/phodex-bridge/package-lock.json
+++ b/phodex-bridge/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.146",
         "qrcode-terminal": "^0.12.0",
         "ws": "^8.19.0"
       },
@@ -17,6 +18,134 @@
         "remodex": "bin/remodex.js",
         "remodex-jsonl-diagnose": "bin/remodex-jsonl-diagnose.js"
       }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.146.tgz",
+      "integrity": "sha512-hK9/Ng+hOyexUemTxdIUsSWJ9o2LFi2YNWzHwz8/YMCohUYOnFMZkBiENvUAb0WIc5hieOyBZrOIlg5OewuJMg==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.146"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.146.tgz",
+      "integrity": "sha512-0IIvlEaenq2CRSVx5Bo5BaCtHQXS87GancM35WKEYveGVLn6DI+5G7ikYuTE4AKRPkMnogFtY4BJt6LulWGj+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.146.tgz",
+      "integrity": "sha512-Dk5xJ03Ff1JXbMRP1t2wc/TyfY6xF/2Ysp31wMhFPjoNiKSPHMWaIg242+T3CHdxLWmJ8plWHL1HL5cyZ/LCkw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.146.tgz",
+      "integrity": "sha512-mzBXDDWWBAC/vDtAYpO1G/dq5QvJtYSPXsqcb+sNdcDhiuf4IYnYp7ytRncYlsUNDkLmX6Gk2jkWAHUUA2Lozg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.146.tgz",
+      "integrity": "sha512-QlCid0ucdrmhUAOewfQjaofN2wlokWcfFTxSFePTSj1umk35JO7TDFP700F7jU49r1fPWIdvJpPwWGyB0DeFPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.146.tgz",
+      "integrity": "sha512-B2baXU1tCBT5CVlD7jJMKjpC4xdO45NUIWpqImmwuOfKvlM/PITjyTXyTY662mGZf1dBmdqBBsqirwFH/jhi8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.146.tgz",
+      "integrity": "sha512-E3coK1ThQT08KIX80RLcsq7DWXFllCKOzoOe32it/bdtY56TBgPY9xemwXhIJ+cVBHTI9/MpBSIlKBcFCt+yQA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.146.tgz",
+      "integrity": "sha512-CIwQxGX2r/yWpjCJ6ahB3smKXhghWgGTxL98+LGW52TUwqTiBnlNrH9DPqqgv1/+Hyquw6xfLrKU+StyfMgiLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.146.tgz",
+      "integrity": "sha512-qmxrsyaqA8s4HShqJls7ZCRjdoqN66Jo/hbjQNB3uHepD8tEO1iD19aPV4+osdLT7feMkhDBfLT07Q30R2NB5w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/qrcode-terminal": {
       "version": "0.12.0",

--- a/phodex-bridge/package.json
+++ b/phodex-bridge/package.json
@@ -28,6 +28,7 @@
   "license": "Apache-2.0",
   "type": "commonjs",
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.146",
     "qrcode-terminal": "^0.12.0",
     "ws": "^8.19.0"
   }

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -69,6 +69,7 @@ const {
   readThreadTurnsListPageFromSessionJsonl,
 } = require("./session-jsonl-history");
 const { buildApplyPatchFileChangeItem } = require("./apply-patch-changes");
+const { createRuntimeProviderRouter } = require("./runtime-provider-router");
 
 const execFileAsync = promisify(execFile);
 const RELAY_WATCHDOG_PING_INTERVAL_MS = 10_000;
@@ -242,6 +243,7 @@ function startBridge({
     appPath: config.codexAppPath,
     logPrefix: "[remodex]",
   });
+  let runtimeProviderRouter = null;
   const voiceHandler = createVoiceHandler({
     sendCodexRequest,
     logPrefix: "[remodex]",
@@ -482,13 +484,7 @@ function startBridge({
     }
     updatePendingAuthLoginFromCodexMessage(message);
     trackCodexHandshakeState(message);
-    desktopRefresher.handleOutbound(message);
-    pushNotificationTracker.handleOutbound(message);
-    rememberThreadFromMessage("codex", message);
-    secureTransport.queueOutboundApplicationMessage(
-      sanitizeRelayBoundCodexMessage(message),
-      sendRelayWireMessage
-    );
+    sendRuntimeApplicationMessage("codex", message);
   });
 
   codex.onClose(() => {
@@ -513,6 +509,7 @@ function startBridge({
     bridgeWakeAssertion.stop();
     clearReconnectTimer();
     stopContextUsageWatcher();
+    runtimeProviderRouter?.shutdown();
     rolloutLiveMirror?.stopAll();
     desktopIpcActionFollower?.stopAll();
     desktopRefresher.handleTransportReset();
@@ -529,6 +526,7 @@ function startBridge({
     clearReconnectTimer();
     clearRelayWatchdog();
     bridgeStatusPublisher.stopHeartbeat();
+    runtimeProviderRouter?.shutdown();
   }));
   process.on("SIGTERM", () => shutdown(codex, () => socket, () => {
     isShuttingDown = true;
@@ -536,6 +534,7 @@ function startBridge({
     clearReconnectTimer();
     clearRelayWatchdog();
     bridgeStatusPublisher.stopHeartbeat();
+    runtimeProviderRouter?.shutdown();
   }));
 
   // Routes decrypted app payloads through the same bridge handlers as before.
@@ -584,10 +583,23 @@ function startBridge({
     if (desktopIpcActionFollower?.observeInbound(rawMessage)) {
       return;
     }
+    if (!runtimeProviderRouter) {
+      runtimeProviderRouter = createRuntimeProviderRouter({
+        sendApplicationResponse,
+        sendCodexRequest,
+        sendRuntimeMessage: (message) => sendRuntimeApplicationMessage("claude", message),
+        logPrefix: "[remodex]",
+      });
+    }
+    if (runtimeProviderRouter.handleApplicationMessage(rawMessage)) {
+      return;
+    }
     if (handleBridgeManagedThreadTurnsListRequest(rawMessage, sendApplicationResponse)) {
       return;
     }
-    const codexRequest = disableUnsupportedReasoningSummaryForTurnStart(rawMessage);
+    const codexRequest = stripProviderFieldsForCodex(
+      disableUnsupportedReasoningSummaryForTurnStart(rawMessage)
+    );
     rememberForwardedRequestMethod(rawMessage);
     rememberThreadFromMessage("phone", codexRequest);
     codex.send(codexRequest);
@@ -595,6 +607,17 @@ function startBridge({
 
   // Encrypts bridge-generated responses instead of letting the relay see plaintext.
   function sendApplicationResponse(rawMessage) {
+    secureTransport.queueOutboundApplicationMessage(
+      sanitizeRelayBoundCodexMessage(rawMessage),
+      sendRelayWireMessage
+    );
+  }
+
+  // Sends provider runtime output through the same relay, refresh, and notification side effects.
+  function sendRuntimeApplicationMessage(provider, rawMessage) {
+    desktopRefresher.handleOutbound(rawMessage);
+    pushNotificationTracker.handleOutbound(rawMessage);
+    rememberThreadFromMessage(provider, rawMessage);
     secureTransport.queueOutboundApplicationMessage(
       sanitizeRelayBoundCodexMessage(rawMessage),
       sendRelayWireMessage
@@ -1593,6 +1616,42 @@ function disableUnsupportedReasoningSummaryForTurnStart(rawMessage) {
       ...params,
       summary: "none",
     },
+  });
+}
+
+// Keeps provider routing metadata on the bridge side when forwarding requests to Codex app-server.
+function stripProviderFieldsForCodex(rawMessage) {
+  const parsed = parseBridgeJSON(rawMessage);
+  if (!parsed || !parsed.params || typeof parsed.params !== "object" || Array.isArray(parsed.params)) {
+    return rawMessage;
+  }
+
+  const params = { ...parsed.params };
+  delete params.modelProvider;
+  delete params.model_provider;
+  delete params.provider;
+  delete params.runtimeProvider;
+  delete params.runtime_provider;
+  delete params.harness;
+
+  if (params.collaborationMode && typeof params.collaborationMode === "object") {
+    const collaborationMode = { ...params.collaborationMode };
+    if (collaborationMode.settings && typeof collaborationMode.settings === "object") {
+      const settings = { ...collaborationMode.settings };
+      delete settings.modelProvider;
+      delete settings.model_provider;
+      delete settings.provider;
+      delete settings.runtimeProvider;
+      delete settings.runtime_provider;
+      delete settings.harness;
+      collaborationMode.settings = settings;
+    }
+    params.collaborationMode = collaborationMode;
+  }
+
+  return JSON.stringify({
+    ...parsed,
+    params,
   });
 }
 
@@ -3423,4 +3482,5 @@ module.exports = {
   sanitizeLiveGeneratedImageMessageForRelay,
   sanitizeThreadHistoryImagesForRelay,
   startBridge,
+  stripProviderFieldsForCodex,
 };

--- a/phodex-bridge/src/claude-models.js
+++ b/phodex-bridge/src/claude-models.js
@@ -1,0 +1,209 @@
+// FILE: claude-models.js
+// Purpose: Declares Claude Code model metadata and provider normalization helpers.
+// Layer: Runtime provider helper
+// Exports: Claude model list, provider constants, selection helpers
+// Depends on: fs, child_process
+
+const fs = require("fs");
+const { execFileSync } = require("child_process");
+
+const CODEX_PROVIDER_ID = "codex";
+const CLAUDE_PROVIDER_ID = "claude";
+
+const CLAUDE_REASONING_EFFORTS = [
+  { reasoningEffort: "low", description: "Low" },
+  { reasoningEffort: "medium", description: "Medium" },
+  { reasoningEffort: "high", description: "High" },
+  { reasoningEffort: "xhigh", description: "Extra High" },
+];
+
+const CLAUDE_MODELS = [
+  {
+    id: "claude-opus-4-7",
+    model: "claude-opus-4-7",
+    displayName: "Claude Opus 4.7",
+    description: "Claude Code Opus 4.7",
+    isDefault: true,
+  },
+  {
+    id: "claude-opus-4-6",
+    model: "claude-opus-4-6",
+    displayName: "Claude Opus 4.6",
+    description: "Claude Code Opus 4.6",
+    isDefault: false,
+  },
+  {
+    id: "claude-opus-4-5-20251101",
+    model: "claude-opus-4-5-20251101",
+    displayName: "Claude Opus 4.5",
+    description: "Claude Code Opus 4.5",
+    isDefault: false,
+  },
+  {
+    id: "claude-sonnet-4-6",
+    model: "claude-sonnet-4-6",
+    displayName: "Claude Sonnet 4.6",
+    description: "Claude Code Sonnet 4.6",
+    isDefault: false,
+  },
+  {
+    id: "claude-haiku-4-5-20251001",
+    model: "claude-haiku-4-5-20251001",
+    displayName: "Claude Haiku 4.5",
+    description: "Claude Code Haiku 4.5",
+    isDefault: false,
+  },
+].map((model) => ({
+  ...model,
+  modelProvider: CLAUDE_PROVIDER_ID,
+  provider: CLAUDE_PROVIDER_ID,
+  supportsFastMode: false,
+  supportedReasoningEfforts: CLAUDE_REASONING_EFFORTS,
+  defaultReasoningEffort: "high",
+}));
+
+function normalizeModelProvider(value) {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (!normalized) {
+    return CODEX_PROVIDER_ID;
+  }
+  if (normalized === "claude-code" || normalized === "claudecode") {
+    return CLAUDE_PROVIDER_ID;
+  }
+  return normalized;
+}
+
+function readModelProvider(params) {
+  if (!params || typeof params !== "object") {
+    return CODEX_PROVIDER_ID;
+  }
+  return normalizeModelProvider(
+    params.modelProvider
+      || params.model_provider
+      || params.provider
+      || params.harness
+      || params.runtimeProvider
+      || params.runtime_provider
+      || params.collaborationMode?.settings?.modelProvider
+      || params.collaborationMode?.settings?.model_provider
+  );
+}
+
+function isClaudeProvider(value) {
+  return normalizeModelProvider(value) === CLAUDE_PROVIDER_ID;
+}
+
+function normalizeClaudeModel(value) {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  if (!normalized) {
+    return CLAUDE_MODELS[0].model;
+  }
+  const match = CLAUDE_MODELS.find((model) => (
+    model.id === normalized
+    || model.model === normalized
+    || model.displayName.toLowerCase() === normalized.toLowerCase()
+  ));
+  return match?.model || normalized;
+}
+
+function normalizeClaudeEffort(value) {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  switch (normalized) {
+    case "low":
+    case "medium":
+    case "high":
+    case "xhigh":
+      return normalized;
+    case "extra_high":
+    case "extra-high":
+      return "xhigh";
+    case "max":
+      return normalized;
+    default:
+      return undefined;
+  }
+}
+
+function isClaudeDisabled(env = process.env) {
+  const rawValue = typeof env.REMODEX_CLAUDE_CODE_ENABLED === "string"
+    ? env.REMODEX_CLAUDE_CODE_ENABLED.trim().toLowerCase()
+    : "";
+  return rawValue === "0" || rawValue === "false" || rawValue === "off" || rawValue === "no";
+}
+
+function resolveClaudeCodeExecutable({
+  env = process.env,
+  fsImpl = fs,
+  execFileSyncImpl = execFileSync,
+} = {}) {
+  if (isClaudeDisabled(env)) {
+    return {
+      available: false,
+      command: "",
+      path: "",
+      reason: "Claude Code is disabled by REMODEX_CLAUDE_CODE_ENABLED.",
+    };
+  }
+
+  const command = normalizeNonEmptyString(env.REMODEX_CLAUDE_CODE_COMMAND) || "claude";
+  if (command.includes("/") || command.includes("\\")) {
+    try {
+      const executableAccessMode = fsImpl.constants?.X_OK ?? 1;
+      fsImpl.accessSync(command, executableAccessMode);
+      return {
+        available: true,
+        command,
+        path: command,
+        reason: "",
+      };
+    } catch {
+      return {
+        available: false,
+        command,
+        path: "",
+        reason: `Claude Code executable is not executable: ${command}`,
+      };
+    }
+  }
+
+  try {
+    const resolved = execFileSyncImpl("which", [command], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (resolved) {
+      return {
+        available: true,
+        command,
+        path: resolved,
+        reason: "",
+      };
+    }
+  } catch {
+    // Report a concise availability reason below.
+  }
+
+  return {
+    available: false,
+    command,
+    path: "",
+    reason: `Claude Code executable not found in PATH: ${command}`,
+  };
+}
+
+function normalizeNonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+module.exports = {
+  CLAUDE_MODELS,
+  CLAUDE_PROVIDER_ID,
+  CODEX_PROVIDER_ID,
+  isClaudeDisabled,
+  isClaudeProvider,
+  normalizeClaudeEffort,
+  normalizeClaudeModel,
+  normalizeModelProvider,
+  readModelProvider,
+  resolveClaudeCodeExecutable,
+};

--- a/phodex-bridge/src/claude-provider.js
+++ b/phodex-bridge/src/claude-provider.js
@@ -1,0 +1,1143 @@
+// FILE: claude-provider.js
+// Purpose: Runs Claude Code turns through the official Agent SDK and adapts them to Remodex RPC events.
+// Layer: Runtime provider
+// Exports: createClaudeProvider
+// Depends on: crypto, ../package.json, ./claude-models, ./claude-thread-store
+
+const { randomBytes, randomUUID } = require("crypto");
+const { version: PACKAGE_VERSION } = require("../package.json");
+const {
+  CLAUDE_MODELS,
+  CLAUDE_PROVIDER_ID,
+  normalizeClaudeEffort,
+  normalizeClaudeModel,
+  resolveClaudeCodeExecutable,
+} = require("./claude-models");
+const { createClaudeThreadStore } = require("./claude-thread-store");
+
+const COMMAND_TOOLS = new Set(["Bash", "BashOutput", "KillShell"]);
+const FILE_TOOLS = new Set(["Edit", "Write", "MultiEdit", "NotebookEdit"]);
+const READ_TOOLS = new Set(["Read"]);
+
+function createClaudeProvider({
+  sendApplicationMessage,
+  env = process.env,
+  store = createClaudeThreadStore(),
+  sdkLoader = () => require("@anthropic-ai/claude-agent-sdk"),
+  executableResolver = resolveClaudeCodeExecutable,
+  randomUUIDImpl = randomUUID,
+  randomBytesImpl = randomBytes,
+  logPrefix = "[remodex]",
+} = {}) {
+  return new ClaudeProvider({
+    env,
+    executableResolver,
+    logPrefix,
+    randomBytesImpl,
+    randomUUIDImpl,
+    sdkLoader,
+    sendApplicationMessage,
+    store,
+  });
+}
+
+class ClaudeProvider {
+  constructor({
+    sendApplicationMessage,
+    env,
+    store,
+    sdkLoader,
+    executableResolver,
+    randomUUIDImpl,
+    randomBytesImpl,
+    logPrefix,
+  }) {
+    this.sendApplicationMessage = sendApplicationMessage;
+    this.env = env;
+    this.store = store;
+    this.sdkLoader = sdkLoader;
+    this.executableResolver = executableResolver;
+    this.randomUUID = randomUUIDImpl;
+    this.randomBytes = randomBytesImpl;
+    this.logPrefix = logPrefix;
+    this.activeTurns = new Map();
+    this.pendingApprovals = new Map();
+    this.stoppedTurns = new Set();
+    this.finalizedTurns = new Set();
+    this.availabilityCache = null;
+    this.warnedAvailabilityReason = "";
+  }
+
+  ownsThread(threadId) {
+    return this.store.ownsThread(threadId);
+  }
+
+  listModels() {
+    const availability = this.resolveAvailability();
+    if (!availability.available) {
+      this.warnUnavailable(availability.reason);
+      return [];
+    }
+    return CLAUDE_MODELS;
+  }
+
+  listThreads(params = {}) {
+    return this.store.listThreads({
+      limit: params.limit,
+      cursor: params.cursor,
+      includeArchived: params.includeArchived === true || params.include_archived === true,
+    });
+  }
+
+  async handleRequest(request) {
+    const method = readString(request?.method);
+    switch (method) {
+      case "thread/start":
+        return this.threadStart(request);
+      case "thread/resume":
+        return this.threadResume(request);
+      case "thread/read":
+        return this.threadRead(request);
+      case "thread/turns/list":
+        return this.threadTurnsList(request);
+      case "turn/start":
+        return this.turnStart(request);
+      case "turn/interrupt":
+        return this.turnInterrupt(request);
+      case "thread/name/set":
+        return this.threadNameSet(request);
+      case "thread/archive":
+        return this.threadArchive(request, true);
+      case "thread/unarchive":
+        return this.threadArchive(request, false);
+      default:
+        throw unsupportedMethodError(method);
+    }
+  }
+
+  handleApplicationResponse(message) {
+    const responseId = message?.id == null ? "" : String(message.id);
+    if (!responseId || !this.pendingApprovals.has(responseId)) {
+      return false;
+    }
+
+    const pending = this.pendingApprovals.get(responseId);
+    this.pendingApprovals.delete(responseId);
+    clearTimeout(pending.timeout);
+
+    if (message.error) {
+      pending.resolve({
+        behavior: "deny",
+        message: readString(message.error.message) || "Approval request failed.",
+      });
+      return true;
+    }
+
+    pending.resolve(permissionResultFromApprovalResponse(
+      message.result,
+      pending.input,
+      pending.suggestions
+    ));
+    return true;
+  }
+
+  shutdown() {
+    for (const active of this.activeTurns.values()) {
+      try {
+        active.abortController.abort();
+      } catch {
+        // Ignore shutdown races.
+      }
+    }
+    this.activeTurns.clear();
+    this.store.flush?.();
+    for (const pending of this.pendingApprovals.values()) {
+      clearTimeout(pending.timeout);
+      pending.resolve({
+        behavior: "deny",
+        message: "Remodex bridge is shutting down.",
+      });
+    }
+    this.pendingApprovals.clear();
+  }
+
+  threadStart(request) {
+    const params = request.params || {};
+    const thread = this.store.createThread({
+      cwd: params.cwd || params.current_working_directory || params.working_directory,
+      model: params.model,
+      title: params.title,
+    });
+
+    return {
+      thread,
+    };
+  }
+
+  threadResume(request) {
+    const threadId = readThreadId(request.params);
+    const thread = this.store.getPublicThread(threadId);
+    if (!thread) {
+      throw threadNotFoundError(threadId);
+    }
+    return {
+      thread,
+    };
+  }
+
+  threadRead(request) {
+    return this.store.readThread(readThreadId(request.params));
+  }
+
+  threadTurnsList(request) {
+    const params = request.params || {};
+    return this.store.listTurns(readThreadId(params), {
+      limit: params.limit,
+      cursor: params.cursor,
+      sortDirection: params.sortDirection || params.sort_direction,
+    });
+  }
+
+  async turnStart(request) {
+    const params = request.params || {};
+    const threadId = readThreadId(params);
+    const thread = this.store.getThread(threadId);
+    if (!thread) {
+      throw threadNotFoundError(threadId);
+    }
+    if (findActiveTurnEntryForThread(this.activeTurns, threadId)) {
+      throw activeTurnError(threadId);
+    }
+
+    const model = normalizeClaudeModel(params.model || thread.model);
+    const turnId = this.randomUUID();
+    const { prompt, inputText } = buildPromptFromTurnInput(params.input);
+    this.store.ensureTurn({
+      threadId,
+      turnId,
+      inputText,
+      model,
+    });
+
+    setImmediate(() => {
+      this.runTurn({
+        threadId,
+        turnId,
+        prompt,
+        model,
+        params,
+      }).catch((error) => {
+        this.failTurn({ threadId, turnId, error });
+      });
+    });
+
+    this.emit("turn/started", {
+      threadId,
+      turnId,
+      turn: {
+        id: turnId,
+        status: "running",
+      },
+    });
+
+    return {
+      turnId,
+      turn: {
+        id: turnId,
+        status: "running",
+      },
+    };
+  }
+
+  async runTurn({ threadId, turnId, prompt, model, params }) {
+    const availability = this.resolveAvailability();
+    if (!availability.available) {
+      throw availabilityError(availability.reason);
+    }
+
+    const sdk = this.sdkLoader();
+    if (!sdk || typeof sdk.query !== "function") {
+      throw availabilityError("Claude Agent SDK is installed but does not expose query().");
+    }
+
+    const abortController = new AbortController();
+    const thread = this.store.getThread(threadId);
+    const permissionMode = permissionModeFromParams(params);
+    const options = {
+      abortController,
+      cwd: thread.cwd || process.cwd(),
+      env: {
+        ...this.env,
+        CLAUDE_AGENT_SDK_CLIENT_APP: `remodex/${PACKAGE_VERSION}`,
+      },
+      effort: normalizeClaudeEffort(params.effort || params.reasoningEffort || params.reasoning_effort),
+      includePartialMessages: true,
+      model,
+      pathToClaudeCodeExecutable: availability.path,
+      permissionMode,
+      settingSources: ["user", "project", "local"],
+      systemPrompt: { type: "preset", preset: "claude_code" },
+      tools: { type: "preset", preset: "claude_code" },
+    };
+
+    if (permissionMode === "bypassPermissions") {
+      options.allowDangerouslySkipPermissions = true;
+    } else {
+      options.canUseTool = (toolName, input, approvalOptions) => this.requestToolApproval({
+        threadId,
+        turnId,
+        toolName,
+        input,
+        approvalOptions,
+      });
+    }
+
+    if (thread.sessionId) {
+      options.resume = thread.sessionId;
+    } else {
+      options.sessionId = thread.id;
+    }
+
+    const query = sdk.query({
+      prompt,
+      options: removeUndefinedValues(options),
+    });
+    this.activeTurns.set(turnId, {
+      abortController,
+      query,
+      threadId,
+    });
+
+    const streamState = {
+      emittedAssistantTextBlocks: new Set(),
+      emittedReasoningTextBlocks: new Set(),
+      currentStreamMessage: null,
+      nextContentItemIndex: 0,
+      nextStreamedAssistantMessageIndex: 0,
+      streamedAssistantMessages: [],
+      toolUseItems: new Map(),
+    };
+
+    try {
+      for await (const message of query) {
+        if (message?.session_id) {
+          this.store.rememberSessionId(threadId, message.session_id);
+        }
+        this.handleSdkMessage({
+          message,
+          model,
+          streamState,
+          threadId,
+          turnId,
+        });
+      }
+    } finally {
+      this.activeTurns.delete(turnId);
+    }
+  }
+
+  handleSdkMessage({ message, model, streamState, threadId, turnId }) {
+    if (!message || typeof message !== "object") {
+      return;
+    }
+
+    if (message.type === "system" && message.subtype === "init") {
+      if (message.session_id) {
+        this.store.rememberSessionId(threadId, message.session_id);
+      }
+      return;
+    }
+
+    if (message.type === "stream_event") {
+      this.handleStreamEvent({
+        event: message.event,
+        streamState,
+        threadId,
+        turnId,
+      });
+      return;
+    }
+
+    if (message.type === "assistant") {
+      this.handleAssistantMessage({
+        message,
+        streamState,
+        threadId,
+        turnId,
+      });
+      return;
+    }
+
+    if (message.type === "user") {
+      this.handleUserReplayMessage({
+        message,
+        streamState,
+        threadId,
+        turnId,
+      });
+      return;
+    }
+
+    if (message.type === "result") {
+      this.handleResultMessage({
+        message,
+        model,
+        threadId,
+        turnId,
+      });
+    }
+  }
+
+  handleStreamEvent({ event, streamState, threadId, turnId }) {
+    if (!event || typeof event !== "object") {
+      return;
+    }
+
+    if (event.type === "message_start") {
+      beginStreamMessage(streamState);
+      return;
+    }
+
+    if (event.type === "content_block_start") {
+      ensureStreamBlockKey(streamState, event, { startsBlock: true });
+      return;
+    }
+
+    if (event.type === "content_block_delta") {
+      const delta = event.delta || {};
+      const text = readString(delta.text || delta.thinking);
+      if (!text) {
+        return;
+      }
+      const blockKey = ensureStreamBlockKey(streamState, event);
+
+      if (delta.type === "thinking_delta") {
+        streamState.emittedReasoningTextBlocks.add(blockKey);
+        this.emitItemDelta({
+          method: "item/reasoning/textDelta",
+          threadId,
+          turnId,
+          itemId: `claude-reasoning-${turnId}-${blockKey}`,
+          delta: text,
+          storeType: "reasoning",
+        });
+        return;
+      }
+
+      streamState.emittedAssistantTextBlocks.add(blockKey);
+      this.emitItemDelta({
+        method: "item/agentMessage/delta",
+        threadId,
+        turnId,
+        itemId: `claude-agent-${turnId}-${blockKey}`,
+        delta: text,
+        storeType: "agentMessage",
+        item: {
+          phase: "final",
+        },
+      });
+    }
+  }
+
+  handleAssistantMessage({ message, streamState, threadId, turnId }) {
+    const content = Array.isArray(message.message?.content) ? message.message.content : [];
+    const assistantMessageBlocks = takeAssistantMessageBlocks(streamState);
+    for (const [index, block] of content.entries()) {
+      if (!block || typeof block !== "object") {
+        continue;
+      }
+      const blockKey = contentBlockKeyForAssistantMessage(streamState, assistantMessageBlocks, index);
+
+      if (block.type === "text" && !streamState.emittedAssistantTextBlocks.has(blockKey)) {
+        const text = readString(block.text);
+        if (text) {
+          this.emitItemDelta({
+            method: "item/agentMessage/delta",
+            threadId,
+            turnId,
+            itemId: `claude-agent-${turnId}-${blockKey}`,
+            delta: text,
+            storeType: "agentMessage",
+            item: {
+              phase: "final",
+            },
+          });
+        }
+        continue;
+      }
+
+      if (block.type === "thinking" && !streamState.emittedReasoningTextBlocks.has(blockKey)) {
+        const text = readString(block.thinking || block.text);
+        if (text) {
+          this.emitItemDelta({
+            method: "item/reasoning/textDelta",
+            threadId,
+            turnId,
+            itemId: `claude-reasoning-${turnId}-${blockKey}`,
+            delta: text,
+            storeType: "reasoning",
+          });
+        }
+        continue;
+      }
+
+      if (block.type === "tool_use") {
+        const toolName = readString(block.name) || "Tool";
+        const toolInput = block.input && typeof block.input === "object" ? block.input : {};
+        const rendered = formatToolUse(toolName, toolInput);
+        const classification = classifyTool(toolName);
+        const toolUseId = readString(block.id) || blockKey;
+        const itemId = `claude-tool-${turnId}-${toolUseId}`;
+        streamState.toolUseItems.set(toolUseId, {
+          itemId,
+          method: classification.method,
+          storeType: classification.storeType,
+        });
+        this.emitItemDelta({
+          method: classification.method,
+          threadId,
+          turnId,
+          itemId,
+          delta: rendered,
+          storeType: classification.storeType,
+          item: {
+            command: readString(toolInput.command),
+            path: readString(toolInput.file_path || toolInput.path || toolInput.notebook_path),
+            toolName,
+          },
+        });
+      }
+    }
+  }
+
+  handleUserReplayMessage({ message, streamState, threadId, turnId }) {
+    const content = Array.isArray(message.message?.content) ? message.message.content : [];
+    for (const [index, block] of content.entries()) {
+      if (!block || typeof block !== "object" || block.type !== "tool_result") {
+        continue;
+      }
+      const contentText = Array.isArray(block.content)
+        ? block.content.map(readToolResultPart).filter(Boolean).join("\n")
+        : readString(block.content);
+      if (!contentText) {
+        continue;
+      }
+      const toolUseId = readString(block.tool_use_id) || String(index);
+      const toolUseItem = streamState?.toolUseItems?.get(toolUseId);
+      const delta = toolUseItem ? ensureLeadingNewline(contentText) : contentText;
+      this.emitItemDelta({
+        method: toolUseItem?.method || "item/toolCall/outputDelta",
+        threadId,
+        turnId,
+        itemId: toolUseItem?.itemId || `claude-tool-${turnId}-${toolUseId}`,
+        delta,
+        storeType: toolUseItem?.storeType || "toolCall",
+      });
+    }
+  }
+
+  handleResultMessage({ message, model, threadId, turnId }) {
+    const isError = message.is_error === true || message.subtype !== "success";
+    const wasStopped = this.stoppedTurns.has(turnId);
+    this.stoppedTurns.delete(turnId);
+    const status = wasStopped ? "stopped" : (isError ? "failed" : "completed");
+    const errorMessage = status === "failed" ? resultErrorMessage(message) : "";
+    this.completeAndEmitTurn({
+      errorMessage,
+      model,
+      status,
+      threadId,
+      turnId,
+    });
+  }
+
+  failTurn({ threadId, turnId, error }) {
+    const wasAborted = this.activeTurns.get(turnId)?.abortController?.signal?.aborted === true
+      || this.stoppedTurns.has(turnId);
+    this.stoppedTurns.delete(turnId);
+    this.activeTurns.delete(turnId);
+    const status = wasAborted ? "stopped" : "failed";
+    const errorMessage = wasAborted ? "" : (error?.message || "Claude turn failed.");
+    this.completeAndEmitTurn({
+      errorMessage,
+      status,
+      threadId,
+      turnId,
+    });
+  }
+
+  async turnInterrupt(request) {
+    const params = request.params || {};
+    const turnId = readString(params.turnId || params.turn_id);
+    const threadId = readThreadId(params);
+    const activeEntry = turnId
+      ? [turnId, this.activeTurns.get(turnId)]
+      : findActiveTurnEntryForThread(this.activeTurns, threadId);
+    const active = activeEntry?.[1] || null;
+    if (!active) {
+      return {
+        success: true,
+        interrupted: false,
+      };
+    }
+
+    try {
+      if (typeof active.query?.interrupt === "function") {
+        await active.query.interrupt();
+      }
+    } catch {
+      // Fall through to abort; interrupt is best-effort for non-streaming SDK paths.
+    }
+    active.abortController.abort();
+    const resolvedTurnId = activeEntry[0] || "";
+    this.activeTurns.delete(resolvedTurnId);
+    this.stoppedTurns.add(resolvedTurnId);
+    if (resolvedTurnId) {
+      const resolvedThreadId = active.threadId || threadId;
+      this.completeAndEmitTurn({
+        status: "stopped",
+        threadId: resolvedThreadId,
+        turnId: resolvedTurnId,
+      });
+    }
+    return {
+      success: true,
+      interrupted: true,
+    };
+  }
+
+  threadNameSet(request) {
+    const params = request.params || {};
+    const threadId = readThreadId(params);
+    const name = params.name || params.title;
+    const thread = this.store.renameThread(threadId, name);
+    this.emit("thread/name/updated", {
+      threadId,
+      thread_id: threadId,
+      name: thread.name || thread.title,
+      title: thread.title,
+    });
+    return {
+      thread,
+    };
+  }
+
+  threadArchive(request, archived) {
+    const thread = this.store.setArchived(readThreadId(request.params), archived);
+    return {
+      thread,
+    };
+  }
+
+  async requestToolApproval({ threadId, turnId, toolName, input, approvalOptions = {} }) {
+    if (toolName === "AskUserQuestion") {
+      return {
+        behavior: "deny",
+        message: "Ask the user directly in the chat instead of using AskUserQuestion.",
+      };
+    }
+
+    const requestId = `claude-approval-${this.randomBytes(12).toString("hex")}`;
+    const approval = approvalRequestForTool({
+      input,
+      requestId,
+      threadId,
+      title: approvalOptions.title,
+      toolName,
+      turnId,
+    });
+
+    return new Promise((resolve) => {
+      const timeout = setTimeout(() => {
+        this.pendingApprovals.delete(requestId);
+        resolve({
+          behavior: "deny",
+          message: "Approval timed out.",
+        });
+      }, 15 * 60_000);
+
+      const abortHandler = () => {
+        clearTimeout(timeout);
+        this.pendingApprovals.delete(requestId);
+        resolve({
+          behavior: "deny",
+          message: "Turn was interrupted before approval completed.",
+        });
+      };
+      approvalOptions.signal?.addEventListener?.("abort", abortHandler, { once: true });
+
+      this.pendingApprovals.set(requestId, {
+        input,
+        resolve,
+        suggestions: Array.isArray(approvalOptions.suggestions) ? approvalOptions.suggestions : [],
+        timeout,
+      });
+      this.sendApplicationMessage(JSON.stringify(approval));
+    });
+  }
+
+  emitItemDelta({ method, threadId, turnId, itemId, delta, storeType, item }) {
+    this.store.appendItemDelta({
+      delta,
+      item,
+      itemId,
+      threadId,
+      turnId,
+      type: storeType,
+    });
+    this.emit(method, {
+      threadId,
+      turnId,
+      itemId,
+      delta,
+      textDelta: delta,
+      item: {
+        id: itemId,
+        turnId,
+        type: storeType,
+        ...removeUndefinedValues(item || {}),
+      },
+    });
+  }
+
+  completeAndEmitTurn({ threadId, turnId, model, status, errorMessage = "" }) {
+    if (this.finalizedTurns.has(turnId)) {
+      return false;
+    }
+    this.finalizedTurns.add(turnId);
+    pruneSet(this.finalizedTurns, 500);
+    try {
+      this.store.completeTurn({
+        errorMessage,
+        status,
+        threadId,
+        turnId,
+      });
+    } catch {
+      // If the store is already gone, still tell the app the turn is terminal.
+    }
+    this.emit("turn/completed", {
+      threadId,
+      turnId,
+      model,
+      status,
+      turn: {
+        id: turnId,
+        status,
+        error: errorMessage ? { message: errorMessage } : undefined,
+      },
+    });
+    return true;
+  }
+
+  emit(method, params) {
+    this.sendApplicationMessage(JSON.stringify({
+      method,
+      params: removeUndefinedValues(params || {}),
+    }));
+  }
+
+  resolveAvailability() {
+    const cacheKey = [
+      this.env.REMODEX_CLAUDE_CODE_ENABLED || "",
+      this.env.REMODEX_CLAUDE_CODE_COMMAND || "",
+    ].join("\0");
+    if (this.availabilityCache?.key === cacheKey) {
+      return this.availabilityCache.value;
+    }
+    try {
+      const value = this.executableResolver({ env: this.env });
+      this.availabilityCache = { key: cacheKey, value };
+      return value;
+    } catch (error) {
+      const value = {
+        available: false,
+        command: "",
+        path: "",
+        reason: error?.message || "Failed to resolve Claude Code executable.",
+      };
+      this.availabilityCache = { key: cacheKey, value };
+      return value;
+    }
+  }
+
+  warnUnavailable(reason) {
+    const normalizedReason = readString(reason);
+    if (!normalizedReason || this.warnedAvailabilityReason === normalizedReason) {
+      return;
+    }
+    this.warnedAvailabilityReason = normalizedReason;
+    console.warn(`${this.logPrefix} Claude Code unavailable: ${normalizedReason}`);
+  }
+}
+
+function buildPromptFromTurnInput(input) {
+  if (typeof input === "string") {
+    return {
+      inputText: input,
+      prompt: input,
+    };
+  }
+  if (!Array.isArray(input)) {
+    return {
+      inputText: "",
+      prompt: "",
+    };
+  }
+  const contentBlocks = [];
+  const inputTextParts = [];
+  const fallbackTextParts = [];
+
+  for (const item of input) {
+    if (typeof item === "string") {
+      const text = item.trim();
+      if (text) {
+        contentBlocks.push({ type: "text", text });
+        inputTextParts.push(text);
+      }
+      continue;
+    }
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const type = readString(item.type).toLowerCase();
+    if (type.includes("image")) {
+      const imageBlock = imageContentBlockFromInput(item);
+      if (imageBlock) {
+        contentBlocks.push(imageBlock);
+      } else {
+        const imagePath = readString(item.path || item.url || item.image_url);
+        fallbackTextParts.push(imagePath ? `[image attached: ${imagePath}]` : "[image attached]");
+      }
+      continue;
+    }
+    const text = readString(item.text || item.content || item.message);
+    if (text) {
+      contentBlocks.push({ type: "text", text });
+      inputTextParts.push(text);
+    }
+  }
+
+  for (const fallbackText of fallbackTextParts) {
+    contentBlocks.push({ type: "text", text: fallbackText });
+  }
+
+  const inputText = inputTextParts.join("\n\n").trim()
+    || (contentBlocks.some((block) => block.type === "image") ? "Image request" : fallbackTextParts.join("\n\n").trim());
+
+  if (!contentBlocks.some((block) => block.type === "image")) {
+    const promptText = [...inputTextParts, ...fallbackTextParts].join("\n\n").trim();
+    return {
+      inputText: inputText || promptText,
+      prompt: promptText,
+    };
+  }
+
+  return {
+    inputText,
+    prompt: singleUserPrompt(contentBlocks),
+  };
+}
+
+async function* singleUserPrompt(contentBlocks) {
+  yield {
+    type: "user",
+    message: {
+      role: "user",
+      content: contentBlocks,
+    },
+    parent_tool_use_id: null,
+  };
+}
+
+function imageContentBlockFromInput(item) {
+  const dataUrl = readString(item.image_url || item.url || item.dataURL || item.data_url);
+  const parsed = parseImageDataUrl(dataUrl);
+  if (!parsed) {
+    return null;
+  }
+  return {
+    type: "image",
+    source: {
+      type: "base64",
+      media_type: parsed.mediaType,
+      data: parsed.data,
+    },
+  };
+}
+
+function parseImageDataUrl(value) {
+  const normalized = readString(value);
+  const match = normalized.match(/^data:([^;,]+);base64,(.+)$/s);
+  if (!match) {
+    return null;
+  }
+  const mediaType = match[1].trim().toLowerCase();
+  const data = match[2].replace(/\s/g, "");
+  if (!mediaType.startsWith("image/") || !data) {
+    return null;
+  }
+  return { mediaType, data };
+}
+
+function permissionModeFromParams(params) {
+  const collaborationMode = readString(params?.collaborationMode?.mode || params?.collaboration_mode?.mode);
+  if (collaborationMode === "plan") {
+    return "plan";
+  }
+
+  const approvalPolicy = readString(params?.approvalPolicy || params?.approval_policy).toLowerCase();
+  const sandbox = readString(params?.sandbox).toLowerCase();
+  const sandboxPolicy = params?.sandboxPolicy || params?.sandbox_policy || {};
+  const sandboxPolicyMode = readString(sandboxPolicy.mode || sandboxPolicy.type || sandboxPolicy.access).toLowerCase();
+  if (approvalPolicy === "never"
+    || sandbox === "danger-full-access"
+    || sandboxPolicyMode === "danger-full-access"
+    || sandboxPolicyMode === "full-access") {
+    return "bypassPermissions";
+  }
+
+  return "default";
+}
+
+function approvalRequestForTool({ requestId, threadId, turnId, toolName, input, title }) {
+  const classification = classifyTool(toolName);
+  const command = readString(input?.command)
+    || readString(input?.file_path || input?.path || input?.notebook_path)
+    || toolName;
+  return {
+    id: requestId,
+    method: classification.approvalMethod,
+    params: {
+      threadId,
+      turnId,
+      itemId: `claude-approval-${turnId}-${toolName}`,
+      toolName,
+      command,
+      reason: readString(title) || `Claude wants to use ${toolName}.`,
+      permissionSource: "claudeCodeSdk",
+      input: sanitizeToolInput(input),
+    },
+  };
+}
+
+function permissionResultFromApprovalResponse(result, input, suggestions = []) {
+  const decision = readString(result?.decision).toLowerCase();
+  if (decision === "accept" || decision === "acceptforsession") {
+    const permissionResult = {
+      behavior: "allow",
+      updatedInput: input,
+    };
+    if (decision === "acceptforsession" && suggestions.length > 0) {
+      permissionResult.updatedPermissions = suggestions;
+    }
+    return permissionResult;
+  }
+  if (result?.permissions && Object.keys(result.permissions).length > 0) {
+    const permissionResult = {
+      behavior: "allow",
+      updatedInput: input,
+    };
+    if (suggestions.length > 0) {
+      permissionResult.updatedPermissions = suggestions;
+    }
+    return permissionResult;
+  }
+  return {
+    behavior: "deny",
+    message: "User denied permission.",
+  };
+}
+
+function classifyTool(toolName) {
+  if (COMMAND_TOOLS.has(toolName)) {
+    return {
+      approvalMethod: "item/commandExecution/requestApproval",
+      method: "item/commandExecution/outputDelta",
+      storeType: "commandExecution",
+    };
+  }
+  if (FILE_TOOLS.has(toolName)) {
+    return {
+      approvalMethod: "item/fileChange/requestApproval",
+      method: "item/fileChange/outputDelta",
+      storeType: "fileChange",
+    };
+  }
+  if (READ_TOOLS.has(toolName)) {
+    return {
+      approvalMethod: "item/fileRead/requestApproval",
+      method: "item/toolCall/outputDelta",
+      storeType: "toolCall",
+    };
+  }
+  return {
+    approvalMethod: "item/permissions/requestApproval",
+    method: "item/toolCall/outputDelta",
+    storeType: "toolCall",
+  };
+}
+
+function formatToolUse(toolName, input) {
+  if (COMMAND_TOOLS.has(toolName)) {
+    const command = readString(input.command) || toolName;
+    return `$ ${command}`;
+  }
+  if (FILE_TOOLS.has(toolName)) {
+    const filePath = readString(input.file_path || input.path || input.notebook_path);
+    return filePath ? `${toolName}: ${filePath}` : `${toolName}`;
+  }
+  const rendered = JSON.stringify(sanitizeToolInput(input));
+  return rendered && rendered !== "{}" ? `${toolName}: ${rendered}` : `${toolName}`;
+}
+
+function ensureLeadingNewline(value) {
+  return value.startsWith("\n") ? value : `\n${value}`;
+}
+
+function sanitizeToolInput(input) {
+  if (!input || typeof input !== "object") {
+    return {};
+  }
+  const result = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof value === "string") {
+      result[key] = value.length > 4000 ? `${value.slice(0, 4000)}...` : value;
+    } else if (typeof value === "number" || typeof value === "boolean" || value == null) {
+      result[key] = value;
+    } else {
+      result[key] = JSON.stringify(value).slice(0, 4000);
+    }
+  }
+  return result;
+}
+
+function readToolResultPart(part) {
+  if (typeof part === "string") {
+    return part;
+  }
+  if (!part || typeof part !== "object") {
+    return "";
+  }
+  return readString(part.text || part.content || part.value);
+}
+
+function resultErrorMessage(message) {
+  if (Array.isArray(message.errors) && message.errors.length > 0) {
+    return message.errors.map(readString).filter(Boolean).join("\n");
+  }
+  return readString(message.result) || "Claude turn failed.";
+}
+
+function readThreadId(params = {}) {
+  return readString(params.threadId || params.thread_id || params.id);
+}
+
+function readString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function removeUndefinedValues(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined)
+  );
+}
+
+function findActiveTurnEntryForThread(activeTurns, threadId) {
+  for (const [turnId, active] of activeTurns.entries()) {
+    if (active.threadId === threadId) {
+      return [turnId, active];
+    }
+  }
+  return null;
+}
+
+function beginStreamMessage(streamState) {
+  const message = {
+    blockKeysByIndex: new Map(),
+    consumed: false,
+  };
+  streamState.currentStreamMessage = message;
+  streamState.streamedAssistantMessages.push(message);
+  return message;
+}
+
+function ensureCurrentStreamMessage(streamState, blockIndex, { startsBlock = false } = {}) {
+  const current = streamState.currentStreamMessage;
+  if (!current || current.consumed || (startsBlock && current.blockKeysByIndex.has(blockIndex))) {
+    return beginStreamMessage(streamState);
+  }
+  return current;
+}
+
+function ensureStreamBlockKey(streamState, event, options = {}) {
+  const blockIndex = contentBlockIndex(event, "0");
+  const current = ensureCurrentStreamMessage(streamState, blockIndex, options);
+  if (!current.blockKeysByIndex.has(blockIndex)) {
+    current.blockKeysByIndex.set(blockIndex, nextContentBlockKey(streamState));
+  }
+  return current.blockKeysByIndex.get(blockIndex);
+}
+
+function takeAssistantMessageBlocks(streamState) {
+  const message = streamState.streamedAssistantMessages[streamState.nextStreamedAssistantMessageIndex] || null;
+  if (!message) {
+    return null;
+  }
+  streamState.nextStreamedAssistantMessageIndex += 1;
+  message.consumed = true;
+  return message.blockKeysByIndex;
+}
+
+function contentBlockKeyForAssistantMessage(streamState, streamedBlocks, index) {
+  const blockIndex = String(index);
+  return streamedBlocks?.get(blockIndex) || nextContentBlockKey(streamState);
+}
+
+function nextContentBlockKey(streamState) {
+  const key = String(streamState.nextContentItemIndex);
+  streamState.nextContentItemIndex += 1;
+  return key;
+}
+
+function contentBlockIndex(event, fallback) {
+  const index = Number(event?.index);
+  return Number.isInteger(index) && index >= 0 ? String(index) : fallback;
+}
+
+function pruneSet(set, maxSize) {
+  while (set.size > maxSize) {
+    const first = set.values().next().value;
+    set.delete(first);
+  }
+}
+
+function unsupportedMethodError(method) {
+  const error = new Error(`Claude provider does not support ${method || "(missing method)"}.`);
+  error.errorCode = "unsupported_method";
+  return error;
+}
+
+function activeTurnError(threadId) {
+  const error = new Error(`Claude thread already has an active turn: ${threadId || "(missing)"}`);
+  error.errorCode = "turn_already_running";
+  error.userMessage = "Claude is already running on this thread. Stop the current turn before starting another.";
+  return error;
+}
+
+function threadNotFoundError(threadId) {
+  const error = new Error(`Claude thread not found: ${threadId || "(missing)"}`);
+  error.errorCode = "thread_not_found";
+  return error;
+}
+
+function availabilityError(reason) {
+  const error = new Error(reason || "Claude Code is unavailable.");
+  error.errorCode = "claude_unavailable";
+  return error;
+}
+
+module.exports = {
+  createClaudeProvider,
+  permissionModeFromParams,
+};

--- a/phodex-bridge/src/claude-thread-store.js
+++ b/phodex-bridge/src/claude-thread-store.js
@@ -1,0 +1,526 @@
+// FILE: claude-thread-store.js
+// Purpose: Persists Remodex-owned Claude Code thread metadata and replayable turn summaries.
+// Layer: Runtime provider state
+// Exports: createClaudeThreadStore
+// Depends on: fs, path, crypto, ./daemon-state
+
+const fs = require("fs");
+const path = require("path");
+const { randomUUID } = require("crypto");
+const { resolveRemodexStateDir } = require("./daemon-state");
+const { CLAUDE_PROVIDER_ID, normalizeClaudeModel } = require("./claude-models");
+
+const STORE_FILE_NAME = "claude-threads.json";
+const STORE_VERSION = 1;
+
+function createClaudeThreadStore({
+  stateDir = resolveRemodexStateDir(),
+  fsImpl = fs,
+  now = () => new Date(),
+  randomUUIDImpl = randomUUID,
+  persistDelayMs = 75,
+} = {}) {
+  const storeFile = path.join(stateDir, STORE_FILE_NAME);
+  let stateCache = null;
+  let pendingWriteTimer = null;
+
+  function loadStateFromDisk() {
+    if (!fsImpl.existsSync(storeFile)) {
+      return createEmptyState();
+    }
+
+    try {
+      const parsed = JSON.parse(fsImpl.readFileSync(storeFile, "utf8"));
+      return normalizeState(parsed);
+    } catch {
+      return createEmptyState();
+    }
+  }
+
+  function readState() {
+    if (!stateCache) {
+      stateCache = loadStateFromDisk();
+    }
+    return stateCache;
+  }
+
+  function writeState(state) {
+    const normalizedState = normalizeState(state);
+    stateCache = normalizedState;
+    fsImpl.mkdirSync(path.dirname(storeFile), { recursive: true, mode: 0o700 });
+    try {
+      fsImpl.chmodSync(path.dirname(storeFile), 0o700);
+    } catch {
+      // Best-effort only on filesystems that do not support POSIX modes.
+    }
+    fsImpl.writeFileSync(storeFile, JSON.stringify(normalizedState, null, 2), { mode: 0o600 });
+    try {
+      fsImpl.chmodSync(storeFile, 0o600);
+    } catch {
+      // Best-effort only on filesystems that do not support POSIX modes.
+    }
+  }
+
+  function scheduleWrite(state) {
+    if (pendingWriteTimer) {
+      return;
+    }
+    pendingWriteTimer = setTimeout(() => {
+      pendingWriteTimer = null;
+      writeState(state);
+    }, persistDelayMs);
+    pendingWriteTimer.unref?.();
+  }
+
+  function flush() {
+    if (!pendingWriteTimer) {
+      return;
+    }
+    clearTimeout(pendingWriteTimer);
+    pendingWriteTimer = null;
+    writeState(readState());
+  }
+
+  function mutate(mutator, { persist = "immediate" } = {}) {
+    const state = readState();
+    const result = mutator(state);
+    if (persist === "debounced") {
+      scheduleWrite(state);
+    } else {
+      flush();
+      writeState(state);
+    }
+    return result;
+  }
+
+  function createThread({ cwd, model, title } = {}) {
+    return mutate((state) => {
+      const timestamp = nowIso(now);
+      const thread = {
+        id: randomUUIDImpl(),
+        title: normalizeString(title) || "Claude",
+        name: null,
+        preview: "",
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        cwd: normalizeString(cwd) || null,
+        model: normalizeClaudeModel(model),
+        modelProvider: CLAUDE_PROVIDER_ID,
+        source: CLAUDE_PROVIDER_ID,
+        archived: false,
+        sessionId: null,
+        turns: [],
+        metadata: {
+          modelProvider: CLAUDE_PROVIDER_ID,
+          source: CLAUDE_PROVIDER_ID,
+        },
+      };
+      state.threads[thread.id] = thread;
+      return publicThread(thread);
+    });
+  }
+
+  function ownsThread(threadId) {
+    const normalizedThreadId = normalizeString(threadId);
+    return Boolean(normalizedThreadId && readState().threads[normalizedThreadId]);
+  }
+
+  function getThread(threadId) {
+    const normalizedThreadId = normalizeString(threadId);
+    if (!normalizedThreadId) {
+      return null;
+    }
+    const thread = readState().threads[normalizedThreadId];
+    return thread ? normalizeThread(thread) : null;
+  }
+
+  function getPublicThread(threadId) {
+    const thread = getThread(threadId);
+    return thread ? publicThread(thread) : null;
+  }
+
+  function listThreads({ limit, cursor, includeArchived } = {}) {
+    const offset = parseCursor(cursor);
+    const maxItems = normalizeLimit(limit, 70);
+    const threads = Object.values(readState().threads)
+      .map(normalizeThread)
+      .filter((thread) => includeArchived || thread.archived !== true)
+      .sort((lhs, rhs) => rhs.updatedAt.localeCompare(lhs.updatedAt));
+    const page = threads.slice(offset, offset + maxItems).map(publicThread);
+    const nextOffset = offset + page.length;
+    return {
+      data: page,
+      nextCursor: nextOffset < threads.length ? String(nextOffset) : null,
+    };
+  }
+
+  function readThread(threadId) {
+    const thread = getThread(threadId);
+    if (!thread) {
+      throw threadNotFoundError(threadId);
+    }
+    return {
+      thread: publicThread(thread, { includeTurns: true }),
+    };
+  }
+
+  function listTurns(threadId, { limit, cursor, sortDirection } = {}) {
+    const thread = getThread(threadId);
+    if (!thread) {
+      throw threadNotFoundError(threadId);
+    }
+
+    const offset = parseCursor(cursor);
+    const maxItems = normalizeLimit(limit, 5);
+    const descending = normalizeString(sortDirection).toLowerCase() !== "asc";
+    const orderedTurns = descending ? [...thread.turns].reverse() : [...thread.turns];
+    const page = orderedTurns.slice(offset, offset + maxItems).map(publicTurn);
+    const nextOffset = offset + page.length;
+    return {
+      data: page,
+      nextCursor: nextOffset < orderedTurns.length ? String(nextOffset) : null,
+    };
+  }
+
+  function ensureTurn({ threadId, turnId, inputText, model }) {
+    return mutate((state) => {
+      const thread = state.threads[normalizeString(threadId)];
+      if (!thread) {
+        throw threadNotFoundError(threadId);
+      }
+
+      if (normalizeString(model)) {
+        thread.model = normalizeClaudeModel(model);
+      }
+
+      const timestamp = nowIso(now);
+      let turn = thread.turns.find((candidate) => candidate.id === turnId);
+      if (!turn) {
+        turn = {
+          id: turnId,
+          status: "running",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+          items: [],
+        };
+        thread.turns.push(turn);
+      }
+
+      const normalizedInput = normalizeString(inputText);
+      if (normalizedInput && !turn.items.some((item) => item.type === "userMessage")) {
+        turn.items.push({
+          id: `user-${turnId}`,
+          type: "userMessage",
+          text: normalizedInput,
+          createdAt: timestamp,
+        });
+        thread.preview = normalizedInput.slice(0, 280);
+      }
+
+      thread.updatedAt = timestamp;
+      turn.updatedAt = timestamp;
+      return publicTurn(turn);
+    }, { persist: "debounced" });
+  }
+
+  function appendItemDelta({ threadId, turnId, itemId, type, delta, item = {} }) {
+    const deltaText = typeof delta === "string" ? delta : "";
+    if (!deltaText.trim()) {
+      return null;
+    }
+
+    return mutate((state) => {
+      const thread = state.threads[normalizeString(threadId)];
+      if (!thread) {
+        throw threadNotFoundError(threadId);
+      }
+      const turn = thread.turns.find((candidate) => candidate.id === turnId);
+      if (!turn) {
+        throw turnNotFoundError(turnId);
+      }
+
+      const timestamp = nowIso(now);
+      const normalizedItemId = normalizeString(itemId) || `${type}-${turnId}`;
+      let existing = turn.items.find((candidate) => candidate.id === normalizedItemId);
+      if (!existing) {
+        existing = {
+          id: normalizedItemId,
+          type,
+          text: "",
+          createdAt: timestamp,
+          ...normalizeItemMetadata(item),
+        };
+        turn.items.push(existing);
+      }
+
+      existing.type = type || existing.type;
+      existing.text = `${existing.text || ""}${deltaText}`;
+      existing.updatedAt = timestamp;
+      turn.updatedAt = timestamp;
+      thread.updatedAt = timestamp;
+      if (type === "agentMessage" && deltaText.trim()) {
+        thread.preview = `${thread.preview || ""}${deltaText}`.trim().slice(0, 280);
+      }
+
+      return publicTurn(turn);
+    });
+  }
+
+  function completeTurn({ threadId, turnId, status = "completed", errorMessage = "" }) {
+    return mutate((state) => {
+      const thread = state.threads[normalizeString(threadId)];
+      if (!thread) {
+        throw threadNotFoundError(threadId);
+      }
+      const turn = thread.turns.find((candidate) => candidate.id === turnId);
+      if (!turn) {
+        throw turnNotFoundError(turnId);
+      }
+
+      const timestamp = nowIso(now);
+      turn.status = status;
+      turn.updatedAt = timestamp;
+      if (errorMessage) {
+        turn.error = { message: errorMessage };
+      } else {
+        delete turn.error;
+      }
+      thread.updatedAt = timestamp;
+      return publicTurn(turn);
+    });
+  }
+
+  function rememberSessionId(threadId, sessionId) {
+    const normalizedSessionId = normalizeString(sessionId);
+    if (!normalizedSessionId) {
+      return null;
+    }
+    return mutate((state) => {
+      const thread = state.threads[normalizeString(threadId)];
+      if (!thread) {
+        return null;
+      }
+      thread.sessionId = normalizedSessionId;
+      return normalizedSessionId;
+    });
+  }
+
+  function renameThread(threadId, name) {
+    const normalizedName = normalizeString(name);
+    return mutate((state) => {
+      const thread = state.threads[normalizeString(threadId)];
+      if (!thread) {
+        throw threadNotFoundError(threadId);
+      }
+      thread.name = normalizedName || null;
+      thread.title = normalizedName || thread.title || "Claude";
+      thread.updatedAt = nowIso(now);
+      return publicThread(thread);
+    });
+  }
+
+  function setArchived(threadId, archived) {
+    return mutate((state) => {
+      const thread = state.threads[normalizeString(threadId)];
+      if (!thread) {
+        throw threadNotFoundError(threadId);
+      }
+      thread.archived = archived === true;
+      thread.updatedAt = nowIso(now);
+      return publicThread(thread);
+    });
+  }
+
+  return {
+    appendItemDelta,
+    completeTurn,
+    createThread,
+    ensureTurn,
+    getPublicThread,
+    getThread,
+    listThreads,
+    listTurns,
+    ownsThread,
+    readThread,
+    rememberSessionId,
+    renameThread,
+    setArchived,
+    storeFile,
+    flush,
+  };
+}
+
+function createEmptyState() {
+  return {
+    version: STORE_VERSION,
+    threads: {},
+  };
+}
+
+function normalizeState(value) {
+  const source = value && typeof value === "object" ? value : {};
+  const threads = source.threads && typeof source.threads === "object" && !Array.isArray(source.threads)
+    ? source.threads
+    : {};
+  return {
+    version: STORE_VERSION,
+    threads: Object.fromEntries(
+      Object.entries(threads)
+        .map(([id, thread]) => [id, normalizeThread({ id, ...thread })])
+        .filter(([, thread]) => Boolean(thread.id))
+    ),
+  };
+}
+
+function normalizeThread(thread) {
+  const timestamp = normalizeString(thread.updatedAt)
+    || normalizeString(thread.createdAt)
+    || new Date(0).toISOString();
+  const id = normalizeString(thread.id);
+  return {
+    id,
+    title: normalizeString(thread.title) || "Claude",
+    name: normalizeString(thread.name) || null,
+    preview: normalizeString(thread.preview),
+    createdAt: normalizeString(thread.createdAt) || timestamp,
+    updatedAt: timestamp,
+    cwd: normalizeString(thread.cwd) || null,
+    model: normalizeClaudeModel(thread.model),
+    modelProvider: CLAUDE_PROVIDER_ID,
+    source: CLAUDE_PROVIDER_ID,
+    archived: thread.archived === true,
+    sessionId: normalizeString(thread.sessionId) || null,
+    turns: Array.isArray(thread.turns) ? thread.turns.map(normalizeTurn).filter(Boolean) : [],
+    metadata: {
+      ...(thread.metadata && typeof thread.metadata === "object" ? thread.metadata : {}),
+      modelProvider: CLAUDE_PROVIDER_ID,
+      source: CLAUDE_PROVIDER_ID,
+    },
+  };
+}
+
+function normalizeTurn(turn) {
+  const id = normalizeString(turn?.id);
+  if (!id) {
+    return null;
+  }
+  const timestamp = normalizeString(turn.updatedAt)
+    || normalizeString(turn.createdAt)
+    || new Date(0).toISOString();
+  const normalized = {
+    id,
+    status: normalizeString(turn.status) || "completed",
+    createdAt: normalizeString(turn.createdAt) || timestamp,
+    updatedAt: timestamp,
+    items: Array.isArray(turn.items) ? turn.items.map(normalizeItem).filter(Boolean) : [],
+  };
+  if (turn.error && typeof turn.error === "object") {
+    normalized.error = {
+      message: normalizeString(turn.error.message) || "Turn failed",
+    };
+  }
+  return normalized;
+}
+
+function normalizeItem(item) {
+  const id = normalizeString(item?.id);
+  const type = normalizeString(item?.type);
+  if (!id || !type) {
+    return null;
+  }
+  return {
+    id,
+    type,
+    text: normalizeString(item.text),
+    createdAt: normalizeString(item.createdAt) || new Date(0).toISOString(),
+    updatedAt: normalizeString(item.updatedAt) || undefined,
+    ...normalizeItemMetadata(item),
+  };
+}
+
+function normalizeItemMetadata(item) {
+  const metadata = {};
+  for (const key of ["command", "path", "toolName", "name", "phase"]) {
+    const value = normalizeString(item?.[key]);
+    if (value) {
+      metadata[key] = value;
+    }
+  }
+  return metadata;
+}
+
+function publicThread(thread, { includeTurns = false } = {}) {
+  const normalized = normalizeThread(thread);
+  const result = {
+    id: normalized.id,
+    title: normalized.title,
+    name: normalized.name,
+    preview: normalized.preview,
+    createdAt: normalized.createdAt,
+    updatedAt: normalized.updatedAt,
+    cwd: normalized.cwd,
+    model: normalized.model,
+    modelProvider: CLAUDE_PROVIDER_ID,
+    source: CLAUDE_PROVIDER_ID,
+    metadata: normalized.metadata,
+  };
+  if (includeTurns) {
+    result.turns = normalized.turns.map(publicTurn);
+  }
+  return result;
+}
+
+function publicTurn(turn) {
+  const normalized = normalizeTurn(turn);
+  const result = {
+    id: normalized.id,
+    status: normalized.status,
+    createdAt: normalized.createdAt,
+    updatedAt: normalized.updatedAt,
+    items: normalized.items.map((item) => Object.fromEntries(
+      Object.entries(item).filter(([, value]) => value !== undefined && value !== null)
+    )),
+  };
+  if (normalized.error) {
+    result.error = normalized.error;
+  }
+  return result;
+}
+
+function parseCursor(cursor) {
+  const numeric = Number(cursor);
+  return Number.isInteger(numeric) && numeric > 0 ? numeric : 0;
+}
+
+function normalizeLimit(limit, fallback) {
+  const numeric = Number(limit);
+  if (!Number.isInteger(numeric) || numeric <= 0) {
+    return fallback;
+  }
+  return Math.min(numeric, 100);
+}
+
+function nowIso(now) {
+  const value = now();
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function normalizeString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function threadNotFoundError(threadId) {
+  const error = new Error(`Claude thread not found: ${threadId || "(missing)"}`);
+  error.errorCode = "thread_not_found";
+  return error;
+}
+
+function turnNotFoundError(turnId) {
+  const error = new Error(`Claude turn not found: ${turnId || "(missing)"}`);
+  error.errorCode = "turn_not_found";
+  return error;
+}
+
+module.exports = {
+  createClaudeThreadStore,
+};

--- a/phodex-bridge/src/runtime-provider-router.js
+++ b/phodex-bridge/src/runtime-provider-router.js
@@ -1,0 +1,211 @@
+// FILE: runtime-provider-router.js
+// Purpose: Routes provider-aware Remodex RPCs between Codex app-server and additional local harnesses.
+// Layer: Bridge runtime routing
+// Exports: createRuntimeProviderRouter, mergeModelListResult, mergeThreadListResult
+// Depends on: ./claude-models, ./claude-provider
+
+const { createClaudeProvider } = require("./claude-provider");
+const {
+  CLAUDE_PROVIDER_ID,
+  CODEX_PROVIDER_ID,
+  isClaudeProvider,
+  readModelProvider,
+} = require("./claude-models");
+
+const ROUTABLE_THREAD_METHODS = new Set([
+  "thread/start",
+  "thread/resume",
+  "thread/read",
+  "thread/turns/list",
+  "thread/name/set",
+  "thread/archive",
+  "thread/unarchive",
+  "turn/start",
+  "turn/interrupt",
+]);
+
+function createRuntimeProviderRouter({
+  sendCodexRequest,
+  sendApplicationResponse,
+  sendRuntimeMessage,
+  claudeProvider = null,
+  logPrefix = "[remodex]",
+} = {}) {
+  const provider = claudeProvider || createClaudeProvider({
+    sendApplicationMessage: sendRuntimeMessage || sendApplicationResponse,
+    logPrefix,
+  });
+
+  function handleApplicationMessage(rawMessage) {
+    const parsed = safeParseJSON(rawMessage);
+    if (!parsed) {
+      return false;
+    }
+
+    if (parsed.id != null && !parsed.method && provider.handleApplicationResponse(parsed)) {
+      return true;
+    }
+
+    const method = typeof parsed.method === "string" ? parsed.method.trim() : "";
+    if (!method) {
+      return false;
+    }
+
+    if (method === "model/list") {
+      respondAsync(parsed, async () => {
+        const codexResult = await sendCodexRequest("model/list", parsed.params || {});
+        return mergeModelListResult(codexResult, provider.listModels());
+      });
+      return true;
+    }
+
+    if (method === "thread/list") {
+      respondAsync(parsed, async () => {
+        const codexResult = await sendCodexRequest("thread/list", parsed.params || {});
+        // V1 keeps provider pagination simple: Claude local threads are merged
+        // only into the first Codex page. A future composite cursor can make
+        // this exact across large mixed-provider histories.
+        const shouldIncludeClaude = !hasCursor(parsed.params);
+        return mergeThreadListResult(
+          codexResult,
+          shouldIncludeClaude ? provider.listThreads(parsed.params || {}).data : []
+        );
+      });
+      return true;
+    }
+
+    if (!ROUTABLE_THREAD_METHODS.has(method)) {
+      return false;
+    }
+
+    if (!shouldRouteToClaude(parsed, provider)) {
+      return false;
+    }
+
+    respondAsync(parsed, () => provider.handleRequest(parsed));
+    return true;
+  }
+
+  function respondAsync(request, resolveResult) {
+    Promise.resolve()
+      .then(resolveResult)
+      .then((result) => {
+        if (request.id != null) {
+          // JSON-RPC responses go back through the relay response path; runtime
+          // events emitted by providers use sendRuntimeMessage so refresh/push
+          // side effects still see thread-scoped lifecycle updates.
+          sendApplicationResponse(JSON.stringify({
+            id: request.id,
+            result,
+          }));
+        }
+      })
+      .catch((error) => {
+        if (request.id != null) {
+          sendApplicationResponse(createJsonRpcErrorResponse(
+            request.id,
+            error,
+            error?.errorCode || "runtime_provider_failed"
+          ));
+        }
+      });
+  }
+
+  return {
+    claudeProvider: provider,
+    handleApplicationMessage,
+    shutdown: () => provider.shutdown(),
+  };
+}
+
+function shouldRouteToClaude(request, provider) {
+  const params = request.params || {};
+  const providerFromRequest = readModelProvider(params);
+  if (isClaudeProvider(providerFromRequest)) {
+    return true;
+  }
+
+  const threadId = readThreadId(params);
+  return Boolean(threadId && provider.ownsThread(threadId));
+}
+
+function mergeModelListResult(codexResult, claudeModels) {
+  const result = codexResult && typeof codexResult === "object" ? codexResult : {};
+  const key = firstArrayKey(result, ["items", "data", "models"]) || "items";
+  const codexModels = Array.isArray(result[key]) ? result[key] : [];
+  const normalizedCodexModels = codexModels.map((model) => ({
+    ...model,
+    modelProvider: readModelProvider(model) || CODEX_PROVIDER_ID,
+    provider: readModelProvider(model) || CODEX_PROVIDER_ID,
+  }));
+  return {
+    ...result,
+    [key]: [
+      ...normalizedCodexModels,
+      ...claudeModels,
+    ],
+  };
+}
+
+function mergeThreadListResult(codexResult, claudeThreads) {
+  const result = codexResult && typeof codexResult === "object" ? codexResult : {};
+  const key = firstArrayKey(result, ["data", "items", "threads"]) || "data";
+  const codexThreads = Array.isArray(result[key]) ? result[key] : [];
+  const merged = [
+    ...codexThreads,
+    ...claudeThreads,
+  ].sort((lhs, rhs) => {
+    const lhsTime = Date.parse(lhs?.updatedAt || lhs?.updated_at || lhs?.createdAt || lhs?.created_at || 0) || 0;
+    const rhsTime = Date.parse(rhs?.updatedAt || rhs?.updated_at || rhs?.createdAt || rhs?.created_at || 0) || 0;
+    return rhsTime - lhsTime;
+  });
+  return {
+    ...result,
+    [key]: merged,
+  };
+}
+
+function firstArrayKey(value, keys) {
+  return keys.find((key) => Array.isArray(value?.[key])) || "";
+}
+
+function hasCursor(params = {}) {
+  const cursor = params.cursor ?? params.nextCursor ?? params.next_cursor;
+  return cursor != null && cursor !== "" && cursor !== false;
+}
+
+function readThreadId(params = {}) {
+  return readString(params.threadId || params.thread_id || params.id);
+}
+
+function readString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function createJsonRpcErrorResponse(requestId, error, defaultErrorCode) {
+  return JSON.stringify({
+    id: requestId,
+    error: {
+      code: -32000,
+      message: error?.userMessage || error?.message || "Runtime provider request failed.",
+      data: {
+        errorCode: error?.errorCode || defaultErrorCode,
+      },
+    },
+  });
+}
+
+function safeParseJSON(rawMessage) {
+  try {
+    return JSON.parse(rawMessage);
+  } catch {
+    return null;
+  }
+}
+
+module.exports = {
+  createRuntimeProviderRouter,
+  mergeModelListResult,
+  mergeThreadListResult,
+  shouldRouteToClaude,
+};

--- a/phodex-bridge/test/bridge.test.js
+++ b/phodex-bridge/test/bridge.test.js
@@ -21,6 +21,7 @@ const {
   resolveJsonlTurnsListRolloutPathForFallback,
   sanitizeLiveGeneratedImageMessageForRelay,
   sanitizeThreadHistoryImagesForRelay,
+  stripProviderFieldsForCodex,
 } = require("../src/bridge");
 
 function expectedGeneratedImagePath(threadId, fileName) {
@@ -78,6 +79,31 @@ test("normalizeRelayBoundJsonRpcMessage unwraps nested app-server result payload
       nextCursor: null,
     },
   });
+});
+
+test("stripProviderFieldsForCodex removes bridge-only provider metadata", () => {
+  const stripped = JSON.parse(stripProviderFieldsForCodex(JSON.stringify({
+    id: "turn-1",
+    method: "turn/start",
+    params: {
+      threadId: "thread-1",
+      model: "gpt-5.5",
+      modelProvider: "codex",
+      provider: "codex",
+      collaborationMode: {
+        mode: "plan",
+        settings: {
+          model: "gpt-5.5",
+          modelProvider: "codex",
+        },
+      },
+    },
+  })));
+
+  assert.equal(stripped.params.modelProvider, undefined);
+  assert.equal(stripped.params.provider, undefined);
+  assert.equal(stripped.params.collaborationMode.settings.modelProvider, undefined);
+  assert.equal(stripped.params.model, "gpt-5.5");
 });
 
 test("normalizeRelayBoundJsonRpcMessage drops non-RPC relay payloads before iOS decode", () => {

--- a/phodex-bridge/test/claude-models.test.js
+++ b/phodex-bridge/test/claude-models.test.js
@@ -1,0 +1,83 @@
+// FILE: claude-models.test.js
+// Purpose: Verifies Claude Code model metadata and executable resolution helpers.
+// Layer: Unit test
+// Exports: node:test suite
+// Depends on: node:test, node:assert/strict, ../src/claude-models
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  CLAUDE_MODELS,
+  normalizeClaudeEffort,
+  readModelProvider,
+  resolveClaudeCodeExecutable,
+} = require("../src/claude-models");
+
+test("Claude model list exposes provider metadata and effort options", () => {
+  assert.deepEqual(CLAUDE_MODELS.map((model) => model.displayName), [
+    "Claude Opus 4.7",
+    "Claude Opus 4.6",
+    "Claude Opus 4.5",
+    "Claude Sonnet 4.6",
+    "Claude Haiku 4.5",
+  ]);
+  assert.equal(CLAUDE_MODELS.every((model) => model.modelProvider === "claude"), true);
+  assert.equal(CLAUDE_MODELS[0].supportedReasoningEfforts.at(-1).reasoningEffort, "xhigh");
+});
+
+test("readModelProvider tolerates legacy and harness spelling", () => {
+  assert.equal(readModelProvider({}), "codex");
+  assert.equal(readModelProvider({ model_provider: "claude-code" }), "claude");
+  assert.equal(readModelProvider({ harness: "claude" }), "claude");
+});
+
+test("normalizeClaudeEffort preserves xhigh and accepts explicit max", () => {
+  assert.equal(normalizeClaudeEffort("low"), "low");
+  assert.equal(normalizeClaudeEffort("xhigh"), "xhigh");
+  assert.equal(normalizeClaudeEffort("extra-high"), "xhigh");
+  assert.equal(normalizeClaudeEffort("max"), "max");
+});
+
+test("resolveClaudeCodeExecutable respects feature disable flag", () => {
+  const result = resolveClaudeCodeExecutable({
+    env: { REMODEX_CLAUDE_CODE_ENABLED: "0" },
+  });
+  assert.equal(result.available, false);
+  assert.match(result.reason, /disabled/i);
+});
+
+test("resolveClaudeCodeExecutable resolves command through PATH", () => {
+  const result = resolveClaudeCodeExecutable({
+    env: { REMODEX_CLAUDE_CODE_COMMAND: "claude" },
+    execFileSyncImpl(command, args) {
+      assert.equal(command, "which");
+      assert.deepEqual(args, ["claude"]);
+      return "/usr/local/bin/claude\n";
+    },
+  });
+  assert.deepEqual(result, {
+    available: true,
+    command: "claude",
+    path: "/usr/local/bin/claude",
+    reason: "",
+  });
+});
+
+test("resolveClaudeCodeExecutable honors injected fs for path commands", () => {
+  const result = resolveClaudeCodeExecutable({
+    env: { REMODEX_CLAUDE_CODE_COMMAND: "/opt/bin/claude" },
+    fsImpl: {
+      accessSync(command, mode) {
+        assert.equal(command, "/opt/bin/claude");
+        assert.equal(mode, 1);
+      },
+    },
+  });
+
+  assert.deepEqual(result, {
+    available: true,
+    command: "/opt/bin/claude",
+    path: "/opt/bin/claude",
+    reason: "",
+  });
+});

--- a/phodex-bridge/test/claude-provider.test.js
+++ b/phodex-bridge/test/claude-provider.test.js
@@ -1,0 +1,565 @@
+// FILE: claude-provider.test.js
+// Purpose: Verifies Claude provider request handling without launching Claude Code.
+// Layer: Unit test
+// Exports: node:test suite
+// Depends on: node:test, node:assert/strict, fs, os, path, ../src/claude-provider
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { createClaudeProvider, permissionModeFromParams } = require("../src/claude-provider");
+const { createClaudeThreadStore } = require("../src/claude-thread-store");
+
+test("permissionModeFromParams maps Remodex access payloads to Claude modes", () => {
+  assert.equal(permissionModeFromParams({ approvalPolicy: "never" }), "bypassPermissions");
+  assert.equal(permissionModeFromParams({ sandbox: "danger-full-access" }), "bypassPermissions");
+  assert.equal(permissionModeFromParams({ collaborationMode: { mode: "plan" } }), "plan");
+  assert.equal(permissionModeFromParams({ approvalPolicy: "on-request" }), "default");
+});
+
+test("Claude provider starts a thread and records a turn from SDK stream messages", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-claude-provider-"));
+  const sent = [];
+  const store = createClaudeThreadStore({
+    stateDir: tempDir,
+    now: fixedClock([
+      "2026-01-01T00:00:00.000Z",
+      "2026-01-01T00:00:01.000Z",
+      "2026-01-01T00:00:02.000Z",
+      "2026-01-01T00:00:03.000Z",
+      "2026-01-01T00:00:04.000Z",
+    ]),
+  });
+  const provider = createClaudeProvider({
+    store,
+    sendApplicationMessage(message) {
+      sent.push(JSON.parse(message));
+    },
+    executableResolver: () => ({ available: true, path: "/usr/local/bin/claude", reason: "" }),
+    sdkLoader: () => ({
+      query() {
+        return makeQuery([
+          {
+            type: "system",
+            subtype: "init",
+            session_id: "session-1",
+          },
+          {
+            type: "stream_event",
+            event: {
+              type: "content_block_delta",
+              delta: { type: "text_delta", text: "hello" },
+            },
+          },
+          {
+            type: "result",
+            subtype: "success",
+            is_error: false,
+            session_id: "session-1",
+          },
+        ]);
+      },
+    }),
+  });
+
+  const startResult = await provider.handleRequest({
+    method: "thread/start",
+    params: {
+      model: "claude-opus-4-7",
+      cwd: tempDir,
+    },
+  });
+  const turnResult = await provider.handleRequest({
+    method: "turn/start",
+    params: {
+      threadId: startResult.thread.id,
+      model: "claude-opus-4-7",
+      input: [{ type: "text", text: "Say hello" }],
+    },
+  });
+
+  await waitFor(() => sent.some((message) => message.method === "turn/completed"));
+
+  assert.equal(turnResult.turn.status, "running");
+  assert.equal(sent.some((message) => message.method === "item/agentMessage/delta"), true);
+
+  const readResult = store.readThread(startResult.thread.id);
+  assert.equal(readResult.thread.turns[0].items[0].text, "Say hello");
+  assert.equal(readResult.thread.turns[0].items[1].text, "hello");
+  assert.equal(readResult.thread.turns[0].status, "completed");
+});
+
+test("Claude provider skips consolidated thinking after streamed thinking deltas", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-claude-thinking-"));
+  const sent = [];
+  const store = createClaudeThreadStore({ stateDir: tempDir });
+  const provider = createClaudeProvider({
+    store,
+    sendApplicationMessage(message) {
+      sent.push(JSON.parse(message));
+    },
+    executableResolver: () => ({ available: true, path: "/usr/local/bin/claude", reason: "" }),
+    sdkLoader: () => ({
+      query() {
+        return makeQuery([
+          {
+            type: "stream_event",
+            event: {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "thinking_delta", thinking: "think" },
+            },
+          },
+          {
+            type: "assistant",
+            message: {
+              content: [
+                { type: "thinking", thinking: "think" },
+              ],
+            },
+          },
+          {
+            type: "result",
+            subtype: "success",
+            is_error: false,
+          },
+        ]);
+      },
+    }),
+  });
+
+  const startResult = await provider.handleRequest({ method: "thread/start", params: { cwd: tempDir } });
+  await provider.handleRequest({
+    method: "turn/start",
+    params: {
+      threadId: startResult.thread.id,
+      input: [{ type: "text", text: "Think once" }],
+    },
+  });
+  await waitFor(() => sent.some((message) => message.method === "turn/completed"));
+
+  const reasoningDeltas = sent.filter((message) => message.method === "item/reasoning/textDelta");
+  assert.equal(reasoningDeltas.length, 1);
+  const readResult = store.readThread(startResult.thread.id);
+  assert.equal(readResult.thread.turns[0].items.find((item) => item.type === "reasoning").text, "think");
+});
+
+test("Claude provider attaches tool results to the originating tool item", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-claude-tool-result-"));
+  const sent = [];
+  const store = createClaudeThreadStore({ stateDir: tempDir });
+  const provider = createClaudeProvider({
+    store,
+    sendApplicationMessage(message) {
+      sent.push(JSON.parse(message));
+    },
+    executableResolver: () => ({ available: true, path: "/usr/local/bin/claude", reason: "" }),
+    sdkLoader: () => ({
+      query() {
+        return makeQuery([
+          {
+            type: "assistant",
+            message: {
+              content: [
+                { type: "tool_use", id: "tool-1", name: "Bash", input: { command: "npm test" } },
+              ],
+            },
+          },
+          {
+            type: "user",
+            message: {
+              content: [
+                { type: "tool_result", tool_use_id: "tool-1", content: "ok" },
+              ],
+            },
+          },
+          {
+            type: "result",
+            subtype: "success",
+            is_error: false,
+          },
+        ]);
+      },
+    }),
+  });
+
+  const startResult = await provider.handleRequest({ method: "thread/start", params: { cwd: tempDir } });
+  await provider.handleRequest({
+    method: "turn/start",
+    params: {
+      threadId: startResult.thread.id,
+      input: [{ type: "text", text: "Run tests" }],
+    },
+  });
+  await waitFor(() => sent.some((message) => message.method === "turn/completed"));
+
+  const commandDeltas = sent.filter((message) => message.method === "item/commandExecution/outputDelta");
+  assert.equal(commandDeltas.length, 2);
+  assert.equal(commandDeltas[0].params.itemId, commandDeltas[1].params.itemId);
+  const readResult = store.readThread(startResult.thread.id);
+  const commandItem = readResult.thread.turns[0].items.find((item) => item.type === "commandExecution");
+  assert.equal(commandItem.text, "$ npm test\nok");
+});
+
+test("Claude provider keeps post-tool assistant text in a later item when stream indexes reset", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-claude-multistep-"));
+  const sent = [];
+  const store = createClaudeThreadStore({ stateDir: tempDir });
+  const provider = createClaudeProvider({
+    store,
+    sendApplicationMessage(message) {
+      sent.push(JSON.parse(message));
+    },
+    executableResolver: () => ({ available: true, path: "/usr/local/bin/claude", reason: "" }),
+    sdkLoader: () => ({
+      query() {
+        return makeQuery([
+          {
+            type: "stream_event",
+            event: { type: "message_start" },
+          },
+          {
+            type: "stream_event",
+            event: { type: "content_block_start", index: 0 },
+          },
+          {
+            type: "stream_event",
+            event: {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "text_delta", text: "before" },
+            },
+          },
+          {
+            type: "assistant",
+            message: {
+              content: [
+                { type: "text", text: "before" },
+                { type: "tool_use", id: "tool-1", name: "Bash", input: { command: "npm test" } },
+              ],
+            },
+          },
+          {
+            type: "user",
+            message: {
+              content: [
+                { type: "tool_result", tool_use_id: "tool-1", content: "ok" },
+              ],
+            },
+          },
+          {
+            type: "stream_event",
+            event: { type: "message_start" },
+          },
+          {
+            type: "stream_event",
+            event: { type: "content_block_start", index: 0 },
+          },
+          {
+            type: "stream_event",
+            event: {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "text_delta", text: "after" },
+            },
+          },
+          {
+            type: "assistant",
+            message: {
+              content: [
+                { type: "text", text: "after" },
+              ],
+            },
+          },
+          {
+            type: "result",
+            subtype: "success",
+            is_error: false,
+          },
+        ]);
+      },
+    }),
+  });
+
+  const startResult = await provider.handleRequest({ method: "thread/start", params: { cwd: tempDir } });
+  await provider.handleRequest({
+    method: "turn/start",
+    params: {
+      threadId: startResult.thread.id,
+      input: [{ type: "text", text: "Run tests then summarize" }],
+    },
+  });
+  await waitFor(() => sent.some((message) => message.method === "turn/completed"));
+
+  const agentDeltas = sent.filter((message) => message.method === "item/agentMessage/delta");
+  assert.equal(agentDeltas.length, 2);
+  assert.notEqual(agentDeltas[0].params.itemId, agentDeltas[1].params.itemId);
+
+  const readResult = store.readThread(startResult.thread.id);
+  assert.deepEqual(readResult.thread.turns[0].items.map((item) => item.type), [
+    "userMessage",
+    "agentMessage",
+    "commandExecution",
+    "agentMessage",
+  ]);
+  assert.equal(readResult.thread.turns[0].items[1].text, "before");
+  assert.equal(readResult.thread.turns[0].items[2].text, "$ npm test\nok");
+  assert.equal(readResult.thread.turns[0].items[3].text, "after");
+});
+
+test("Claude provider emits one terminal event when an interrupted query rejects", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-claude-interrupt-"));
+  const sent = [];
+  let capturedAbortController;
+  const provider = createClaudeProvider({
+    store: createClaudeThreadStore({ stateDir: tempDir }),
+    sendApplicationMessage(message) {
+      sent.push(JSON.parse(message));
+    },
+    executableResolver: () => ({ available: true, path: "/usr/local/bin/claude", reason: "" }),
+    sdkLoader: () => ({
+      query({ options }) {
+        capturedAbortController = options.abortController;
+        return {
+          async *[Symbol.asyncIterator]() {
+            await new Promise((resolve) => {
+              capturedAbortController.signal.addEventListener("abort", resolve, { once: true });
+            });
+            throw new Error("aborted");
+          },
+          async interrupt() {},
+        };
+      },
+    }),
+  });
+
+  const startResult = await provider.handleRequest({ method: "thread/start", params: { cwd: tempDir } });
+  const turnResult = await provider.handleRequest({
+    method: "turn/start",
+    params: {
+      threadId: startResult.thread.id,
+      input: [{ type: "text", text: "Stop me" }],
+    },
+  });
+  await waitFor(() => capturedAbortController);
+  await provider.handleRequest({
+    method: "turn/interrupt",
+    params: {
+      threadId: startResult.thread.id,
+      turnId: turnResult.turnId,
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  const completions = sent.filter((message) => message.method === "turn/completed");
+  assert.equal(completions.length, 1);
+  assert.equal(completions[0].params.status, "stopped");
+});
+
+test("Claude provider sends data URL images as SDK image content blocks", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-claude-image-"));
+  let capturedPrompt;
+  const provider = createClaudeProvider({
+    store: createClaudeThreadStore({ stateDir: tempDir }),
+    sendApplicationMessage() {},
+    executableResolver: () => ({ available: true, path: "/usr/local/bin/claude", reason: "" }),
+    sdkLoader: () => ({
+      query({ prompt }) {
+        capturedPrompt = prompt;
+        return makeQuery([
+          {
+            type: "result",
+            subtype: "success",
+            is_error: false,
+          },
+        ]);
+      },
+    }),
+  });
+
+  const startResult = await provider.handleRequest({ method: "thread/start", params: { cwd: tempDir } });
+  await provider.handleRequest({
+    method: "turn/start",
+    params: {
+      threadId: startResult.thread.id,
+      input: [
+        { type: "image", image_url: "data:image/png;base64,aGVsbG8=" },
+        { type: "text", text: "Describe it" },
+      ],
+    },
+  });
+  await waitFor(() => capturedPrompt);
+  const messages = [];
+  for await (const message of capturedPrompt) {
+    messages.push(message);
+  }
+
+  assert.equal(messages[0].type, "user");
+  assert.equal(messages[0].message.content[0].type, "image");
+  assert.equal(messages[0].message.content[0].source.media_type, "image/png");
+  assert.equal(messages[0].message.content[0].source.data, "aGVsbG8=");
+  assert.deepEqual(messages[0].message.content[1], { type: "text", text: "Describe it" });
+});
+
+test("Claude provider caches executable availability checks", () => {
+  let resolveCount = 0;
+  const provider = createClaudeProvider({
+    sendApplicationMessage() {},
+    executableResolver: () => {
+      resolveCount += 1;
+      return { available: true, path: "/usr/local/bin/claude", reason: "" };
+    },
+  });
+
+  assert.equal(provider.listModels().length > 0, true);
+  assert.equal(provider.listModels().length > 0, true);
+  assert.equal(resolveCount, 1);
+});
+
+test("Claude provider rejects concurrent turns on the same thread", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-claude-concurrent-"));
+  let capturedAbortController;
+  const provider = createClaudeProvider({
+    store: createClaudeThreadStore({ stateDir: tempDir }),
+    sendApplicationMessage() {},
+    executableResolver: () => ({ available: true, path: "/usr/local/bin/claude", reason: "" }),
+    sdkLoader: () => ({
+      query({ options }) {
+        capturedAbortController = options.abortController;
+        return {
+          async *[Symbol.asyncIterator]() {
+            await new Promise((resolve) => {
+              capturedAbortController.signal.addEventListener("abort", resolve, { once: true });
+            });
+            throw new Error("aborted");
+          },
+          async interrupt() {},
+        };
+      },
+    }),
+  });
+
+  const startResult = await provider.handleRequest({ method: "thread/start", params: { cwd: tempDir } });
+  const firstTurn = await provider.handleRequest({
+    method: "turn/start",
+    params: {
+      threadId: startResult.thread.id,
+      input: [{ type: "text", text: "First" }],
+    },
+  });
+  await waitFor(() => capturedAbortController);
+
+  await assert.rejects(
+    provider.handleRequest({
+      method: "turn/start",
+      params: {
+        threadId: startResult.thread.id,
+        input: [{ type: "text", text: "Second" }],
+      },
+    }),
+    /already has an active turn/
+  );
+
+  await provider.handleRequest({
+    method: "turn/interrupt",
+    params: {
+      threadId: startResult.thread.id,
+      turnId: firstTurn.turnId,
+    },
+  });
+});
+
+test("Claude provider bridges tool approval responses to SDK permission results", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-claude-approval-"));
+  const sent = [];
+  const provider = createClaudeProvider({
+    store: createClaudeThreadStore({ stateDir: tempDir }),
+    sendApplicationMessage(message) {
+      sent.push(JSON.parse(message));
+    },
+  });
+
+  const approvalPromise = provider.requestToolApproval({
+    threadId: "thread-1",
+    turnId: "turn-1",
+    toolName: "Bash",
+    input: { command: "npm test" },
+    approvalOptions: {},
+  });
+
+  assert.equal(sent[0].method, "item/commandExecution/requestApproval");
+  assert.equal(provider.handleApplicationResponse({
+    id: sent[0].id,
+    result: { decision: "accept" },
+  }), true);
+
+  assert.deepEqual(await approvalPromise, {
+    behavior: "allow",
+    updatedInput: { command: "npm test" },
+  });
+});
+
+test("Claude provider carries session approval suggestions back to the SDK", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remodex-claude-session-approval-"));
+  const sent = [];
+  const provider = createClaudeProvider({
+    store: createClaudeThreadStore({ stateDir: tempDir }),
+    sendApplicationMessage(message) {
+      sent.push(JSON.parse(message));
+    },
+  });
+  const suggestion = {
+    toolName: "Bash",
+    ruleContent: "Bash(npm test)",
+    destination: "session",
+  };
+
+  const approvalPromise = provider.requestToolApproval({
+    threadId: "thread-1",
+    turnId: "turn-1",
+    toolName: "Bash",
+    input: { command: "npm test" },
+    approvalOptions: { suggestions: [suggestion] },
+  });
+
+  assert.equal(provider.handleApplicationResponse({
+    id: sent[0].id,
+    result: { decision: "acceptForSession" },
+  }), true);
+
+  assert.deepEqual(await approvalPromise, {
+    behavior: "allow",
+    updatedInput: { command: "npm test" },
+    updatedPermissions: [suggestion],
+  });
+});
+
+function makeQuery(messages) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const message of messages) {
+        await Promise.resolve();
+        yield message;
+      }
+    },
+    async interrupt() {},
+  };
+}
+
+function fixedClock(values) {
+  let index = 0;
+  return () => new Date(values[Math.min(index++, values.length - 1)]);
+}
+
+async function waitFor(predicate, timeoutMs = 500) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.fail("Timed out waiting for predicate");
+}

--- a/phodex-bridge/test/runtime-provider-router.test.js
+++ b/phodex-bridge/test/runtime-provider-router.test.js
@@ -1,0 +1,60 @@
+// FILE: runtime-provider-router.test.js
+// Purpose: Verifies provider-aware model/thread routing helpers.
+// Layer: Unit test
+// Exports: node:test suite
+// Depends on: node:test, node:assert/strict, ../src/runtime-provider-router
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  mergeModelListResult,
+  mergeThreadListResult,
+  shouldRouteToClaude,
+} = require("../src/runtime-provider-router");
+
+test("mergeModelListResult tags Codex models and appends Claude models", () => {
+  const result = mergeModelListResult({
+    items: [
+      { id: "gpt-5.5", model: "gpt-5.5", displayName: "GPT-5.5" },
+    ],
+  }, [
+    { id: "claude-opus-4-7", model: "claude-opus-4-7", modelProvider: "claude" },
+  ]);
+
+  assert.equal(result.items[0].modelProvider, "codex");
+  assert.equal(result.items[0].provider, "codex");
+  assert.equal(result.items[1].modelProvider, "claude");
+});
+
+test("mergeThreadListResult keeps newest provider threads first", () => {
+  const result = mergeThreadListResult({
+    data: [
+      { id: "codex-old", updatedAt: "2026-01-01T00:00:00.000Z" },
+    ],
+  }, [
+    { id: "claude-new", updatedAt: "2026-01-02T00:00:00.000Z", modelProvider: "claude" },
+  ]);
+
+  assert.deepEqual(result.data.map((thread) => thread.id), ["claude-new", "codex-old"]);
+});
+
+test("shouldRouteToClaude uses request provider or stored thread ownership", () => {
+  const provider = {
+    ownsThread(threadId) {
+      return threadId === "claude-thread";
+    },
+  };
+
+  assert.equal(shouldRouteToClaude({
+    method: "thread/start",
+    params: { modelProvider: "claude" },
+  }, provider), true);
+  assert.equal(shouldRouteToClaude({
+    method: "turn/start",
+    params: { threadId: "claude-thread" },
+  }, provider), true);
+  assert.equal(shouldRouteToClaude({
+    method: "turn/start",
+    params: { threadId: "codex-thread" },
+  }, provider), false);
+});


### PR DESCRIPTION
## Summary

Adds Claude Code as a first-class Remodex runtime provider alongside Codex, using the user's existing local Claude Code login through `@anthropic-ai/claude-agent-sdk`.

This keeps Codex as the default/backward-compatible path, adds provider-aware model selection in the iOS app, and routes Claude-owned threads/turns through the local bridge without storing Anthropic API keys or Claude credentials.

## What changed

- Adds provider-aware model metadata, including stable `provider:model` selection keys.
- Updates runtime defaults, thread overrides, and turn/thread-start payloads to carry `modelProvider`.
- Adds a provider-grouped model selector so the app can show Codex and Claude models separately.
- Adds a bridge runtime provider router that keeps Codex requests on the existing path and routes Claude requests to the Claude provider.
- Adds a Claude provider backed by `@anthropic-ai/claude-agent-sdk`, using the local `claude` executable and existing Claude Code auth/session state.
- Merges Claude models into `model/list` only when Claude Code is available, with `REMODEX_CLAUDE_CODE_ENABLED=0` as an opt-out.
- Streams Claude text, reasoning, tool calls, tool results, file changes, approvals, interrupts, and terminal states into existing Remodex timeline events.
- Persists Claude thread metadata under the existing Remodex state root with no secrets stored.
- Adds bridge regression coverage for model merging, availability caching, effort normalization, streaming dedupe, multi-message ordering, tool result attachment, image inputs, approvals, interrupts, shutdown, and concurrent-turn rejection.

## Compatibility / scope

- Legacy Codex behavior remains the default when `modelProvider` is missing.
- Provider metadata is stripped before forwarding requests to Codex, so the existing Codex transport stays unchanged.
- The relay remains provider-agnostic encrypted transport.
- V1 exposes only Codex and Claude providers.

## Validation

- `cd phodex-bridge && npm test`  
  - 384 passing
- `git diff --check`
- `xcodebuild -project CodexMobile.xcodeproj -scheme CodexMobile -destination 'generic/platform=iOS Simulator' -configuration Debug EXCLUDED_ARCHS=x86_64 build`
  - Build succeeded
- Physical-device smoke setup was also exercised with a local signing override and local relay route for an iPhone 16 Pro.

Not run:
- Full iOS XCTest suite.