### PR TITLE
perf: improve bridge memory and low-network efficiency

### DIFF
--- a/.github/workflows/bridge-check.yml
+++ b/.github/workflows/bridge-check.yml
@@ -1,17 +1,20 @@
-name: Bridge Check
+name: Node Package Tests
 
 on:
   push:
     paths:
       - ".github/workflows/bridge-check.yml"
       - "phodex-bridge/**"
+      - "relay/**"
   pull_request:
     paths:
       - ".github/workflows/bridge-check.yml"
       - "phodex-bridge/**"
+      - "relay/**"
 
 jobs:
   bridge-check:
+    name: Bridge tests
     runs-on: ubuntu-latest
 
     steps:
@@ -27,9 +30,36 @@ jobs:
 
       - name: Install bridge dependencies
         working-directory: phodex-bridge
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Verify bridge entrypoints load
         working-directory: phodex-bridge
         run: |
           node -e "const mod = require('./src'); const names = ['startBridge', 'openLastActiveThread', 'watchThreadRollout']; for (const name of names) { if (typeof mod[name] !== 'function') { throw new Error('Missing export: ' + name); } }"
+
+      - name: Run bridge tests
+        working-directory: phodex-bridge
+        run: npm test
+
+  relay-check:
+    name: Relay tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: relay/package-lock.json
+
+      - name: Install relay dependencies
+        working-directory: relay
+        run: npm ci --ignore-scripts
+
+      - name: Run relay tests
+        working-directory: relay
+        run: npm test

--- a/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
@@ -29,14 +29,16 @@ extension CodexService {
 
         // Foreground polling is intentionally more aggressive so desktop-authored changes
         // feel closer to live on iPhone even when Codex.app itself doesn't push updates.
-        let listIntervalForegroundNs: UInt64 = 10_000_000_000
-        let listIntervalBackgroundNs: UInt64 = 75_000_000_000
-        let historyIntervalForegroundNs: UInt64 = 3_000_000_000
-        let historyIntervalForegroundMirroredNs: UInt64 = 1_000_000_000
-        let historyIntervalBackgroundIdleNs: UInt64 = 90_000_000_000
-        let historyIntervalBackgroundRunningNs: UInt64 = 12_000_000_000
-        let watchIntervalForegroundNs: UInt64 = 2_000_000_000
-        let watchIntervalBackgroundNs: UInt64 = 15_000_000_000
+        // Low-network multiplier stretches intervals when connectivity is constrained.
+        let networkMultiplier: UInt64 = isConstrainedNetwork ? 2 : 1
+        let listIntervalForegroundNs: UInt64 = 10_000_000_000 * networkMultiplier
+        let listIntervalBackgroundNs: UInt64 = 75_000_000_000 * networkMultiplier
+        let historyIntervalForegroundNs: UInt64 = 3_000_000_000 * networkMultiplier
+        let historyIntervalForegroundMirroredNs: UInt64 = 1_000_000_000 * networkMultiplier
+        let historyIntervalBackgroundIdleNs: UInt64 = 90_000_000_000 * networkMultiplier
+        let historyIntervalBackgroundRunningNs: UInt64 = 12_000_000_000 * networkMultiplier
+        let watchIntervalForegroundNs: UInt64 = 2_000_000_000 * networkMultiplier
+        let watchIntervalBackgroundNs: UInt64 = 15_000_000_000 * networkMultiplier
 
         threadListSyncTask = Task { [weak self] in
             while let self, !Task.isCancelled {
@@ -217,6 +219,7 @@ extension CodexService {
         let persistedDeletedIDs = locallyDeletedThreadIDs
 
         var merged: [String: CodexThread] = [:]
+        merged.reserveCapacity(max(threads.count, serverThreads.count))
         var snapshotOnlyPinnedIDs: Set<String> = []
 
         // Merge active server threads.

--- a/CodexMobile/CodexMobile/Services/CodexService+Transport.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Transport.swift
@@ -17,6 +17,7 @@ let codexWebSocketMaximumMessageSizeBytes = 16 * 1024 * 1024
 private enum CodexWebSocketKeepAlivePolicy {
     static let intervalNanoseconds: UInt64 = 25_000_000_000
     static let foregroundProbeTimeoutNanoseconds: UInt64 = 1_500_000_000
+    static let constrainedIntervalNanoseconds: UInt64 = 35_000_000_000
 }
 
 private final class CodexForegroundProbeWaiter: @unchecked Sendable {
@@ -164,7 +165,7 @@ nonisolated private func codexLogPairingTransport(_ message: String) {
 extension CodexService {
     // Rejects oversized relay frames before Network.framework turns them into a raw EMSGSIZE failure.
     func validateOutgoingWebSocketMessageSize(_ text: String) throws {
-        let payloadSize = Data(text.utf8).count
+        let payloadSize = text.utf8.count
         guard payloadSize <= codexWebSocketMaximumMessageSizeBytes else {
             throw CodexServiceError.invalidInput(
                 "This payload is too large for the relay connection. Try fewer or smaller images and retry."
@@ -369,8 +370,11 @@ extension CodexService {
 
         webSocketKeepAliveTask = Task { @MainActor [weak self] in
             while let self, !Task.isCancelled {
+                let defaultInterval = self.isConstrainedNetwork
+                    ? CodexWebSocketKeepAlivePolicy.constrainedIntervalNanoseconds
+                    : CodexWebSocketKeepAlivePolicy.intervalNanoseconds
                 let interval = self.webSocketKeepAliveIntervalOverrideNanoseconds
-                    ?? CodexWebSocketKeepAlivePolicy.intervalNanoseconds
+                    ?? defaultInterval
                 try? await Task.sleep(nanoseconds: interval)
                 guard !Task.isCancelled else {
                     return

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -560,6 +560,10 @@ final class CodexService {
     // Coalesces sidebar/bootstrap thread/list refreshes so launch paths do not duplicate the same fetch.
     @ObservationIgnored var threadListFetchTaskByLimit: [Int: (id: UUID, task: Task<[CodexThread], Error>)] = [:]
     var isAppInForeground = true
+    // Network quality flag: when true, sync and keepalive intervals are stretched to reduce
+    // bandwidth usage on constrained connections (Low Data Mode, hotspot tethering).
+    var isConstrainedNetwork = false
+    @ObservationIgnored var networkPathMonitor: NWPathMonitor?
     var threadListSyncTask: Task<Void, Never>?
     var activeThreadSyncTask: Task<Void, Never>?
     var runningThreadWatchSyncTask: Task<Void, Never>?
@@ -813,6 +817,26 @@ final class CodexService {
             self.secureMacFingerprint = codexSecureFingerprint(for: trustedMac.macIdentityPublicKey)
         }
         rebuildThreadLookupCaches()
+        startNetworkPathMonitor()
+    }
+
+    func startNetworkPathMonitor() {
+        networkPathMonitor?.cancel()
+        let monitor = NWPathMonitor()
+        networkPathMonitor = monitor
+        monitor.pathUpdateHandler = { [weak self] path in
+            let constrained = path.isConstrained
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if self.isConstrainedNetwork != constrained {
+                    self.isConstrainedNetwork = constrained
+                    if self.isConnected, self.isInitialized {
+                        self.startSyncLoop()
+                    }
+                }
+            }
+        }
+        monitor.start(queue: DispatchQueue(label: "CodexMobile.NetworkPathMonitor", qos: .utility))
     }
 
     // Persists per-thread plan-mode provenance so reconnect/relaunch keeps native vs fallback behavior stable.
@@ -1034,6 +1058,7 @@ final class CodexService {
 
     deinit {
         MainActor.assumeIsolated {
+            networkPathMonitor?.cancel()
             trustedSessionResolveTask?.cancel()
             messagePersistenceDebounceTask?.cancel()
             coalescedRevertRefreshTask?.cancel()

--- a/CodexMobile/Docs/Performance-Scripts.md
+++ b/CodexMobile/Docs/Performance-Scripts.md
@@ -1,0 +1,43 @@
+# Performance Scripts
+
+The performance guard scripts in `CodexMobile/scripts` compare fresh XCTest metrics against a JSON baseline file. Baselines are machine- and simulator-sensitive, so they are supplied explicitly instead of checked in as universal truth.
+
+## Sidebar Run Badge
+
+Show the required baseline shape:
+
+```bash
+CodexMobile/scripts/check-sidebar-badge-performance.sh --print-baseline-template
+```
+
+Run with an explicit baseline:
+
+```bash
+BASELINE_PATH=/path/to/Sidebar-RunBadge-Performance-Baseline.json \
+  CodexMobile/scripts/check-sidebar-badge-performance.sh
+```
+
+## Turn View
+
+Show the required baseline shape:
+
+```bash
+CodexMobile/scripts/check-turnview-performance.sh --print-baseline-template
+```
+
+Run with an explicit baseline:
+
+```bash
+BASELINE_PATH=/path/to/TurnView-Performance-Baseline.json \
+  CodexMobile/scripts/check-turnview-performance.sh
+```
+
+Both scripts also accept `SCHEME`, `DESTINATION`, and `MAX_REGRESSION_PERCENT` environment overrides.
+
+## Usage Checks
+
+The preflight/help paths can be checked without running Xcode:
+
+```bash
+CodexMobile/scripts/test-performance-script-usage.sh
+```

--- a/CodexMobile/scripts/check-sidebar-badge-performance.sh
+++ b/CodexMobile/scripts/check-sidebar-badge-performance.sh
@@ -11,8 +11,65 @@ DESTINATION="${DESTINATION:-platform=iOS Simulator,name=iPhone 17}"
 BASELINE_PATH="${BASELINE_PATH:-$ROOT_DIR/Docs/Sidebar-RunBadge-Performance-Baseline.json}"
 MAX_REGRESSION_PERCENT="${MAX_REGRESSION_PERCENT:-}"
 
+print_usage() {
+  cat <<EOF
+Usage: BASELINE_PATH=/path/to/sidebar-baseline.json $0
+
+Runs SidebarRunBadgePerformanceTests and compares xcresult metrics with a JSON baseline.
+
+Environment:
+  SCHEME                   Xcode scheme. Default: CodexMobile
+  DESTINATION              xcodebuild destination. Default: platform=iOS Simulator,name=iPhone 17
+  BASELINE_PATH            Required baseline JSON path. Default: $ROOT_DIR/Docs/Sidebar-RunBadge-Performance-Baseline.json
+  MAX_REGRESSION_PERCENT   Optional override for the baseline max_regression_percent value.
+
+Helpers:
+  $0 --print-baseline-template
+  $0 --help
+EOF
+}
+
+print_baseline_template() {
+  cat <<'EOF'
+{
+  "max_regression_percent": 12.0,
+  "metrics": {
+    "snapshot_clock_s": 0.0,
+    "snapshot_cpu_time_s": 0.0,
+    "large_timeline_clock_s": 0.0,
+    "large_timeline_cpu_time_s": 0.0
+  }
+}
+EOF
+}
+
+case "${1:-}" in
+  "" ) ;;
+  "-h"|"--help" )
+    print_usage
+    exit 0
+    ;;
+  "--print-baseline-template" )
+    print_baseline_template
+    exit 0
+    ;;
+  * )
+    echo "Unknown argument: $1" >&2
+    print_usage >&2
+    exit 2
+    ;;
+esac
+
 if [[ ! -f "$BASELINE_PATH" ]]; then
-  echo "Baseline file not found: $BASELINE_PATH"
+  cat >&2 <<EOF
+Baseline file not found: $BASELINE_PATH
+
+Provide an explicit baseline file before running the performance check:
+  BASELINE_PATH=/path/to/sidebar-baseline.json $0
+
+To see the required JSON shape:
+  $0 --print-baseline-template
+EOF
   exit 1
 fi
 

--- a/CodexMobile/scripts/check-turnview-performance.sh
+++ b/CodexMobile/scripts/check-turnview-performance.sh
@@ -11,8 +11,65 @@ DESTINATION="${DESTINATION:-platform=iOS Simulator,name=iPhone 17}"
 BASELINE_PATH="${BASELINE_PATH:-$ROOT_DIR/Docs/TurnView-Performance-Baseline.json}"
 MAX_REGRESSION_PERCENT="${MAX_REGRESSION_PERCENT:-}"
 
+print_usage() {
+  cat <<EOF
+Usage: BASELINE_PATH=/path/to/turnview-baseline.json $0
+
+Runs TurnView UI performance tests and compares xcresult metrics with a JSON baseline.
+
+Environment:
+  SCHEME                   Xcode scheme. Default: CodexMobile
+  DESTINATION              xcodebuild destination. Default: platform=iOS Simulator,name=iPhone 17
+  BASELINE_PATH            Required baseline JSON path. Default: $ROOT_DIR/Docs/TurnView-Performance-Baseline.json
+  MAX_REGRESSION_PERCENT   Optional override for the baseline max_regression_percent value.
+
+Helpers:
+  $0 --print-baseline-template
+  $0 --help
+EOF
+}
+
+print_baseline_template() {
+  cat <<'EOF'
+{
+  "max_regression_percent": 5.0,
+  "metrics": {
+    "scroll_duration_s": 0.0,
+    "stream_clock_s": 0.0,
+    "stream_cpu_time_s": 0.0,
+    "stream_peak_memory_kb": 0.0
+  }
+}
+EOF
+}
+
+case "${1:-}" in
+  "" ) ;;
+  "-h"|"--help" )
+    print_usage
+    exit 0
+    ;;
+  "--print-baseline-template" )
+    print_baseline_template
+    exit 0
+    ;;
+  * )
+    echo "Unknown argument: $1" >&2
+    print_usage >&2
+    exit 2
+    ;;
+esac
+
 if [[ ! -f "$BASELINE_PATH" ]]; then
-  echo "Baseline file not found: $BASELINE_PATH"
+  cat >&2 <<EOF
+Baseline file not found: $BASELINE_PATH
+
+Provide an explicit baseline file before running the performance check:
+  BASELINE_PATH=/path/to/turnview-baseline.json $0
+
+To see the required JSON shape:
+  $0 --print-baseline-template
+EOF
   exit 1
 fi
 

--- a/CodexMobile/scripts/test-performance-script-usage.sh
+++ b/CodexMobile/scripts/test-performance-script-usage.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# FILE: test-performance-script-usage.sh
+# Purpose: Verifies performance script preflight/help paths without invoking xcodebuild.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "Expected output to contain: $needle" >&2
+    echo "Actual output:" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+
+assert_template_keys() {
+  local script_path="$1"
+  shift
+  local template_json
+  template_json="$("$script_path" --print-baseline-template)"
+
+  python3 - "$template_json" "$@" <<'PY'
+import json
+import sys
+
+template = json.loads(sys.argv[1])
+expected_keys = sys.argv[2:]
+metrics = template.get("metrics", {})
+missing = [key for key in expected_keys if key not in metrics]
+if missing:
+    raise SystemExit(f"Missing template metric keys: {', '.join(missing)}")
+if not isinstance(template.get("max_regression_percent"), (int, float)):
+    raise SystemExit("max_regression_percent must be numeric")
+PY
+}
+
+assert_missing_baseline_message() {
+  local script_path="$1"
+  local output
+  local missing_path
+  missing_path="$(mktemp -u)"
+
+  set +e
+  output="$(BASELINE_PATH="$missing_path" "$script_path" 2>&1)"
+  local status=$?
+  set -e
+
+  if [[ "$status" -eq 0 ]]; then
+    echo "Expected $script_path to fail when BASELINE_PATH is missing." >&2
+    exit 1
+  fi
+
+  assert_contains "$output" "Baseline file not found: $missing_path"
+  assert_contains "$output" "BASELINE_PATH=/path/to"
+  assert_contains "$output" "--print-baseline-template"
+}
+
+sidebar_script="$SCRIPT_DIR/check-sidebar-badge-performance.sh"
+turnview_script="$SCRIPT_DIR/check-turnview-performance.sh"
+
+assert_contains "$("$sidebar_script" --help)" "BASELINE_PATH"
+assert_contains "$("$turnview_script" --help)" "BASELINE_PATH"
+
+assert_template_keys \
+  "$sidebar_script" \
+  "snapshot_clock_s" \
+  "snapshot_cpu_time_s" \
+  "large_timeline_clock_s" \
+  "large_timeline_cpu_time_s"
+
+assert_template_keys \
+  "$turnview_script" \
+  "scroll_duration_s" \
+  "stream_clock_s" \
+  "stream_cpu_time_s" \
+  "stream_peak_memory_kb"
+
+assert_missing_baseline_message "$sidebar_script"
+assert_missing_baseline_message "$turnview_script"
+
+echo "Performance script usage checks passed."

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -106,6 +106,21 @@ const RELAY_TURNS_LIST_PAGINATION_RESULT_KEYS = [
   "previous_cursor",
 ];
 const jsonlArtifactItemsCacheByThread = new Map();
+const FORWARDED_REQUEST_METHODS_MAX_SIZE = 500;
+const JSONL_ROLLOUT_PATH_CACHE_MAX_SIZE = 200;
+
+function evictOldestEntries(map, maxSize) {
+  if (map.size <= maxSize) {
+    return;
+  }
+  const excess = map.size - maxSize;
+  const iterator = map.keys();
+  for (let i = 0; i < excess; i += 1) {
+    const key = iterator.next().value;
+    map.delete(key);
+  }
+}
+
 function startBridge({
   config: explicitConfig = null,
   printPairingQr = true,
@@ -404,7 +419,9 @@ function startBridge({
     }
 
     reconnectAttempt += 1;
-    const delayMs = Math.min(1_000 * reconnectAttempt, 5_000);
+    const baseDelayMs = Math.min(1_000 * reconnectAttempt, 5_000);
+    const jitterMs = Math.floor(Math.random() * Math.min(baseDelayMs, 2_000));
+    const delayMs = baseDelayMs + jitterMs;
     logConnectionStatus("connecting");
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
@@ -419,6 +436,11 @@ function startBridge({
 
     logConnectionStatus("connecting");
     const nextSocket = new WebSocket(relaySessionUrl, {
+      perMessageDeflate: {
+        zlibDeflateOptions: { level: 6 },
+        threshold: 256,
+        concurrencyLimit: 4,
+      },
       // The relay uses this per-session secret to authenticate the first push registration.
       headers: {
         "x-role": "mac",
@@ -993,16 +1015,31 @@ function startBridge({
   }
 
   function pruneExpiredForwardedRequestMethods(now = Date.now()) {
+    const expiredForwarded = [];
     for (const [requestId, trackedRequest] of forwardedRequestMethodsById.entries()) {
       if (!trackedRequest || (now - trackedRequest.createdAt) >= forwardedRequestMethodTTLms) {
-        forwardedRequestMethodsById.delete(requestId);
+        expiredForwarded.push(requestId);
       }
     }
+    for (const id of expiredForwarded) {
+      forwardedRequestMethodsById.delete(id);
+    }
+
+    const expiredSanitized = [];
     for (const [requestId, trackedRequest] of relaySanitizedResponseMethodsById.entries()) {
       if (!trackedRequest || (now - trackedRequest.createdAt) >= forwardedRequestMethodTTLms) {
-        relaySanitizedResponseMethodsById.delete(requestId);
+        expiredSanitized.push(requestId);
       }
     }
+    for (const id of expiredSanitized) {
+      relaySanitizedResponseMethodsById.delete(id);
+    }
+
+    evictOldestEntries(forwardedRequestMethodsById, FORWARDED_REQUEST_METHODS_MAX_SIZE);
+    evictOldestEntries(relaySanitizedResponseMethodsById, FORWARDED_REQUEST_METHODS_MAX_SIZE);
+    evictOldestEntries(jsonlArtifactItemsCacheByThread, RELAY_JSONL_ARTIFACT_CACHE_MAX_ENTRIES);
+    evictOldestEntries(jsonlTurnsListRolloutCacheByThread, JSONL_ROLLOUT_PATH_CACHE_MAX_SIZE);
+    evictOldestEntries(jsonlTurnsListRolloutMissCacheByThread, JSONL_ROLLOUT_PATH_CACHE_MAX_SIZE);
   }
 
   function safeParseJSON(value) {

--- a/phodex-bridge/src/codex-transport.js
+++ b/phodex-bridge/src/codex-transport.js
@@ -155,13 +155,12 @@ function createSpawnTransport({ env, appPath, platform, spawnImpl = spawn }) {
         return;
       }
       stdoutBuffer += chunk.toString("utf8");
-      const lines = stdoutBuffer.split("\n");
-      stdoutBuffer = lines.pop() || "";
-
-      for (const line of lines) {
-        const trimmedLine = line.trim();
-        if (trimmedLine) {
-          listeners.emitMessage(trimmedLine);
+      let newlineIndex;
+      while ((newlineIndex = stdoutBuffer.indexOf("\n")) !== -1) {
+        const line = stdoutBuffer.substring(0, newlineIndex).trim();
+        stdoutBuffer = stdoutBuffer.substring(newlineIndex + 1);
+        if (line) {
+          listeners.emitMessage(line);
         }
       }
     });

--- a/phodex-bridge/src/push-notification-service-client.js
+++ b/phodex-bridge/src/push-notification-service-client.js
@@ -5,6 +5,8 @@
 // Depends on: global fetch
 
 const DEFAULT_PUSH_SERVICE_TIMEOUT_MS = 10_000;
+const DEFAULT_PUSH_SERVICE_RETRY_LIMIT = 2;
+const DEFAULT_PUSH_SERVICE_RETRY_BASE_DELAY_MS = 500;
 
 function createPushNotificationServiceClient({
   baseUrl = "",
@@ -13,8 +15,16 @@ function createPushNotificationServiceClient({
   fetchImpl = globalThis.fetch,
   logPrefix = "[remodex]",
   requestTimeoutMs = DEFAULT_PUSH_SERVICE_TIMEOUT_MS,
+  retryLimit = DEFAULT_PUSH_SERVICE_RETRY_LIMIT,
+  retryBaseDelayMs = DEFAULT_PUSH_SERVICE_RETRY_BASE_DELAY_MS,
+  sleepImpl = sleep,
 } = {}) {
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  const safeRetryLimit = normalizeNonNegativeInteger(retryLimit, DEFAULT_PUSH_SERVICE_RETRY_LIMIT);
+  const safeRetryBaseDelayMs = normalizeNonNegativeInteger(
+    retryBaseDelayMs,
+    DEFAULT_PUSH_SERVICE_RETRY_BASE_DELAY_MS
+  );
 
   async function registerDevice({
     deviceToken,
@@ -55,48 +65,70 @@ function createPushNotificationServiceClient({
       return { ok: false, skipped: true };
     }
 
-    const controller = typeof AbortController === "function" && requestTimeoutMs > 0
-      ? new AbortController()
-      : null;
-    const timeoutID = controller
-      ? setTimeout(() => {
-        controller.abort(createTimeoutAbortError(requestTimeoutMs));
-      }, requestTimeoutMs)
-      : null;
+    const bodyJSON = JSON.stringify(payload);
+    let lastError = null;
+    for (let attempt = 0; attempt <= safeRetryLimit; attempt += 1) {
+      if (attempt > 0) {
+        const delayMs = safeRetryBaseDelayMs * Math.pow(2, attempt - 1);
+        if (delayMs > 0) {
+          await sleepImpl(delayMs);
+        }
+      }
 
-    let response;
-    try {
-      response = await fetchImpl(`${normalizedBaseUrl}${pathname}`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-        },
-        body: JSON.stringify(payload),
-        signal: controller?.signal,
-      });
-    } catch (error) {
-      if (isAbortError(error)) {
-        const timeoutError = new Error(`Push service request timed out after ${requestTimeoutMs}ms`);
-        timeoutError.code = "push_request_timeout";
-        throw timeoutError;
+      const controller = typeof AbortController === "function" && requestTimeoutMs > 0
+        ? new AbortController()
+        : null;
+      const timeoutID = controller
+        ? setTimeout(() => {
+          controller.abort(createTimeoutAbortError(requestTimeoutMs));
+        }, requestTimeoutMs)
+        : null;
+
+      let response;
+      try {
+        response = await fetchImpl(`${normalizedBaseUrl}${pathname}`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: bodyJSON,
+          signal: controller?.signal,
+        });
+      } catch (error) {
+        lastError = error;
+        if (isAbortError(error)) {
+          continue;
+        }
+        if (isRetryableNetworkError(error)) {
+          continue;
+        }
+        throw error;
+      } finally {
+        if (timeoutID) {
+          clearTimeout(timeoutID);
+        }
       }
-      throw error;
-    } finally {
-      if (timeoutID) {
-        clearTimeout(timeoutID);
+
+      const responseText = await response.text();
+      const parsed = safeParseJSON(responseText);
+      if (!response.ok) {
+        const message = parsed?.error || parsed?.message || responseText || `HTTP ${response.status}`;
+        const error = new Error(message);
+        error.status = response.status;
+        if (response.status >= 500 && attempt < safeRetryLimit) {
+          lastError = error;
+          continue;
+        }
+        throw error;
       }
+
+      return parsed ?? { ok: true };
     }
 
-    const responseText = await response.text();
-    const parsed = safeParseJSON(responseText);
-    if (!response.ok) {
-      const message = parsed?.error || parsed?.message || responseText || `HTTP ${response.status}`;
-      const error = new Error(message);
-      error.status = response.status;
-      throw error;
+    if (lastError) {
+      throw lastError;
     }
-
-    return parsed ?? { ok: true };
+    return { ok: false };
   }
 
   return {
@@ -127,11 +159,27 @@ function normalizeBaseUrl(value) {
 function createTimeoutAbortError(timeoutMs) {
   const error = new Error(`Push service request timed out after ${timeoutMs}ms`);
   error.name = "AbortError";
+  error.code = "push_request_timeout";
   return error;
 }
 
 function isAbortError(error) {
   return error?.name === "AbortError" || error?.code === "ABORT_ERR";
+}
+
+function isRetryableNetworkError(error) {
+  const code = error?.code ?? "";
+  return code === "ECONNRESET" || code === "ECONNREFUSED" || code === "ETIMEDOUT"
+    || code === "ENETUNREACH" || code === "EHOSTUNREACH" || code === "ENOTFOUND"
+    || error?.message?.includes("fetch failed");
+}
+
+function normalizeNonNegativeInteger(value, fallback) {
+  return Number.isInteger(value) && value >= 0 ? value : fallback;
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
 }
 
 function safeParseJSON(value) {

--- a/phodex-bridge/src/push-notification-tracker.js
+++ b/phodex-bridge/src/push-notification-tracker.js
@@ -9,6 +9,9 @@ const {
 } = require("./push-notification-completion-dedupe");
 
 const DEFAULT_PREVIEW_MAX_CHARS = 160;
+const MAX_THREAD_TITLE_ENTRIES = 200;
+const MAX_TURN_STATE_ENTRIES = 500;
+const MAX_THREAD_ID_BY_TURN_ENTRIES = 500;
 
 function createPushNotificationTracker({
   sessionId,
@@ -73,6 +76,10 @@ function createPushNotificationTracker({
   // Remembers thread/turn linkage before the terminal event arrives on a different payload shape.
   function rememberMessageContext({ threadId, turnId, params, eventObject }) {
     if (threadId && turnId) {
+      if (!threadIdByTurnId.has(turnId) && threadIdByTurnId.size >= MAX_THREAD_ID_BY_TURN_ENTRIES) {
+        const oldest = threadIdByTurnId.keys().next().value;
+        threadIdByTurnId.delete(oldest);
+      }
       threadIdByTurnId.set(turnId, threadId);
       ensureTurnState(threadId, turnId);
     }
@@ -83,6 +90,10 @@ function createPushNotificationTracker({
 
     const nextTitle = extractThreadTitle(params, eventObject);
     if (nextTitle) {
+      if (!threadTitleById.has(threadId) && threadTitleById.size >= MAX_THREAD_TITLE_ENTRIES) {
+        const oldest = threadTitleById.keys().next().value;
+        threadTitleById.delete(oldest);
+      }
       threadTitleById.set(threadId, nextTitle);
     }
   }
@@ -225,6 +236,10 @@ function createPushNotificationTracker({
   function ensureTurnState(threadId, turnId) {
     const key = turnStateKey(threadId, turnId);
     if (!turnStateByKey.has(key)) {
+      if (turnStateByKey.size >= MAX_TURN_STATE_ENTRIES) {
+        const oldest = turnStateByKey.keys().next().value;
+        turnStateByKey.delete(oldest);
+      }
       turnStateByKey.set(key, {
         latestAssistantPreview: "",
         latestFailurePreview: "",

--- a/phodex-bridge/src/rollout-live-mirror.js
+++ b/phodex-bridge/src/rollout-live-mirror.js
@@ -170,9 +170,15 @@ function createThreadRolloutLiveMirror({
           return;
         }
 
-        const combined = `${partialLine}${chunk}`;
-        const lines = combined.split("\n");
-        partialLine = lines.pop() || "";
+        const combined = partialLine ? `${partialLine}${chunk}` : chunk;
+        let searchStart = 0;
+        let nlIndex;
+        const lines = [];
+        while ((nlIndex = combined.indexOf("\n", searchStart)) !== -1) {
+          lines.push(combined.substring(searchStart, nlIndex));
+          searchStart = nlIndex + 1;
+        }
+        partialLine = searchStart < combined.length ? combined.substring(searchStart) : "";
         processRolloutLines(lines, state, sendApplicationResponse);
         return;
       }

--- a/phodex-bridge/src/secure-transport.js
+++ b/phodex-bridge/src/secure-transport.js
@@ -475,15 +475,22 @@ function createBridgeSecureTransport({
   }
 
   function trimOutboundBuffer() {
+    let removeCount = 0;
+    let removedBytes = 0;
     while (
-      outboundBuffer.length > MAX_BRIDGE_OUTBOUND_MESSAGES
-      || outboundBufferBytes > MAX_BRIDGE_OUTBOUND_BYTES
+      (outboundBuffer.length - removeCount) > MAX_BRIDGE_OUTBOUND_MESSAGES
+      || (outboundBufferBytes - removedBytes) > MAX_BRIDGE_OUTBOUND_BYTES
     ) {
-      const removed = outboundBuffer.shift();
-      if (!removed) {
+      const entry = outboundBuffer[removeCount];
+      if (!entry) {
         break;
       }
-      outboundBufferBytes = Math.max(0, outboundBufferBytes - removed.sizeBytes);
+      removedBytes += entry.sizeBytes;
+      removeCount += 1;
+    }
+    if (removeCount > 0) {
+      outboundBuffer.splice(0, removeCount);
+      outboundBufferBytes = Math.max(0, outboundBufferBytes - removedBytes);
     }
   }
 

--- a/phodex-bridge/src/session-jsonl-history.js
+++ b/phodex-bridge/src/session-jsonl-history.js
@@ -37,9 +37,15 @@ function parseSessionJsonlMetadata(content) {
   let threadId = "";
   let cwd = "";
 
-  const lines = String(content || "").split(/\r?\n/);
-  for (const rawLine of lines) {
-    const line = rawLine.trim();
+  const raw = String(content || "");
+  let lineStart = 0;
+  while (lineStart < raw.length) {
+    let lineEnd = raw.indexOf("\n", lineStart);
+    if (lineEnd === -1) {
+      lineEnd = raw.length;
+    }
+    const line = raw.substring(lineStart, lineEnd).trim();
+    lineStart = lineEnd + 1;
     if (!line) {
       continue;
     }
@@ -80,9 +86,17 @@ function parseSessionJsonlTurns(content, { threadId = "" } = {}) {
   const skippedCallIds = new Set();
   const pendingUserMessages = [];
 
-  const lines = String(content || "").split(/\r?\n/);
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index].trim();
+  const raw = String(content || "");
+  let index = -1;
+  let lineStart = 0;
+  while (lineStart < raw.length) {
+    index += 1;
+    let lineEnd = raw.indexOf("\n", lineStart);
+    if (lineEnd === -1) {
+      lineEnd = raw.length;
+    }
+    const line = raw.substring(lineStart, lineEnd).trim();
+    lineStart = lineEnd + 1;
     if (!line) {
       continue;
     }

--- a/phodex-bridge/test/push-notification-service-client.test.js
+++ b/phodex-bridge/test/push-notification-service-client.test.js
@@ -10,12 +10,16 @@ const assert = require("node:assert/strict");
 const { createPushNotificationServiceClient } = require("../src/push-notification-service-client");
 
 test("push service client aborts stalled requests with a timeout error", async () => {
+  let attempts = 0;
   const client = createPushNotificationServiceClient({
     baseUrl: "https://push.example.test",
     sessionId: "session-timeout",
     notificationSecret: "secret-timeout",
-    requestTimeoutMs: 20,
+    requestTimeoutMs: 5,
+    retryBaseDelayMs: 0,
+    sleepImpl: async () => {},
     fetchImpl: async (_url, options) => new Promise((_, reject) => {
+      attempts += 1;
       options.signal.addEventListener("abort", () => {
         reject(options.signal.reason);
       }, { once: true });
@@ -28,6 +32,53 @@ test("push service client aborts stalled requests with a timeout error", async (
       alertsEnabled: true,
       apnsEnvironment: "development",
     }),
-    /timed out after 20ms/
+    (error) => {
+      assert.equal(error.code, "push_request_timeout");
+      assert.match(error.message, /timed out after 5ms/);
+      return true;
+    }
   );
+  assert.equal(attempts, 3);
+});
+
+test("push service client retries transient server failures with exponential delay", async () => {
+  const statuses = [503, 502, 200];
+  const delays = [];
+  const payloads = [];
+  const client = createPushNotificationServiceClient({
+    baseUrl: "https://push.example.test",
+    sessionId: "session-retry",
+    notificationSecret: "secret-retry",
+    retryBaseDelayMs: 25,
+    sleepImpl: async (delayMs) => {
+      delays.push(delayMs);
+    },
+    fetchImpl: async (_url, options) => {
+      payloads.push(options.body);
+      const status = statuses.shift();
+      return {
+        ok: status === 200,
+        status,
+        async text() {
+          return status === 200
+            ? JSON.stringify({ ok: true, delivered: true })
+            : JSON.stringify({ error: `temporary ${status}` });
+        },
+      };
+    },
+  });
+
+  const result = await client.notifyCompletion({
+    threadId: "thread-retry",
+    turnId: "turn-retry",
+    result: "completed",
+    title: "Retry me",
+    body: "Ready",
+    dedupeKey: "dedupe-retry",
+  });
+
+  assert.deepEqual(result, { ok: true, delivered: true });
+  assert.deepEqual(delays, [25, 50]);
+  assert.equal(payloads.length, 3);
+  assert.equal(new Set(payloads).size, 1);
 });

--- a/relay/server.js
+++ b/relay/server.js
@@ -52,7 +52,10 @@ function createRelayServer({
       trustProxy,
     });
   });
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({
+    noServer: true,
+    perMessageDeflate: true,
+  });
   setupRelay(wss, relayOptions);
 
   server.on("upgrade", (req, socket, head) => {

--- a/relay/server.test.js
+++ b/relay/server.test.js
@@ -54,6 +54,22 @@ test("detailed health exposes relay pressure counters", async () => {
   }, { exposeDetailedHealth: true });
 });
 
+test("relay negotiates per-message deflate when clients offer it", async () => {
+  await withServer(async ({ port }) => {
+    const mac = new WebSocket(`ws://127.0.0.1:${port}/relay/session-deflate`, {
+      headers: { "x-role": "mac" },
+      perMessageDeflate: true,
+    });
+    await onceOpen(mac);
+
+    assert.equal(mac.extensions, "permessage-deflate");
+
+    const macClosed = onceClosed(mac);
+    mac.close();
+    await macClosed;
+  });
+});
+
 test("push routes stay disabled until explicitly enabled", async () => {
   const { body, status } = await withServer(async ({ port }) => {
     const response = await fetch(`http://127.0.0.1:${port}/v1/push/session/register-device`, {
@@ -542,19 +558,13 @@ test("trusted session resolve starts working immediately after a mac updates its
       },
     }));
 
-    const response = await fetch(`http://127.0.0.1:${port}/v1/trusted/session/resolve`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(makeTrustedResolveBody({
-        macDeviceId: "mac-4",
-        phoneIdentity,
-        nonce: "nonce-live-update",
-        timestamp: Date.now(),
-      })),
+    const { body, status } = await resolveTrustedSessionEventually(port, {
+      macDeviceId: "mac-4",
+      phoneIdentity,
+      noncePrefix: "nonce-live-update",
     });
 
-    assert.equal(response.status, 200);
-    const body = await response.json();
+    assert.equal(status, 200);
     assert.equal(body.displayName, "Updated-Mac");
     assert.equal(body.sessionId, "live-session-4");
 
@@ -955,6 +965,9 @@ function listen(server) {
 
 function close(server, wss) {
   return new Promise((resolve, reject) => {
+    for (const client of wss.clients) {
+      client.terminate();
+    }
     wss.close();
     server.close((error) => {
       if (error) {
@@ -964,6 +977,34 @@ function close(server, wss) {
       resolve();
     });
   });
+}
+
+async function resolveTrustedSessionEventually(port, {
+  macDeviceId,
+  phoneIdentity,
+  noncePrefix,
+  attempts = 10,
+}) {
+  let lastResult = null;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/trusted/session/resolve`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(makeTrustedResolveBody({
+        macDeviceId,
+        phoneIdentity,
+        nonce: `${noncePrefix}-${attempt}`,
+        timestamp: Date.now(),
+      })),
+    });
+    const body = await response.json();
+    lastResult = { body, status: response.status };
+    if (response.status === 200) {
+      return lastResult;
+    }
+    await delay(10);
+  }
+  return lastResult;
 }
 
 function onceOpen(socket) {

--- a/relay/simulated-pairing-reconnect.test.js
+++ b/relay/simulated-pairing-reconnect.test.js
@@ -1,0 +1,635 @@
+// FILE: simulated-pairing-reconnect.test.js
+// Purpose: Exercises relay pairing, trusted reconnect, and secure replay without a live app or Simulator.
+// Layer: Integration test
+// Exports: node:test suite
+// Depends on: node:test, node:assert/strict, crypto, ws, ./server, ../phodex-bridge/src/secure-transport
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  diffieHellman,
+  generateKeyPairSync,
+  hkdfSync,
+  sign,
+} = require("crypto");
+const WebSocket = require("ws");
+const {
+  HANDSHAKE_MODE_QR_BOOTSTRAP,
+  HANDSHAKE_MODE_TRUSTED_RECONNECT,
+  createBridgeSecureTransport,
+  nonceForDirection,
+} = require("../phodex-bridge/src/secure-transport");
+const { createRelayServer } = require("./server");
+
+test("simulated relay harness covers QR bootstrap, trusted resolve, and reconnect replay", async () => {
+  await withServer(async ({ port, wss }) => {
+    const sessionId = "simulated-pairing-session";
+    const macDeviceId = "simulated-mac";
+    const pairingCode = "AB23CD34";
+    const macIdentity = createOkpKeyPair("ed25519");
+    const phoneIdentity = createPhoneIdentity("simulated-phone");
+    const applicationMessages = [];
+
+    let macSocket = null;
+    const secureTransport = createBridgeSecureTransport({
+      sessionId,
+      relayUrl: `ws://127.0.0.1:${port}/relay`,
+      displayName: "Simulated Mac",
+      persistTrustedPhone: false,
+      deviceState: {
+        macDeviceId,
+        macIdentityPrivateKey: macIdentity.privateKey,
+        macIdentityPublicKey: macIdentity.publicKey,
+        trustedPhones: {},
+      },
+      onTrustedPhoneUpdate(_deviceState, trustedPhone) {
+        macSocket.send(JSON.stringify({
+          kind: "relayMacRegistration",
+          registration: {
+            macDeviceId,
+            macIdentityPublicKey: macIdentity.publicKey,
+            displayName: "Simulated Mac",
+            trustedPhoneDeviceId: trustedPhone.phoneDeviceId,
+            trustedPhonePublicKey: trustedPhone.phoneIdentityPublicKey,
+          },
+        }));
+      },
+    });
+
+    macSocket = new WebSocket(`ws://127.0.0.1:${port}/relay/${sessionId}`, {
+      headers: {
+        "x-role": "mac",
+        "x-mac-device-id": macDeviceId,
+        "x-mac-identity-public-key": macIdentity.publicKey,
+        "x-machine-name": "Simulated Mac",
+        "x-pairing-code": pairingCode,
+        "x-pairing-version": "2",
+        "x-pairing-expires-at": String(Date.now() + 60_000),
+      },
+    });
+    await onceOpen(macSocket);
+    bindBridgeTransportToSocket({
+      applicationMessages,
+      secureTransport,
+      socket: macSocket,
+    });
+
+    const pairingResponse = await fetch(`http://127.0.0.1:${port}/v1/pairing/code/resolve`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code: "AB23-CD34" }),
+    });
+    const pairingPayload = await pairingResponse.json();
+    assert.equal(pairingResponse.status, 200);
+    assert.equal(pairingPayload.sessionId, sessionId);
+    assert.equal(pairingPayload.macDeviceId, macDeviceId);
+    assert.equal(pairingPayload.macIdentityPublicKey, macIdentity.publicKey);
+
+    const firstPhoneSocket = new WebSocket(`ws://127.0.0.1:${port}/relay/${sessionId}`, {
+      headers: { "x-role": "iphone" },
+    });
+    await onceOpen(firstPhoneSocket);
+    const firstPhone = new SimulatedPhone({
+      macDeviceId,
+      macIdentityPublicKey: macIdentity.publicKey,
+      phoneIdentity,
+      sessionId,
+      socket: firstPhoneSocket,
+    });
+    await firstPhone.completeHandshake({
+      handshakeMode: HANDSHAKE_MODE_QR_BOOTSTRAP,
+      lastAppliedBridgeOutboundSeq: 0,
+    });
+    await waitUntil(() => secureTransport.isSecureChannelReady());
+    assert.equal(secureTransport.isSecureChannelReady(), true);
+
+    const trustedSession = await resolveTrustedSessionEventually(port, {
+      macDeviceId,
+      phoneIdentity,
+    });
+    assert.equal(trustedSession.status, 200);
+    assert.equal(trustedSession.body.sessionId, sessionId);
+    assert.equal(trustedSession.body.displayName, "Simulated Mac");
+
+    firstPhone.sendApplicationMessage(JSON.stringify({
+      id: "request-1",
+      method: "thread/list",
+      params: {},
+    }));
+    await waitUntil(() => applicationMessages.length === 1);
+    assert.deepEqual(applicationMessages, [
+      JSON.stringify({ id: "request-1", method: "thread/list", params: {} }),
+    ]);
+
+    secureTransport.queueOutboundApplicationMessage(
+      JSON.stringify({ id: "response-1", result: { ok: true } }),
+      failUnexpectedDirectSend
+    );
+    const firstOutbound = await firstPhone.nextBridgePayload();
+    assert.equal(firstOutbound.bridgeOutboundSeq, 1);
+    assert.equal(firstOutbound.payloadText, JSON.stringify({ id: "response-1", result: { ok: true } }));
+
+    const firstPhoneClosed = onceClosed(firstPhoneSocket);
+    firstPhoneSocket.close();
+    await firstPhoneClosed;
+    await waitUntil(() => countRelayClients(wss, "iphone") === 0);
+
+    secureTransport.queueOutboundApplicationMessage(
+      JSON.stringify({ id: "response-2", result: { replayed: true } }),
+      failUnexpectedDirectSend
+    );
+    await waitUntil(() => macSocket.bufferedAmount === 0);
+    await delay(25);
+
+    const secondPhoneSocket = new WebSocket(`ws://127.0.0.1:${port}/relay/${sessionId}`, {
+      headers: { "x-role": "iphone" },
+    });
+    await onceOpen(secondPhoneSocket);
+    const secondPhone = new SimulatedPhone({
+      macDeviceId,
+      macIdentityPublicKey: macIdentity.publicKey,
+      phoneIdentity,
+      sessionId,
+      socket: secondPhoneSocket,
+    });
+    await secondPhone.completeHandshake({
+      handshakeMode: HANDSHAKE_MODE_TRUSTED_RECONNECT,
+      lastAppliedBridgeOutboundSeq: firstOutbound.bridgeOutboundSeq,
+    });
+
+    const replayedPayload = await secondPhone.nextBridgePayload();
+    assert.equal(replayedPayload.bridgeOutboundSeq, 2);
+    assert.equal(replayedPayload.payloadText, JSON.stringify({ id: "response-2", result: { replayed: true } }));
+
+    const secondPhoneClosed = onceClosed(secondPhoneSocket);
+    const macClosed = onceClosed(macSocket);
+    secondPhoneSocket.close();
+    macSocket.close();
+    await Promise.all([secondPhoneClosed, macClosed]);
+  });
+});
+
+class SimulatedPhone {
+  constructor({
+    macDeviceId,
+    macIdentityPublicKey,
+    phoneIdentity,
+    sessionId,
+    socket,
+  }) {
+    this.macDeviceId = macDeviceId;
+    this.macIdentityPublicKey = macIdentityPublicKey;
+    this.outboundCounter = 0;
+    this.phoneIdentity = phoneIdentity;
+    this.sessionId = sessionId;
+    this.socket = socket;
+  }
+
+  async completeHandshake({
+    handshakeMode,
+    lastAppliedBridgeOutboundSeq,
+  }) {
+    const phoneEphemeral = createOkpKeyPair("x25519");
+    const clientNonce = Buffer.alloc(32, 7 + this.outboundCounter);
+    this.socket.send(JSON.stringify({
+      kind: "clientHello",
+      protocolVersion: 1,
+      sessionId: this.sessionId,
+      handshakeMode,
+      phoneDeviceId: this.phoneIdentity.phoneDeviceId,
+      phoneIdentityPublicKey: this.phoneIdentity.phoneIdentityPublicKey,
+      phoneEphemeralPublicKey: phoneEphemeral.publicKey,
+      clientNonce: clientNonce.toString("base64"),
+    }));
+
+    const serverHello = JSON.parse(await onceMessage(this.socket));
+    assert.equal(serverHello.kind, "serverHello");
+    assert.equal(serverHello.macIdentityPublicKey, this.macIdentityPublicKey);
+
+    const transcriptBytes = buildTranscriptBytes({
+      sessionId: this.sessionId,
+      protocolVersion: 1,
+      handshakeMode,
+      keyEpoch: serverHello.keyEpoch,
+      macDeviceId: this.macDeviceId,
+      phoneDeviceId: this.phoneIdentity.phoneDeviceId,
+      macIdentityPublicKey: this.macIdentityPublicKey,
+      phoneIdentityPublicKey: this.phoneIdentity.phoneIdentityPublicKey,
+      macEphemeralPublicKey: serverHello.macEphemeralPublicKey,
+      phoneEphemeralPublicKey: phoneEphemeral.publicKey,
+      clientNonce,
+      serverNonce: Buffer.from(serverHello.serverNonce, "base64"),
+      expiresAtForTranscript: serverHello.expiresAtForTranscript,
+    });
+    const phoneAuthTranscript = Buffer.concat([
+      transcriptBytes,
+      encodeLengthPrefixedUTF8("client-auth"),
+    ]);
+    const phoneSignature = sign(
+      null,
+      phoneAuthTranscript,
+      {
+        key: {
+          crv: "Ed25519",
+          d: base64ToBase64Url(this.phoneIdentity.phoneIdentityPrivateKey),
+          kty: "OKP",
+          x: base64ToBase64Url(this.phoneIdentity.phoneIdentityPublicKey),
+        },
+        format: "jwk",
+      }
+    );
+
+    this.socket.send(JSON.stringify({
+      kind: "clientAuth",
+      sessionId: this.sessionId,
+      phoneDeviceId: this.phoneIdentity.phoneDeviceId,
+      keyEpoch: serverHello.keyEpoch,
+      phoneSignature: phoneSignature.toString("base64"),
+    }));
+
+    const secureReady = JSON.parse(await onceMessage(this.socket));
+    assert.equal(secureReady.kind, "secureReady");
+
+    const keys = deriveSessionKeys({
+      macDeviceId: this.macDeviceId,
+      phoneDeviceId: this.phoneIdentity.phoneDeviceId,
+      phoneEphemeral,
+      serverHello,
+      sessionId: this.sessionId,
+      transcriptBytes,
+    });
+    this.keyEpoch = serverHello.keyEpoch;
+    this.macToPhoneKey = keys.macToPhoneKey;
+    this.phoneToMacKey = keys.phoneToMacKey;
+    this.outboundCounter = 0;
+
+    this.socket.send(JSON.stringify({
+      kind: "resumeState",
+      sessionId: this.sessionId,
+      keyEpoch: this.keyEpoch,
+      lastAppliedBridgeOutboundSeq,
+    }));
+  }
+
+  async nextBridgePayload() {
+    const envelope = JSON.parse(await onceMessage(this.socket));
+    assert.equal(envelope.kind, "encryptedEnvelope");
+    return decryptEnvelope(envelope, this.macToPhoneKey);
+  }
+
+  sendApplicationMessage(payloadText) {
+    const envelope = encryptEnvelope(
+      { payloadText },
+      this.phoneToMacKey,
+      "iphone",
+      this.outboundCounter,
+      this.sessionId,
+      this.keyEpoch
+    );
+    this.outboundCounter += 1;
+    this.socket.send(JSON.stringify(envelope));
+  }
+}
+
+function bindBridgeTransportToSocket({
+  applicationMessages,
+  secureTransport,
+  socket,
+}) {
+  secureTransport.bindLiveSendWireMessage((message) => {
+    socket.send(message);
+    return true;
+  });
+  socket.on("message", (data) => {
+    secureTransport.handleIncomingWireMessage(data.toString("utf8"), {
+      sendControlMessage(message) {
+        socket.send(JSON.stringify(message));
+      },
+      onApplicationMessage(message) {
+        applicationMessages.push(message);
+      },
+    });
+  });
+}
+
+async function withServer(run) {
+  const { server, wss } = createRelayServer();
+  const address = await listen(server);
+  try {
+    return await run({ port: address.port, wss });
+  } finally {
+    for (const client of wss.clients) {
+      client.terminate();
+    }
+    await close(server, wss);
+  }
+}
+
+function listen(server) {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve(server.address());
+    });
+  });
+}
+
+function close(server, wss) {
+  return new Promise((resolve, reject) => {
+    wss.close();
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function resolveTrustedSessionEventually(port, {
+  macDeviceId,
+  phoneIdentity,
+}) {
+  let lastResult = null;
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/trusted/session/resolve`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(makeTrustedResolveBody({
+        macDeviceId,
+        phoneIdentity,
+        nonce: `trusted-resolve-${attempt}`,
+        timestamp: Date.now(),
+      })),
+    });
+    lastResult = {
+      body: await response.json(),
+      status: response.status,
+    };
+    if (response.status === 200) {
+      return lastResult;
+    }
+    await delay(10);
+  }
+  return lastResult;
+}
+
+function onceOpen(socket) {
+  return new Promise((resolve, reject) => {
+    socket.once("open", resolve);
+    socket.once("error", reject);
+  });
+}
+
+function onceMessage(socket) {
+  return new Promise((resolve, reject) => {
+    socket.once("message", (value) => resolve(value.toString("utf8")));
+    socket.once("error", reject);
+  });
+}
+
+function onceClosed(socket) {
+  return new Promise((resolve) => {
+    if (socket.readyState === WebSocket.CLOSED) {
+      resolve();
+      return;
+    }
+    socket.once("close", resolve);
+  });
+}
+
+function waitUntil(predicate, { attempts = 20, delayMs = 10 } = {}) {
+  return new Promise((resolve, reject) => {
+    let attempt = 0;
+    const tick = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      attempt += 1;
+      if (attempt >= attempts) {
+        reject(new Error("condition was not met before timeout"));
+        return;
+      }
+      setTimeout(tick, delayMs);
+    };
+    tick();
+  });
+}
+
+function countRelayClients(wss, role) {
+  let count = 0;
+  for (const client of wss.clients) {
+    if (client._relayRole === role && client.readyState === WebSocket.OPEN) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+function createOkpKeyPair(type) {
+  const { privateKey, publicKey } = generateKeyPairSync(type);
+  const privateJwk = privateKey.export({ format: "jwk" });
+  const publicJwk = publicKey.export({ format: "jwk" });
+  return {
+    privateKey: base64UrlToBase64(privateJwk.d),
+    publicKey: base64UrlToBase64(publicJwk.x),
+  };
+}
+
+function createPhoneIdentity(phoneDeviceId) {
+  const identity = createOkpKeyPair("ed25519");
+  return {
+    phoneDeviceId,
+    phoneIdentityPrivateKey: identity.privateKey,
+    phoneIdentityPublicKey: identity.publicKey,
+  };
+}
+
+function makeTrustedResolveBody({
+  macDeviceId,
+  phoneIdentity,
+  nonce,
+  timestamp,
+}) {
+  const transcript = buildTrustedResolveTranscript({
+    macDeviceId,
+    nonce,
+    phoneDeviceId: phoneIdentity.phoneDeviceId,
+    phoneIdentityPublicKey: phoneIdentity.phoneIdentityPublicKey,
+    timestamp,
+  });
+  return {
+    macDeviceId,
+    nonce,
+    phoneDeviceId: phoneIdentity.phoneDeviceId,
+    phoneIdentityPublicKey: phoneIdentity.phoneIdentityPublicKey,
+    signature: sign(
+      null,
+      transcript,
+      {
+        key: {
+          crv: "Ed25519",
+          d: base64ToBase64Url(phoneIdentity.phoneIdentityPrivateKey),
+          kty: "OKP",
+          x: base64ToBase64Url(phoneIdentity.phoneIdentityPublicKey),
+        },
+        format: "jwk",
+      }
+    ).toString("base64"),
+    timestamp,
+  };
+}
+
+function buildTrustedResolveTranscript({
+  macDeviceId,
+  nonce,
+  phoneDeviceId,
+  phoneIdentityPublicKey,
+  timestamp,
+}) {
+  return Buffer.concat([
+    encodeLengthPrefixedUTF8("remodex-trusted-session-resolve-v1"),
+    encodeLengthPrefixedUTF8(macDeviceId),
+    encodeLengthPrefixedUTF8(phoneDeviceId),
+    encodeLengthPrefixedBuffer(Buffer.from(phoneIdentityPublicKey, "base64")),
+    encodeLengthPrefixedUTF8(nonce),
+    encodeLengthPrefixedUTF8(String(timestamp)),
+  ]);
+}
+
+function buildTranscriptBytes({
+  sessionId,
+  protocolVersion,
+  handshakeMode,
+  keyEpoch,
+  macDeviceId,
+  phoneDeviceId,
+  macIdentityPublicKey,
+  phoneIdentityPublicKey,
+  macEphemeralPublicKey,
+  phoneEphemeralPublicKey,
+  clientNonce,
+  serverNonce,
+  expiresAtForTranscript,
+}) {
+  return Buffer.concat([
+    encodeLengthPrefixedUTF8("remodex-e2ee-v1"),
+    encodeLengthPrefixedUTF8(sessionId),
+    encodeLengthPrefixedUTF8(String(protocolVersion)),
+    encodeLengthPrefixedUTF8(handshakeMode),
+    encodeLengthPrefixedUTF8(String(keyEpoch)),
+    encodeLengthPrefixedUTF8(macDeviceId),
+    encodeLengthPrefixedUTF8(phoneDeviceId),
+    encodeLengthPrefixedBuffer(Buffer.from(macIdentityPublicKey, "base64")),
+    encodeLengthPrefixedBuffer(Buffer.from(phoneIdentityPublicKey, "base64")),
+    encodeLengthPrefixedBuffer(Buffer.from(macEphemeralPublicKey, "base64")),
+    encodeLengthPrefixedBuffer(Buffer.from(phoneEphemeralPublicKey, "base64")),
+    encodeLengthPrefixedBuffer(clientNonce),
+    encodeLengthPrefixedBuffer(serverNonce),
+    encodeLengthPrefixedUTF8(String(expiresAtForTranscript)),
+  ]);
+}
+
+function encodeLengthPrefixedUTF8(value) {
+  return encodeLengthPrefixedBuffer(Buffer.from(value, "utf8"));
+}
+
+function encodeLengthPrefixedBuffer(buffer) {
+  const length = Buffer.allocUnsafe(4);
+  length.writeUInt32BE(buffer.length, 0);
+  return Buffer.concat([length, buffer]);
+}
+
+function deriveSessionKeys({
+  macDeviceId,
+  phoneDeviceId,
+  phoneEphemeral,
+  serverHello,
+  sessionId,
+  transcriptBytes,
+}) {
+  const sharedSecret = diffieHellman({
+    privateKey: createPrivateKey({
+      key: {
+        crv: "X25519",
+        d: base64ToBase64Url(phoneEphemeral.privateKey),
+        kty: "OKP",
+        x: base64ToBase64Url(phoneEphemeral.publicKey),
+      },
+      format: "jwk",
+    }),
+    publicKey: createPublicKey({
+      key: {
+        crv: "X25519",
+        kty: "OKP",
+        x: base64ToBase64Url(serverHello.macEphemeralPublicKey),
+      },
+      format: "jwk",
+    }),
+  });
+  const salt = createHash("sha256").update(transcriptBytes).digest();
+  const infoPrefix = `remodex-e2ee-v1|${sessionId}|${macDeviceId}|${phoneDeviceId}|${serverHello.keyEpoch}`;
+  return {
+    macToPhoneKey: Buffer.from(
+      hkdfSync("sha256", sharedSecret, salt, Buffer.from(`${infoPrefix}|macToPhone`, "utf8"), 32)
+    ),
+    phoneToMacKey: Buffer.from(
+      hkdfSync("sha256", sharedSecret, salt, Buffer.from(`${infoPrefix}|phoneToMac`, "utf8"), 32)
+    ),
+  };
+}
+
+function encryptEnvelope(payloadObject, key, sender, counter, sessionId, keyEpoch) {
+  const nonce = nonceForDirection(sender, counter);
+  const cipher = createCipheriv("aes-256-gcm", key, nonce);
+  const ciphertext = Buffer.concat([
+    cipher.update(Buffer.from(JSON.stringify(payloadObject), "utf8")),
+    cipher.final(),
+  ]);
+  return {
+    kind: "encryptedEnvelope",
+    v: 1,
+    sessionId,
+    keyEpoch,
+    sender,
+    counter,
+    ciphertext: ciphertext.toString("base64"),
+    tag: cipher.getAuthTag().toString("base64"),
+  };
+}
+
+function decryptEnvelope(envelope, key) {
+  const nonce = nonceForDirection(envelope.sender, envelope.counter);
+  const decipher = createDecipheriv("aes-256-gcm", key, nonce);
+  decipher.setAuthTag(Buffer.from(envelope.tag, "base64"));
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(envelope.ciphertext, "base64")),
+    decipher.final(),
+  ]);
+  return JSON.parse(plaintext.toString("utf8"));
+}
+
+function base64UrlToBase64(value) {
+  const padded = `${value}${"=".repeat((4 - (value.length % 4 || 4)) % 4)}`;
+  return padded.replace(/-/g, "+").replace(/_/g, "/");
+}
+
+function base64ToBase64Url(value) {
+  return value.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function failUnexpectedDirectSend() {
+  throw new Error("expected bound relay sender to handle secure transport output");
+}


### PR DESCRIPTION
## Summary
- Reduce bridge-side allocation pressure and bound long-lived request/cache state for long sessions.
- Improve low-network behavior with constrained-network iOS sync/keepalive handling, reconnect jitter, push retry/backoff, and WebSocket compression negotiated on both bridge and relay.
- Expand focused coverage for the touched paths with bridge/relay CI, relay reconnect tests, and iOS performance script smoke checks.

## Improvements
- Bridge request/response tracking is now bounded: forwarded request methods `500`, sanitized response methods `500`.
- JSONL-related bridge caches are bounded: artifact cache `128`, rollout path cache `200`, rollout miss cache `200`.
- Push notification tracker memory is bounded: thread titles `200`, turn states `500`, turn-to-thread mappings `500`.
- Constrained-network iOS polling stretches sync intervals `2x` when `NWPath.isConstrained` is true.
- Constrained-network WebSocket keepalive interval increases from `25s` to `35s`.
- Push service retry now allows up to `3` total attempts with `500ms` then `1000ms` backoff for retryable failures.
- WebSocket compression now negotiates end-to-end: the bridge offers `perMessageDeflate`, and the relay enables it server-side.
- Relay reconnects now add jitter of up to `2s` on top of the existing backoff, reducing synchronized reconnect bursts.
- JSONL/session parsing and rollout line parsing avoid whole-buffer line-array splits in hot paths, reducing temporary allocations on large logs.
- Codex stdout parsing now drains complete lines incrementally instead of splitting the whole buffer on each chunk.
- Secure replay buffer trimming now removes old entries in one splice instead of repeated array shifts.
- iOS outgoing payload size checks use `text.utf8.count` instead of allocating `Data(text.utf8)`.
- iOS thread reconciliation reserves merge dictionary capacity before combining server/local thread state.

## Verification
- GitHub Actions `Node Package Tests`: passed.
- GitHub Actions `Build Unsigned IPA`: passed and uploaded `remodex-unsigned-release.ipa`.
- `npm ci --ignore-scripts && npm test` in `phodex-bridge`: 367/367 passed.
- `npm ci --ignore-scripts && npm test` in `relay`: 41/41 passed.
- `CodexMobile/scripts/test-performance-script-usage.sh`: passed.
- `bash -n CodexMobile/scripts/check-sidebar-badge-performance.sh CodexMobile/scripts/check-turnview-performance.sh CodexMobile/scripts/test-performance-script-usage.sh`: passed.
- `git diff --check`: passed.
- `xcodebuild -project CodexMobile/CodexMobile.xcodeproj -scheme CodexMobile -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO ARCHS=arm64 ONLY_ACTIVE_ARCH=YES build`: passed.

## Notes
- This PR has concrete bounds, reduced polling rates, retry/backoff numbers, and passing test/build evidence.
- It does not include a measured real-device bandwidth or latency benchmark, so it avoids claiming a universal percent speedup.
- Push notification retries favor transient-failure resilience over fastest failure reporting; with the default `10s` per-attempt timeout and `2` retries, a fully unavailable push service can take about `31.5s` before the request fails.
