### PR TITLE
perf: full-stack performance upgrade for low-network environments

### DIFF
--- a/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
@@ -29,14 +29,16 @@ extension CodexService {
 
         // Foreground polling is intentionally more aggressive so desktop-authored changes
         // feel closer to live on iPhone even when Codex.app itself doesn't push updates.
-        let listIntervalForegroundNs: UInt64 = 10_000_000_000
-        let listIntervalBackgroundNs: UInt64 = 75_000_000_000
-        let historyIntervalForegroundNs: UInt64 = 3_000_000_000
-        let historyIntervalForegroundMirroredNs: UInt64 = 1_000_000_000
+        // Low-network multiplier stretches intervals when connectivity is constrained.
+        let networkMultiplier: UInt64 = isConstrainedNetwork ? 2 : 1
+        let listIntervalForegroundNs: UInt64 = 10_000_000_000 * networkMultiplier
+        let listIntervalBackgroundNs: UInt64 = 75_000_000_000 * networkMultiplier
+        let historyIntervalForegroundNs: UInt64 = 3_000_000_000 * networkMultiplier
+        let historyIntervalForegroundMirroredNs: UInt64 = 1_000_000_000 * networkMultiplier
         let historyIntervalBackgroundIdleNs: UInt64 = 90_000_000_000
-        let historyIntervalBackgroundRunningNs: UInt64 = 12_000_000_000
-        let watchIntervalForegroundNs: UInt64 = 2_000_000_000
-        let watchIntervalBackgroundNs: UInt64 = 15_000_000_000
+        let historyIntervalBackgroundRunningNs: UInt64 = 12_000_000_000 * networkMultiplier
+        let watchIntervalForegroundNs: UInt64 = 2_000_000_000 * networkMultiplier
+        let watchIntervalBackgroundNs: UInt64 = 15_000_000_000 * networkMultiplier
 
         threadListSyncTask = Task { [weak self] in
             while let self, !Task.isCancelled {
@@ -217,6 +219,7 @@ extension CodexService {
         let persistedDeletedIDs = locallyDeletedThreadIDs
 
         var merged: [String: CodexThread] = [:]
+        merged.reserveCapacity(max(threads.count, serverThreads.count))
         var snapshotOnlyPinnedIDs: Set<String> = []
 
         // Merge active server threads.

--- a/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
@@ -35,7 +35,7 @@ extension CodexService {
         let listIntervalBackgroundNs: UInt64 = 75_000_000_000 * networkMultiplier
         let historyIntervalForegroundNs: UInt64 = 3_000_000_000 * networkMultiplier
         let historyIntervalForegroundMirroredNs: UInt64 = 1_000_000_000 * networkMultiplier
-        let historyIntervalBackgroundIdleNs: UInt64 = 90_000_000_000
+        let historyIntervalBackgroundIdleNs: UInt64 = 90_000_000_000 * networkMultiplier
         let historyIntervalBackgroundRunningNs: UInt64 = 12_000_000_000 * networkMultiplier
         let watchIntervalForegroundNs: UInt64 = 2_000_000_000 * networkMultiplier
         let watchIntervalBackgroundNs: UInt64 = 15_000_000_000 * networkMultiplier

--- a/CodexMobile/CodexMobile/Services/CodexService+Transport.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Transport.swift
@@ -16,7 +16,7 @@ let codexWebSocketMaximumMessageSizeBytes = 16 * 1024 * 1024
 
 private enum CodexWebSocketKeepAlivePolicy {
     static let intervalNanoseconds: UInt64 = 25_000_000_000
-    static let constrainedIntervalNanoseconds: UInt64 = 45_000_000_000
+    static let constrainedIntervalNanoseconds: UInt64 = 35_000_000_000
 }
 
 private enum CodexRelayTransportPreference {

--- a/CodexMobile/CodexMobile/Services/CodexService+Transport.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Transport.swift
@@ -16,6 +16,7 @@ let codexWebSocketMaximumMessageSizeBytes = 16 * 1024 * 1024
 
 private enum CodexWebSocketKeepAlivePolicy {
     static let intervalNanoseconds: UInt64 = 25_000_000_000
+    static let constrainedIntervalNanoseconds: UInt64 = 45_000_000_000
 }
 
 private enum CodexRelayTransportPreference {
@@ -122,7 +123,7 @@ nonisolated private func codexLogPairingTransport(_ message: String) {
 extension CodexService {
     // Rejects oversized relay frames before Network.framework turns them into a raw EMSGSIZE failure.
     func validateOutgoingWebSocketMessageSize(_ text: String) throws {
-        let payloadSize = Data(text.utf8).count
+        let payloadSize = text.utf8.count
         guard payloadSize <= codexWebSocketMaximumMessageSizeBytes else {
             throw CodexServiceError.invalidInput(
                 "This payload is too large for the relay connection. Try fewer or smaller images and retry."
@@ -327,8 +328,11 @@ extension CodexService {
 
         webSocketKeepAliveTask = Task { @MainActor [weak self] in
             while let self, !Task.isCancelled {
+                let defaultInterval = self.isConstrainedNetwork
+                    ? CodexWebSocketKeepAlivePolicy.constrainedIntervalNanoseconds
+                    : CodexWebSocketKeepAlivePolicy.intervalNanoseconds
                 let interval = self.webSocketKeepAliveIntervalOverrideNanoseconds
-                    ?? CodexWebSocketKeepAlivePolicy.intervalNanoseconds
+                    ?? defaultInterval
                 try? await Task.sleep(nanoseconds: interval)
                 guard !Task.isCancelled else {
                     return

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -555,6 +555,10 @@ final class CodexService {
     // Coalesces sidebar/bootstrap thread/list refreshes so launch paths do not duplicate the same fetch.
     @ObservationIgnored var threadListFetchTaskByLimit: [Int: (id: UUID, task: Task<[CodexThread], Error>)] = [:]
     var isAppInForeground = true
+    // Network quality flag: when true, sync and keepalive intervals are stretched to reduce
+    // bandwidth usage on constrained (cellular, low-signal) connections.
+    var isConstrainedNetwork = false
+    @ObservationIgnored var networkPathMonitor: NWPathMonitor?
     var threadListSyncTask: Task<Void, Never>?
     var activeThreadSyncTask: Task<Void, Never>?
     var runningThreadWatchSyncTask: Task<Void, Never>?
@@ -912,6 +916,26 @@ final class CodexService {
             self.secureMacFingerprint = codexSecureFingerprint(for: trustedMac.macIdentityPublicKey)
         }
         rebuildThreadLookupCaches()
+        startNetworkPathMonitor()
+    }
+
+    func startNetworkPathMonitor() {
+        networkPathMonitor?.cancel()
+        let monitor = NWPathMonitor()
+        networkPathMonitor = monitor
+        monitor.pathUpdateHandler = { [weak self] path in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let constrained = path.isConstrained || path.isExpensive
+                if self.isConstrainedNetwork != constrained {
+                    self.isConstrainedNetwork = constrained
+                    if self.isConnected, self.isInitialized {
+                        self.startSyncLoop()
+                    }
+                }
+            }
+        }
+        monitor.start(queue: DispatchQueue(label: "CodexMobile.NetworkPathMonitor", qos: .utility))
     }
 
     // Persists per-thread plan-mode provenance so reconnect/relaunch keeps native vs fallback behavior stable.

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -556,7 +556,7 @@ final class CodexService {
     @ObservationIgnored var threadListFetchTaskByLimit: [Int: (id: UUID, task: Task<[CodexThread], Error>)] = [:]
     var isAppInForeground = true
     // Network quality flag: when true, sync and keepalive intervals are stretched to reduce
-    // bandwidth usage on constrained (cellular, low-signal) connections.
+    // bandwidth usage on constrained connections (Low Data Mode, hotspot tethering).
     var isConstrainedNetwork = false
     @ObservationIgnored var networkPathMonitor: NWPathMonitor?
     var threadListSyncTask: Task<Void, Never>?
@@ -926,7 +926,7 @@ final class CodexService {
         monitor.pathUpdateHandler = { [weak self] path in
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                let constrained = path.isConstrained || path.isExpensive
+                let constrained = path.isConstrained
                 if self.isConstrainedNetwork != constrained {
                     self.isConstrainedNetwork = constrained
                     if self.isConnected, self.isInitialized {
@@ -936,6 +936,10 @@ final class CodexService {
             }
         }
         monitor.start(queue: DispatchQueue(label: "CodexMobile.NetworkPathMonitor", qos: .utility))
+    }
+
+    deinit {
+        networkPathMonitor?.cancel()
     }
 
     // Persists per-thread plan-mode provenance so reconnect/relaunch keeps native vs fallback behavior stable.

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -924,9 +924,9 @@ final class CodexService {
         let monitor = NWPathMonitor()
         networkPathMonitor = monitor
         monitor.pathUpdateHandler = { [weak self] path in
+            let constrained = path.isConstrained
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                let constrained = path.isConstrained
                 if self.isConstrainedNetwork != constrained {
                     self.isConstrainedNetwork = constrained
                     if self.isConnected, self.isInitialized {

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -106,6 +106,21 @@ const RELAY_TURNS_LIST_PAGINATION_RESULT_KEYS = [
   "previous_cursor",
 ];
 const jsonlArtifactItemsCacheByThread = new Map();
+const JSONL_ARTIFACT_CACHE_MAX_SIZE = 64;
+const FORWARDED_REQUEST_METHODS_MAX_SIZE = 500;
+
+function evictLRUEntries(map, maxSize) {
+  if (map.size <= maxSize) {
+    return;
+  }
+  const excess = map.size - maxSize;
+  const iterator = map.keys();
+  for (let i = 0; i < excess; i += 1) {
+    const key = iterator.next().value;
+    map.delete(key);
+  }
+}
+
 function startBridge({
   config: explicitConfig = null,
   printPairingQr = true,
@@ -382,7 +397,9 @@ function startBridge({
     }
 
     reconnectAttempt += 1;
-    const delayMs = Math.min(1_000 * reconnectAttempt, 5_000);
+    const baseDelayMs = Math.min(1_000 * reconnectAttempt, 5_000);
+    const jitterMs = Math.floor(Math.random() * Math.min(baseDelayMs, 2_000));
+    const delayMs = baseDelayMs + jitterMs;
     logConnectionStatus("connecting");
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
@@ -397,6 +414,11 @@ function startBridge({
 
     logConnectionStatus("connecting");
     const nextSocket = new WebSocket(relaySessionUrl, {
+      perMessageDeflate: {
+        zlibDeflateOptions: { level: 6 },
+        threshold: 256,
+        concurrencyLimit: 4,
+      },
       // The relay uses this per-session secret to authenticate the first push registration.
       headers: {
         "x-role": "mac",
@@ -998,6 +1020,11 @@ function startBridge({
         relaySanitizedResponseMethodsById.delete(requestId);
       }
     }
+    evictLRUEntries(forwardedRequestMethodsById, FORWARDED_REQUEST_METHODS_MAX_SIZE);
+    evictLRUEntries(relaySanitizedResponseMethodsById, FORWARDED_REQUEST_METHODS_MAX_SIZE);
+    evictLRUEntries(jsonlArtifactItemsCacheByThread, JSONL_ARTIFACT_CACHE_MAX_SIZE);
+    evictLRUEntries(jsonlTurnsListRolloutCacheByThread, JSONL_ARTIFACT_CACHE_MAX_SIZE);
+    evictLRUEntries(jsonlTurnsListRolloutMissCacheByThread, JSONL_ARTIFACT_CACHE_MAX_SIZE);
   }
 
   function safeParseJSON(value) {

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -109,7 +109,7 @@ const jsonlArtifactItemsCacheByThread = new Map();
 const FORWARDED_REQUEST_METHODS_MAX_SIZE = 500;
 const JSONL_ROLLOUT_PATH_CACHE_MAX_SIZE = 200;
 
-function evictLRUEntries(map, maxSize) {
+function evictOldestEntries(map, maxSize) {
   if (map.size <= maxSize) {
     return;
   }
@@ -1020,11 +1020,11 @@ function startBridge({
         relaySanitizedResponseMethodsById.delete(requestId);
       }
     }
-    evictLRUEntries(forwardedRequestMethodsById, FORWARDED_REQUEST_METHODS_MAX_SIZE);
-    evictLRUEntries(relaySanitizedResponseMethodsById, FORWARDED_REQUEST_METHODS_MAX_SIZE);
-    evictLRUEntries(jsonlArtifactItemsCacheByThread, RELAY_JSONL_ARTIFACT_CACHE_MAX_ENTRIES);
-    evictLRUEntries(jsonlTurnsListRolloutCacheByThread, JSONL_ROLLOUT_PATH_CACHE_MAX_SIZE);
-    evictLRUEntries(jsonlTurnsListRolloutMissCacheByThread, JSONL_ROLLOUT_PATH_CACHE_MAX_SIZE);
+    evictOldestEntries(forwardedRequestMethodsById, FORWARDED_REQUEST_METHODS_MAX_SIZE);
+    evictOldestEntries(relaySanitizedResponseMethodsById, FORWARDED_REQUEST_METHODS_MAX_SIZE);
+    evictOldestEntries(jsonlArtifactItemsCacheByThread, RELAY_JSONL_ARTIFACT_CACHE_MAX_ENTRIES);
+    evictOldestEntries(jsonlTurnsListRolloutCacheByThread, JSONL_ROLLOUT_PATH_CACHE_MAX_SIZE);
+    evictOldestEntries(jsonlTurnsListRolloutMissCacheByThread, JSONL_ROLLOUT_PATH_CACHE_MAX_SIZE);
   }
 
   function safeParseJSON(value) {

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -106,8 +106,8 @@ const RELAY_TURNS_LIST_PAGINATION_RESULT_KEYS = [
   "previous_cursor",
 ];
 const jsonlArtifactItemsCacheByThread = new Map();
-const JSONL_ARTIFACT_CACHE_MAX_SIZE = 64;
 const FORWARDED_REQUEST_METHODS_MAX_SIZE = 500;
+const JSONL_ROLLOUT_PATH_CACHE_MAX_SIZE = 200;
 
 function evictLRUEntries(map, maxSize) {
   if (map.size <= maxSize) {
@@ -1022,9 +1022,9 @@ function startBridge({
     }
     evictLRUEntries(forwardedRequestMethodsById, FORWARDED_REQUEST_METHODS_MAX_SIZE);
     evictLRUEntries(relaySanitizedResponseMethodsById, FORWARDED_REQUEST_METHODS_MAX_SIZE);
-    evictLRUEntries(jsonlArtifactItemsCacheByThread, JSONL_ARTIFACT_CACHE_MAX_SIZE);
-    evictLRUEntries(jsonlTurnsListRolloutCacheByThread, JSONL_ARTIFACT_CACHE_MAX_SIZE);
-    evictLRUEntries(jsonlTurnsListRolloutMissCacheByThread, JSONL_ARTIFACT_CACHE_MAX_SIZE);
+    evictLRUEntries(jsonlArtifactItemsCacheByThread, RELAY_JSONL_ARTIFACT_CACHE_MAX_ENTRIES);
+    evictLRUEntries(jsonlTurnsListRolloutCacheByThread, JSONL_ROLLOUT_PATH_CACHE_MAX_SIZE);
+    evictLRUEntries(jsonlTurnsListRolloutMissCacheByThread, JSONL_ROLLOUT_PATH_CACHE_MAX_SIZE);
   }
 
   function safeParseJSON(value) {

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -1010,16 +1010,26 @@ function startBridge({
   }
 
   function pruneExpiredForwardedRequestMethods(now = Date.now()) {
+    const expiredForwarded = [];
     for (const [requestId, trackedRequest] of forwardedRequestMethodsById.entries()) {
       if (!trackedRequest || (now - trackedRequest.createdAt) >= forwardedRequestMethodTTLms) {
-        forwardedRequestMethodsById.delete(requestId);
+        expiredForwarded.push(requestId);
       }
     }
+    for (const id of expiredForwarded) {
+      forwardedRequestMethodsById.delete(id);
+    }
+
+    const expiredSanitized = [];
     for (const [requestId, trackedRequest] of relaySanitizedResponseMethodsById.entries()) {
       if (!trackedRequest || (now - trackedRequest.createdAt) >= forwardedRequestMethodTTLms) {
-        relaySanitizedResponseMethodsById.delete(requestId);
+        expiredSanitized.push(requestId);
       }
     }
+    for (const id of expiredSanitized) {
+      relaySanitizedResponseMethodsById.delete(id);
+    }
+
     evictOldestEntries(forwardedRequestMethodsById, FORWARDED_REQUEST_METHODS_MAX_SIZE);
     evictOldestEntries(relaySanitizedResponseMethodsById, FORWARDED_REQUEST_METHODS_MAX_SIZE);
     evictOldestEntries(jsonlArtifactItemsCacheByThread, RELAY_JSONL_ARTIFACT_CACHE_MAX_ENTRIES);

--- a/phodex-bridge/src/codex-transport.js
+++ b/phodex-bridge/src/codex-transport.js
@@ -155,13 +155,12 @@ function createSpawnTransport({ env, appPath, platform, spawnImpl = spawn }) {
         return;
       }
       stdoutBuffer += chunk.toString("utf8");
-      const lines = stdoutBuffer.split("\n");
-      stdoutBuffer = lines.pop() || "";
-
-      for (const line of lines) {
-        const trimmedLine = line.trim();
-        if (trimmedLine) {
-          listeners.emitMessage(trimmedLine);
+      let newlineIndex;
+      while ((newlineIndex = stdoutBuffer.indexOf("\n")) !== -1) {
+        const line = stdoutBuffer.substring(0, newlineIndex).trim();
+        stdoutBuffer = stdoutBuffer.substring(newlineIndex + 1);
+        if (line) {
+          listeners.emitMessage(line);
         }
       }
     });

--- a/phodex-bridge/src/push-notification-service-client.js
+++ b/phodex-bridge/src/push-notification-service-client.js
@@ -85,9 +85,6 @@ function createPushNotificationServiceClient({
           signal: controller?.signal,
         });
       } catch (error) {
-        if (timeoutID) {
-          clearTimeout(timeoutID);
-        }
         lastError = error;
         if (isAbortError(error)) {
           continue;

--- a/phodex-bridge/src/push-notification-service-client.js
+++ b/phodex-bridge/src/push-notification-service-client.js
@@ -5,6 +5,8 @@
 // Depends on: global fetch
 
 const DEFAULT_PUSH_SERVICE_TIMEOUT_MS = 10_000;
+const DEFAULT_PUSH_SERVICE_RETRY_LIMIT = 2;
+const DEFAULT_PUSH_SERVICE_RETRY_BASE_DELAY_MS = 500;
 
 function createPushNotificationServiceClient({
   baseUrl = "",
@@ -55,48 +57,71 @@ function createPushNotificationServiceClient({
       return { ok: false, skipped: true };
     }
 
-    const controller = typeof AbortController === "function" && requestTimeoutMs > 0
-      ? new AbortController()
-      : null;
-    const timeoutID = controller
-      ? setTimeout(() => {
-        controller.abort(createTimeoutAbortError(requestTimeoutMs));
-      }, requestTimeoutMs)
-      : null;
+    const bodyJSON = JSON.stringify(payload);
+    let lastError = null;
+    for (let attempt = 0; attempt <= DEFAULT_PUSH_SERVICE_RETRY_LIMIT; attempt += 1) {
+      if (attempt > 0) {
+        const delayMs = DEFAULT_PUSH_SERVICE_RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
 
-    let response;
-    try {
-      response = await fetchImpl(`${normalizedBaseUrl}${pathname}`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-        },
-        body: JSON.stringify(payload),
-        signal: controller?.signal,
-      });
-    } catch (error) {
-      if (isAbortError(error)) {
-        const timeoutError = new Error(`Push service request timed out after ${requestTimeoutMs}ms`);
-        timeoutError.code = "push_request_timeout";
-        throw timeoutError;
+      const controller = typeof AbortController === "function" && requestTimeoutMs > 0
+        ? new AbortController()
+        : null;
+      const timeoutID = controller
+        ? setTimeout(() => {
+          controller.abort(createTimeoutAbortError(requestTimeoutMs));
+        }, requestTimeoutMs)
+        : null;
+
+      let response;
+      try {
+        response = await fetchImpl(`${normalizedBaseUrl}${pathname}`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: bodyJSON,
+          signal: controller?.signal,
+        });
+      } catch (error) {
+        if (timeoutID) {
+          clearTimeout(timeoutID);
+        }
+        lastError = error;
+        if (isAbortError(error)) {
+          continue;
+        }
+        if (isRetryableNetworkError(error)) {
+          continue;
+        }
+        throw error;
+      } finally {
+        if (timeoutID) {
+          clearTimeout(timeoutID);
+        }
       }
-      throw error;
-    } finally {
-      if (timeoutID) {
-        clearTimeout(timeoutID);
+
+      const responseText = await response.text();
+      const parsed = safeParseJSON(responseText);
+      if (!response.ok) {
+        const message = parsed?.error || parsed?.message || responseText || `HTTP ${response.status}`;
+        const error = new Error(message);
+        error.status = response.status;
+        if (response.status >= 500 && attempt < DEFAULT_PUSH_SERVICE_RETRY_LIMIT) {
+          lastError = error;
+          continue;
+        }
+        throw error;
       }
+
+      return parsed ?? { ok: true };
     }
 
-    const responseText = await response.text();
-    const parsed = safeParseJSON(responseText);
-    if (!response.ok) {
-      const message = parsed?.error || parsed?.message || responseText || `HTTP ${response.status}`;
-      const error = new Error(message);
-      error.status = response.status;
-      throw error;
+    if (lastError) {
+      throw lastError;
     }
-
-    return parsed ?? { ok: true };
+    return { ok: false };
   }
 
   return {
@@ -132,6 +157,13 @@ function createTimeoutAbortError(timeoutMs) {
 
 function isAbortError(error) {
   return error?.name === "AbortError" || error?.code === "ABORT_ERR";
+}
+
+function isRetryableNetworkError(error) {
+  const code = error?.code ?? "";
+  return code === "ECONNRESET" || code === "ECONNREFUSED" || code === "ETIMEDOUT"
+    || code === "ENETUNREACH" || code === "EHOSTUNREACH" || code === "ENOTFOUND"
+    || error?.message?.includes("fetch failed");
 }
 
 function safeParseJSON(value) {

--- a/phodex-bridge/src/push-notification-service-client.js
+++ b/phodex-bridge/src/push-notification-service-client.js
@@ -15,8 +15,16 @@ function createPushNotificationServiceClient({
   fetchImpl = globalThis.fetch,
   logPrefix = "[remodex]",
   requestTimeoutMs = DEFAULT_PUSH_SERVICE_TIMEOUT_MS,
+  retryLimit = DEFAULT_PUSH_SERVICE_RETRY_LIMIT,
+  retryBaseDelayMs = DEFAULT_PUSH_SERVICE_RETRY_BASE_DELAY_MS,
+  sleepImpl = sleep,
 } = {}) {
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  const safeRetryLimit = normalizeNonNegativeInteger(retryLimit, DEFAULT_PUSH_SERVICE_RETRY_LIMIT);
+  const safeRetryBaseDelayMs = normalizeNonNegativeInteger(
+    retryBaseDelayMs,
+    DEFAULT_PUSH_SERVICE_RETRY_BASE_DELAY_MS
+  );
 
   async function registerDevice({
     deviceToken,
@@ -59,10 +67,12 @@ function createPushNotificationServiceClient({
 
     const bodyJSON = JSON.stringify(payload);
     let lastError = null;
-    for (let attempt = 0; attempt <= DEFAULT_PUSH_SERVICE_RETRY_LIMIT; attempt += 1) {
+    for (let attempt = 0; attempt <= safeRetryLimit; attempt += 1) {
       if (attempt > 0) {
-        const delayMs = DEFAULT_PUSH_SERVICE_RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        const delayMs = safeRetryBaseDelayMs * Math.pow(2, attempt - 1);
+        if (delayMs > 0) {
+          await sleepImpl(delayMs);
+        }
       }
 
       const controller = typeof AbortController === "function" && requestTimeoutMs > 0
@@ -105,7 +115,7 @@ function createPushNotificationServiceClient({
         const message = parsed?.error || parsed?.message || responseText || `HTTP ${response.status}`;
         const error = new Error(message);
         error.status = response.status;
-        if (response.status >= 500 && attempt < DEFAULT_PUSH_SERVICE_RETRY_LIMIT) {
+        if (response.status >= 500 && attempt < safeRetryLimit) {
           lastError = error;
           continue;
         }
@@ -149,6 +159,7 @@ function normalizeBaseUrl(value) {
 function createTimeoutAbortError(timeoutMs) {
   const error = new Error(`Push service request timed out after ${timeoutMs}ms`);
   error.name = "AbortError";
+  error.code = "push_request_timeout";
   return error;
 }
 
@@ -161,6 +172,14 @@ function isRetryableNetworkError(error) {
   return code === "ECONNRESET" || code === "ECONNREFUSED" || code === "ETIMEDOUT"
     || code === "ENETUNREACH" || code === "EHOSTUNREACH" || code === "ENOTFOUND"
     || error?.message?.includes("fetch failed");
+}
+
+function normalizeNonNegativeInteger(value, fallback) {
+  return Number.isInteger(value) && value >= 0 ? value : fallback;
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
 }
 
 function safeParseJSON(value) {

--- a/phodex-bridge/src/push-notification-tracker.js
+++ b/phodex-bridge/src/push-notification-tracker.js
@@ -9,6 +9,8 @@ const {
 } = require("./push-notification-completion-dedupe");
 
 const DEFAULT_PREVIEW_MAX_CHARS = 160;
+const MAX_THREAD_TITLE_ENTRIES = 200;
+const MAX_TURN_STATE_ENTRIES = 500;
 
 function createPushNotificationTracker({
   sessionId,
@@ -83,6 +85,10 @@ function createPushNotificationTracker({
 
     const nextTitle = extractThreadTitle(params, eventObject);
     if (nextTitle) {
+      if (!threadTitleById.has(threadId) && threadTitleById.size >= MAX_THREAD_TITLE_ENTRIES) {
+        const oldest = threadTitleById.keys().next().value;
+        threadTitleById.delete(oldest);
+      }
       threadTitleById.set(threadId, nextTitle);
     }
   }
@@ -225,6 +231,10 @@ function createPushNotificationTracker({
   function ensureTurnState(threadId, turnId) {
     const key = turnStateKey(threadId, turnId);
     if (!turnStateByKey.has(key)) {
+      if (turnStateByKey.size >= MAX_TURN_STATE_ENTRIES) {
+        const oldest = turnStateByKey.keys().next().value;
+        turnStateByKey.delete(oldest);
+      }
       turnStateByKey.set(key, {
         latestAssistantPreview: "",
         latestFailurePreview: "",

--- a/phodex-bridge/src/push-notification-tracker.js
+++ b/phodex-bridge/src/push-notification-tracker.js
@@ -11,6 +11,7 @@ const {
 const DEFAULT_PREVIEW_MAX_CHARS = 160;
 const MAX_THREAD_TITLE_ENTRIES = 200;
 const MAX_TURN_STATE_ENTRIES = 500;
+const MAX_THREAD_ID_BY_TURN_ENTRIES = 500;
 
 function createPushNotificationTracker({
   sessionId,
@@ -75,6 +76,10 @@ function createPushNotificationTracker({
   // Remembers thread/turn linkage before the terminal event arrives on a different payload shape.
   function rememberMessageContext({ threadId, turnId, params, eventObject }) {
     if (threadId && turnId) {
+      if (!threadIdByTurnId.has(turnId) && threadIdByTurnId.size >= MAX_THREAD_ID_BY_TURN_ENTRIES) {
+        const oldest = threadIdByTurnId.keys().next().value;
+        threadIdByTurnId.delete(oldest);
+      }
       threadIdByTurnId.set(turnId, threadId);
       ensureTurnState(threadId, turnId);
     }

--- a/phodex-bridge/src/rollout-live-mirror.js
+++ b/phodex-bridge/src/rollout-live-mirror.js
@@ -170,9 +170,15 @@ function createThreadRolloutLiveMirror({
           return;
         }
 
-        const combined = `${partialLine}${chunk}`;
-        const lines = combined.split("\n");
-        partialLine = lines.pop() || "";
+        const combined = partialLine ? `${partialLine}${chunk}` : chunk;
+        let searchStart = 0;
+        let nlIndex;
+        const lines = [];
+        while ((nlIndex = combined.indexOf("\n", searchStart)) !== -1) {
+          lines.push(combined.substring(searchStart, nlIndex));
+          searchStart = nlIndex + 1;
+        }
+        partialLine = searchStart < combined.length ? combined.substring(searchStart) : "";
         processRolloutLines(lines, state, sendApplicationResponse);
         return;
       }

--- a/phodex-bridge/src/secure-transport.js
+++ b/phodex-bridge/src/secure-transport.js
@@ -467,15 +467,22 @@ function createBridgeSecureTransport({
   }
 
   function trimOutboundBuffer() {
+    let removeCount = 0;
+    let removedBytes = 0;
     while (
-      outboundBuffer.length > MAX_BRIDGE_OUTBOUND_MESSAGES
-      || outboundBufferBytes > MAX_BRIDGE_OUTBOUND_BYTES
+      (outboundBuffer.length - removeCount) > MAX_BRIDGE_OUTBOUND_MESSAGES
+      || (outboundBufferBytes - removedBytes) > MAX_BRIDGE_OUTBOUND_BYTES
     ) {
-      const removed = outboundBuffer.shift();
-      if (!removed) {
+      const entry = outboundBuffer[removeCount];
+      if (!entry) {
         break;
       }
-      outboundBufferBytes = Math.max(0, outboundBufferBytes - removed.sizeBytes);
+      removedBytes += entry.sizeBytes;
+      removeCount += 1;
+    }
+    if (removeCount > 0) {
+      outboundBuffer.splice(0, removeCount);
+      outboundBufferBytes = Math.max(0, outboundBufferBytes - removedBytes);
     }
   }
 

--- a/phodex-bridge/src/session-jsonl-history.js
+++ b/phodex-bridge/src/session-jsonl-history.js
@@ -37,9 +37,15 @@ function parseSessionJsonlMetadata(content) {
   let threadId = "";
   let cwd = "";
 
-  const lines = String(content || "").split(/\r?\n/);
-  for (const rawLine of lines) {
-    const line = rawLine.trim();
+  const raw = String(content || "");
+  let lineStart = 0;
+  while (lineStart < raw.length) {
+    let lineEnd = raw.indexOf("\n", lineStart);
+    if (lineEnd === -1) {
+      lineEnd = raw.length;
+    }
+    const line = raw.substring(lineStart, lineEnd).trim();
+    lineStart = lineEnd + 1;
     if (!line) {
       continue;
     }
@@ -80,12 +86,33 @@ function parseSessionJsonlTurns(content, { threadId = "" } = {}) {
   const skippedCallIds = new Set();
   const pendingUserMessages = [];
 
-  const lines = String(content || "").split(/\r?\n/);
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index].trim();
-    if (!line) {
+  const raw = String(content || "");
+  let index = 0;
+  let lineStart = 0;
+  let lineNumber = 0;
+  while (lineStart < raw.length) {
+    let lineEnd = raw.indexOf("\n", lineStart);
+    if (lineEnd === -1) {
+      lineEnd = raw.length;
+    }
+    let end = lineEnd;
+    if (end > lineStart && raw.charCodeAt(end - 1) === 13) {
+      end -= 1;
+    }
+    let start = lineStart;
+    while (start < end && (raw.charCodeAt(start) === 32 || raw.charCodeAt(start) === 9)) {
+      start += 1;
+    }
+    while (end > start && (raw.charCodeAt(end - 1) === 32 || raw.charCodeAt(end - 1) === 9)) {
+      end -= 1;
+    }
+    lineStart = lineEnd + 1;
+    lineNumber += 1;
+    index = lineNumber - 1;
+    if (start >= end) {
       continue;
     }
+    const line = raw.substring(start, end);
 
     let entry;
     try {

--- a/phodex-bridge/src/session-jsonl-history.js
+++ b/phodex-bridge/src/session-jsonl-history.js
@@ -87,32 +87,19 @@ function parseSessionJsonlTurns(content, { threadId = "" } = {}) {
   const pendingUserMessages = [];
 
   const raw = String(content || "");
-  let index = 0;
+  let index = -1;
   let lineStart = 0;
-  let lineNumber = 0;
   while (lineStart < raw.length) {
+    index += 1;
     let lineEnd = raw.indexOf("\n", lineStart);
     if (lineEnd === -1) {
       lineEnd = raw.length;
     }
-    let end = lineEnd;
-    if (end > lineStart && raw.charCodeAt(end - 1) === 13) {
-      end -= 1;
-    }
-    let start = lineStart;
-    while (start < end && (raw.charCodeAt(start) === 32 || raw.charCodeAt(start) === 9)) {
-      start += 1;
-    }
-    while (end > start && (raw.charCodeAt(end - 1) === 32 || raw.charCodeAt(end - 1) === 9)) {
-      end -= 1;
-    }
+    const line = raw.substring(lineStart, lineEnd).trim();
     lineStart = lineEnd + 1;
-    lineNumber += 1;
-    index = lineNumber - 1;
-    if (start >= end) {
+    if (!line) {
       continue;
     }
-    const line = raw.substring(start, end);
 
     let entry;
     try {

--- a/phodex-bridge/test/push-notification-service-client.test.js
+++ b/phodex-bridge/test/push-notification-service-client.test.js
@@ -10,12 +10,16 @@ const assert = require("node:assert/strict");
 const { createPushNotificationServiceClient } = require("../src/push-notification-service-client");
 
 test("push service client aborts stalled requests with a timeout error", async () => {
+  let attempts = 0;
   const client = createPushNotificationServiceClient({
     baseUrl: "https://push.example.test",
     sessionId: "session-timeout",
     notificationSecret: "secret-timeout",
-    requestTimeoutMs: 20,
+    requestTimeoutMs: 5,
+    retryBaseDelayMs: 0,
+    sleepImpl: async () => {},
     fetchImpl: async (_url, options) => new Promise((_, reject) => {
+      attempts += 1;
       options.signal.addEventListener("abort", () => {
         reject(options.signal.reason);
       }, { once: true });
@@ -28,6 +32,53 @@ test("push service client aborts stalled requests with a timeout error", async (
       alertsEnabled: true,
       apnsEnvironment: "development",
     }),
-    /timed out after 20ms/
+    (error) => {
+      assert.equal(error.code, "push_request_timeout");
+      assert.match(error.message, /timed out after 5ms/);
+      return true;
+    }
   );
+  assert.equal(attempts, 3);
+});
+
+test("push service client retries transient server failures with exponential delay", async () => {
+  const statuses = [503, 502, 200];
+  const delays = [];
+  const payloads = [];
+  const client = createPushNotificationServiceClient({
+    baseUrl: "https://push.example.test",
+    sessionId: "session-retry",
+    notificationSecret: "secret-retry",
+    retryBaseDelayMs: 25,
+    sleepImpl: async (delayMs) => {
+      delays.push(delayMs);
+    },
+    fetchImpl: async (_url, options) => {
+      payloads.push(options.body);
+      const status = statuses.shift();
+      return {
+        ok: status === 200,
+        status,
+        async text() {
+          return status === 200
+            ? JSON.stringify({ ok: true, delivered: true })
+            : JSON.stringify({ error: `temporary ${status}` });
+        },
+      };
+    },
+  });
+
+  const result = await client.notifyCompletion({
+    threadId: "thread-retry",
+    turnId: "turn-retry",
+    result: "completed",
+    title: "Retry me",
+    body: "Ready",
+    dedupeKey: "dedupe-retry",
+  });
+
+  assert.deepEqual(result, { ok: true, delivered: true });
+  assert.deepEqual(delays, [25, 50]);
+  assert.equal(payloads.length, 3);
+  assert.equal(new Set(payloads).size, 1);
 });


### PR DESCRIPTION
Full-stack performance upgrade targeting memory efficiency and low-network/low-connectivity resilience across both the Node.js bridge and iOS app.

### Key changes (from fork PR https://github.com/kartikkabadi-max/remodex/pull/1)
- WS per-message deflate + reconnect jitter + push retry backoff (bridge)
- Bounded Maps with robust FIFO eviction + streaming JSONL parse + O(n) trim
- iOS: NWPathMonitor isConstrained only (not expensive), adaptive intervals 2x, 35s keepalive, explicit deinit
- Review fixes: safe async capture in monitor, collect-to-delete prune for memory caps, injectable retry for deterministic tests + new test coverage

All relevant tests pass. Backward-compatible. Ready for low-network environments.

(Prepared via kartikkabadi primary review + fixes on the fork)