### PR TITLE
[codex] Improve menu bar bridge device status

### DIFF
--- a/CodexMobile/RemodexMenuBar/BridgeControlModels.swift
+++ b/CodexMobile/RemodexMenuBar/BridgeControlModels.swift
@@ -16,6 +16,7 @@ struct BridgeSnapshot: Codable, Equatable {
     let daemonConfig: BridgeDaemonConfig?
     let bridgeStatus: BridgeRuntimeStatus?
     let pairingSession: BridgePairingSession?
+    let trustedDevice: BridgeTrustedDeviceSummary?
     let stdoutLogPath: String
     let stderrLogPath: String
 }
@@ -33,6 +34,8 @@ struct BridgeRuntimeStatus: Codable, Equatable {
     let pid: Int?
     let lastError: String?
     let updatedAt: String?
+    let activeDevice: BridgeActivePhoneSummary?
+    let activePhone: BridgeActivePhoneSummary?
 }
 
 struct BridgePairingSession: Codable, Equatable {
@@ -47,6 +50,23 @@ struct BridgePairingPayload: Codable, Equatable {
     let macDeviceId: String
     let macIdentityPublicKey: String
     let expiresAt: Int64
+}
+
+struct BridgeTrustedDeviceSummary: Codable, Equatable {
+    let macDeviceFingerprint: String?
+    let trustedPhoneCount: Int
+    let trustedPhoneFingerprint: String?
+    let lastSeenDeviceKind: String?
+    let lastSeenPhoneAppVersion: String?
+}
+
+struct BridgeActivePhoneSummary: Codable, Equatable {
+    let connected: Bool
+    let phoneFingerprint: String?
+    let deviceKind: String?
+    let handshakeMode: String?
+    let keyEpoch: Int?
+    let updatedAt: String?
 }
 
 struct BridgePackageUpdateState: Equatable {
@@ -173,6 +193,46 @@ extension BridgeSnapshot {
 
     var relayKindLabel: String {
         classifyRelay(effectiveRelayURL)
+    }
+
+    var trustedPhoneStatusLabel: String {
+        if let activeDevice = bridgeStatus?.activeDevice ?? bridgeStatus?.activePhone,
+           activeDevice.connected {
+            let deviceName = Self.displayDeviceName(activeDevice.deviceKind)
+            if let fingerprint = activeDevice.phoneFingerprint?.nonEmptyTrimmed {
+                return "Connected \(deviceName) · \(fingerprint)"
+            }
+
+            return "Connected \(deviceName)"
+        }
+
+        guard let trustedDevice else {
+            return "Unknown"
+        }
+
+        if trustedDevice.trustedPhoneCount <= 0 {
+            return "No device paired"
+        }
+
+        let deviceName = Self.displayDeviceName(trustedDevice.lastSeenDeviceKind)
+        if let appVersion = trustedDevice.lastSeenPhoneAppVersion?.nonEmptyTrimmed {
+            return "Trusted \(deviceName) · app \(appVersion)"
+        }
+
+        return "Trusted \(deviceName)"
+    }
+
+    private static func displayDeviceName(_ deviceKind: String?) -> String {
+        switch deviceKind?.nonEmptyTrimmed?.lowercased() {
+        case "iphone":
+            return "iPhone"
+        case "android":
+            return "Android"
+        case "mac":
+            return "Mac"
+        default:
+            return "device"
+        }
     }
 
     private static let relativeFormatter: RelativeDateTimeFormatter = {

--- a/CodexMobile/RemodexMenuBar/BridgeControlService.swift
+++ b/CodexMobile/RemodexMenuBar/BridgeControlService.swift
@@ -4,6 +4,7 @@
 // Exports: BridgeControlService, ShellCommandRunner
 // Depends on: Foundation, BridgeControlModels
 
+import CryptoKit
 import Foundation
 
 struct BridgeCLIInvocation {
@@ -134,7 +135,8 @@ final class BridgeControlService {
         }
 
         do {
-            return try decoder.decode(BridgeSnapshot.self, from: data)
+            let snapshot = try decoder.decode(BridgeSnapshot.self, from: data)
+            return snapshotWithLocalTrustFallback(snapshot)
         } catch {
             return try await loadFallbackSnapshot(from: result.stdout, invocation: invocation)
         }
@@ -148,10 +150,26 @@ final class BridgeControlService {
         )
     }
 
+    func restartBridge(relayOverride: String?) async throws {
+        let invocation = try await resolveCLIInvocation()
+        _ = try await runner.run(
+            command: invocation.command(["restart"]),
+            environment: commandEnvironment(relayOverride: relayOverride)
+        )
+    }
+
     func stopBridge(relayOverride: String?) async throws {
         let invocation = try await resolveCLIInvocation()
         _ = try await runner.run(
             command: invocation.command(["stop"]),
+            environment: commandEnvironment(relayOverride: relayOverride)
+        )
+    }
+
+    func refreshPairing(relayOverride: String?) async throws {
+        let invocation = try await resolveCLIInvocation()
+        _ = try await runner.run(
+            command: invocation.command(["pair", "--json"]),
             environment: commandEnvironment(relayOverride: relayOverride)
         )
     }
@@ -226,6 +244,7 @@ final class BridgeControlService {
         let daemonConfig: BridgeDaemonConfig? = readStateFile(named: "daemon-config.json", in: stateDirectory)
         let bridgeStatus: BridgeRuntimeStatus? = readStateFile(named: "bridge-status.json", in: stateDirectory)
         let pairingSession: BridgePairingSession? = readStateFile(named: "pairing-session.json", in: stateDirectory)
+        let trustedDevice: BridgeTrustedDeviceSummary? = readDeviceTrustSummary(in: stateDirectory)
         let stdoutLogPath = statusLines["stdout log"] ?? stateDirectory.appendingPathComponent("logs/bridge.stdout.log").path
         let stderrLogPath = statusLines["stderr log"] ?? stateDirectory.appendingPathComponent("logs/bridge.stderr.log").path
         let launchdPid = parsePid(statusLines["pid"])
@@ -242,8 +261,35 @@ final class BridgeControlService {
             daemonConfig: daemonConfig,
             bridgeStatus: bridgeStatus,
             pairingSession: pairingSession,
+            trustedDevice: trustedDevice,
             stdoutLogPath: stdoutLogPath,
             stderrLogPath: stderrLogPath
+        )
+    }
+
+    private func snapshotWithLocalTrustFallback(_ snapshot: BridgeSnapshot) -> BridgeSnapshot {
+        guard snapshot.trustedDevice == nil else {
+            return snapshot
+        }
+
+        let stateDirectory = URL(fileURLWithPath: snapshot.stateDirectoryPath)
+        guard let trustedDevice = readDeviceTrustSummary(in: stateDirectory) else {
+            return snapshot
+        }
+
+        return BridgeSnapshot(
+            currentVersion: snapshot.currentVersion,
+            label: snapshot.label,
+            platform: snapshot.platform,
+            installed: snapshot.installed,
+            launchdLoaded: snapshot.launchdLoaded,
+            launchdPid: snapshot.launchdPid,
+            daemonConfig: snapshot.daemonConfig,
+            bridgeStatus: snapshot.bridgeStatus,
+            pairingSession: snapshot.pairingSession,
+            trustedDevice: trustedDevice,
+            stdoutLogPath: snapshot.stdoutLogPath,
+            stderrLogPath: snapshot.stderrLogPath
         )
     }
 
@@ -306,6 +352,26 @@ final class BridgeControlService {
         }
 
         return try? decoder.decode(T.self, from: data)
+    }
+
+    private func readDeviceTrustSummary(in stateDirectory: URL) -> BridgeTrustedDeviceSummary? {
+        guard let state: LegacyBridgeDeviceState = readStateFile(named: "device-state.json", in: stateDirectory) else {
+            return nil
+        }
+
+        let trustedPhones = state.trustedPhones.filter { key, value in
+            !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        let firstTrustedPhoneId = trustedPhones.keys.sorted().first
+        let lastSeenPhoneAppVersion = normalizeNonEmptyString(state.lastSeenPhoneAppVersion)
+        return BridgeTrustedDeviceSummary(
+            macDeviceFingerprint: shortFingerprint(state.macDeviceId),
+            trustedPhoneCount: trustedPhones.count,
+            trustedPhoneFingerprint: shortFingerprint(firstTrustedPhoneId),
+            lastSeenDeviceKind: normalizeDeviceKind(state.lastSeenDeviceKind) ?? (lastSeenPhoneAppVersion == nil ? nil : "iphone"),
+            lastSeenPhoneAppVersion: lastSeenPhoneAppVersion
+        )
     }
 
     // Prefers the Node runtime sitting next to the resolved CLI binary so mixed installs stay compatible.
@@ -519,4 +585,61 @@ final class BridgeControlService {
 
 private func shellQuoted(_ value: String) -> String {
     "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+}
+
+private struct LegacyBridgeDeviceState: Decodable {
+    let macDeviceId: String?
+    let trustedPhones: [String: String]
+    let lastSeenDeviceKind: String?
+    let lastSeenPhoneAppVersion: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case macDeviceId
+        case trustedPhones
+        case lastSeenDeviceKind
+        case lastSeenPhoneAppVersion
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        macDeviceId = try container.decodeIfPresent(String.self, forKey: .macDeviceId)
+        trustedPhones = try container.decodeIfPresent([String: String].self, forKey: .trustedPhones) ?? [:]
+        lastSeenDeviceKind = try container.decodeIfPresent(String.self, forKey: .lastSeenDeviceKind)
+        lastSeenPhoneAppVersion = try container.decodeIfPresent(String.self, forKey: .lastSeenPhoneAppVersion)
+    }
+}
+
+private func normalizeDeviceKind(_ value: String?) -> String? {
+    guard let normalized = normalizeNonEmptyFingerprintInput(value)?.lowercased() else {
+        return nil
+    }
+
+    switch normalized {
+    case "ios", "iphone":
+        return "iphone"
+    case "android":
+        return "android"
+    case "mac", "macos", "darwin":
+        return "mac"
+    default:
+        return normalized
+    }
+}
+
+private func shortFingerprint(_ value: String?) -> String? {
+    guard let normalized = normalizeNonEmptyFingerprintInput(value) else {
+        return nil
+    }
+
+    let digest = SHA256.hash(data: Data(normalized.utf8))
+    return digest.prefix(4).map { String(format: "%02x", $0) }.joined()
+}
+
+private func normalizeNonEmptyFingerprintInput(_ value: String?) -> String? {
+    guard let value else {
+        return nil
+    }
+
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
 }

--- a/CodexMobile/RemodexMenuBar/BridgeMenuBarStore.swift
+++ b/CodexMobile/RemodexMenuBar/BridgeMenuBarStore.swift
@@ -99,6 +99,23 @@ final class BridgeMenuBarStore: ObservableObject {
         }
     }
 
+    func restartBridge() {
+        runAction(successMessage: "Bridge riavviato.") {
+            try await self.requireCLIAvailability()
+            try await self.service.restartBridge(relayOverride: self.effectiveRelayOverride)
+            try await self.refreshAfterAction()
+        }
+    }
+
+    func refreshPairing() {
+        let previousPairingDate = snapshot?.pairingSession?.createdDate
+        runAction(successMessage: "QR pairing aggiornato.") {
+            try await self.requireCLIAvailability()
+            try await self.service.refreshPairing(relayOverride: self.effectiveRelayOverride)
+            try await self.waitForFreshPairing(after: previousPairingDate)
+        }
+    }
+
     func resumeLastThread() {
         runAction(successMessage: "Ultimo thread riaperto in Codex.") {
             try await self.requireCLIAvailability()

--- a/CodexMobile/RemodexMenuBar/BridgeMenuBarViews.swift
+++ b/CodexMobile/RemodexMenuBar/BridgeMenuBarViews.swift
@@ -96,6 +96,8 @@ struct BridgeMenuBarContentView: View {
             } else {
                 LabelValueRow(label: "Relay URL", value: "Not configured yet")
             }
+
+            LabelValueRow(label: "Device", value: store.snapshot?.trustedPhoneStatusLabel ?? "Unknown")
         }
         .padding(12)
         .background(cardFill, in: cardShape)
@@ -117,10 +119,10 @@ struct BridgeMenuBarContentView: View {
                 .font(.system(size: 12, weight: .regular, design: .monospaced))
                 .padding(.horizontal, 12)
                 .padding(.vertical, 10)
-                .background(Color(nsColor: .textBackgroundColor).opacity(0.82), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .background(Color.clear, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
                 .overlay(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(Color.primary.opacity(0.10), lineWidth: 1)
                 )
 
             HStack(spacing: 6) {
@@ -148,18 +150,27 @@ struct BridgeMenuBarContentView: View {
                 CompactActionButton("Start", style: .primary) {
                     store.startBridge()
                 }
+                CompactActionButton("Restart", style: .secondary) {
+                    store.restartBridge()
+                }
                 CompactActionButton("Stop", style: .destructive) {
                     store.stopBridge()
-                }
-                CompactActionButton("Resume", style: .secondary) {
-                    store.resumeLastThread()
                 }
             }
 
             HStack(spacing: 6) {
+                CompactActionButton("Pair QR", style: .primary) {
+                    store.refreshPairing()
+                }
+                CompactActionButton("Resume", style: .secondary) {
+                    store.resumeLastThread()
+                }
                 CompactActionButton("Refresh", style: .secondary) {
                     Task { await store.refresh(showSpinner: true) }
                 }
+            }
+
+            HStack(spacing: 6) {
                 CompactActionButton("Reset Pair", style: .destructive) {
                     store.resetPairing()
                 }
@@ -318,15 +329,15 @@ struct BridgeMenuBarContentView: View {
 
     // MARK: - Shared primitives
 
-    private let cardShape = RoundedRectangle(cornerRadius: 12, style: .continuous)
+    private let cardShape = RoundedRectangle(cornerRadius: 8, style: .continuous)
 
     private var cardFill: Color {
-        Color(nsColor: .controlBackgroundColor).opacity(colorScheme == .dark ? 0.45 : 0.6)
+        Color.clear
     }
 
     private var cardBorder: some View {
-        RoundedRectangle(cornerRadius: 12, style: .continuous)
-            .stroke(Color.primary.opacity(0.06), lineWidth: 1)
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .stroke(Color.primary.opacity(colorScheme == .dark ? 0.14 : 0.10), lineWidth: 1)
     }
 
     private var statusTint: Color {
@@ -383,10 +394,10 @@ struct BridgeMenuBarContentView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(12)
-        .background(Color(nsColor: .textBackgroundColor).opacity(0.78), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .background(Color.clear, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
         .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color.primary.opacity(0.06), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
         )
     }
 
@@ -401,10 +412,10 @@ struct BridgeMenuBarContentView: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
-        .background(Color(nsColor: .textBackgroundColor).opacity(0.78), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .background(Color.clear, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
         .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color.primary.opacity(0.06), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
         )
     }
 
@@ -431,8 +442,11 @@ struct BridgeMenuBarLabel: View {
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            Image(systemName: "terminal")
-                .font(.system(size: 15, weight: .semibold))
+            Image("remodex_control_symbol")
+                .renderingMode(.template)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 17, height: 17)
                 .foregroundStyle(isBusy ? Color.primary.opacity(0.7) : Color.primary)
             if updateState.isUpdateAvailable {
                 Circle()
@@ -499,15 +513,13 @@ private struct CompactActionButton: View {
 
     private var backgroundColor: Color {
         switch style {
-        case .primary: return .primary
-        case .secondary: return Color(nsColor: .textBackgroundColor).opacity(0.5)
-        case .destructive: return Color(nsColor: .textBackgroundColor).opacity(0.5)
+        case .primary, .secondary, .destructive: return .clear
         }
     }
 
     private var foregroundColor: Color {
         switch style {
-        case .primary: return Color(nsColor: .windowBackgroundColor)
+        case .primary: return .primary
         case .secondary: return .primary
         case .destructive: return .red
         }
@@ -515,8 +527,8 @@ private struct CompactActionButton: View {
 
     private var borderColor: Color {
         switch style {
-        case .primary: return .clear
-        case .secondary: return .primary.opacity(0.06)
+        case .primary: return .primary.opacity(0.18)
+        case .secondary: return .primary.opacity(0.08)
         case .destructive: return .red.opacity(0.15)
         }
     }

--- a/MacDano.md
+++ b/MacDano.md
@@ -1,0 +1,334 @@
+# Remodex Menu Bar and Bridge CLI Deep Audit
+
+Date: 2026-05-22
+Scope: macOS Remodex Menu Bar companion, `remodex` bridge CLI, macOS launchd bridge lifecycle, and the bridge RPC surface that should or should not be exposed through the Menu Bar.
+
+## Executive Summary
+
+The Remodex Menu Bar should be a clean macOS control surface over the stable `remodex` CLI, not a second implementation of bridge lifecycle logic. The current direction is good: the Menu Bar now reads `status --json`, controls the daemon, displays pairing state, and avoids direct bridge internals. The main remaining issue is that some responsibilities are still split between Swift and Node in ways that will become costly as the bridge grows.
+
+The strongest recommendation is to make the CLI the single control-plane facade for companion apps:
+
+- Keep lifecycle commands in the CLI.
+- Add machine-readable contracts for every Menu Bar action.
+- Move npm update/version lookup logic out of Swift and into the CLI/bridge package.
+- Keep developer/internal commands out of the Menu Bar.
+- Add a diagnostic command so the Menu Bar can show actionable local setup issues without duplicating shell checks.
+
+## Current Public CLI Surface
+
+The CLI currently exposes:
+
+- `remodex up`
+- `remodex run`
+- `remodex run-service`
+- `remodex start`
+- `remodex restart`
+- `remodex qr`
+- `remodex pair`
+- `remodex stop`
+- `remodex status`
+- `remodex reset-pairing`
+- `remodex resume`
+- `remodex watch [threadId]`
+- `remodex --version`
+
+Several commands support `--json`: `start`, `restart`, `pair`/`qr`, `stop`, `status`, `reset-pairing`, `resume`, and `--version`.
+
+## Menu Bar Surface After Alignment
+
+The Menu Bar currently exposes the useful end-user actions:
+
+- Start
+- Restart
+- Stop
+- Pair QR
+- Resume
+- Refresh
+- Reset Pair
+- Update, when an update is available
+- Open logs folder/stdout/stderr
+- Relay override
+- Pairing QR display
+- CLI availability blocker
+
+This is mostly the correct surface. The commands that should not be shown in the Menu Bar are `run`, `run-service`, and `watch`.
+
+## Findings
+
+### High: Self-update logic is duplicated and should be centralized
+
+The Menu Bar currently runs `npm install -g remodex@latest` from Swift. The bridge already has a more robust update-and-restart path through `desktop/bridge/updateAndRestart`, including timeout handling and delayed restart after the response returns to the client.
+
+Risk:
+
+- Divergent update behavior between iOS and Menu Bar.
+- Different timeout/error behavior depending on the entry point.
+- Swift must know npm details that belong to the Node package.
+- Future package-manager changes would require editing multiple clients.
+
+Recommended fix:
+
+Add `remodex update --json` and make the Menu Bar call that command. The Node CLI should own:
+
+- npm command construction
+- shell environment setup
+- timeout
+- output truncation
+- restart scheduling
+- JSON response
+
+Suggested JSON result:
+
+```json
+{
+  "ok": true,
+  "currentVersion": "1.5.6",
+  "command": "npm install -g remodex@latest",
+  "restartScheduled": true,
+  "restartDelayMs": 750
+}
+```
+
+### Medium: `status --json` should expose capabilities
+
+The Menu Bar currently infers availability mostly from installed version and fallback behavior. That is workable, but it makes the app guess what the bridge supports.
+
+Recommended fix:
+
+Add a `capabilities` block to `remodex status --json`.
+
+Suggested shape:
+
+```json
+{
+  "currentVersion": "1.5.6",
+  "capabilities": {
+    "statusJson": true,
+    "pairJson": true,
+    "restart": true,
+    "selfUpdate": true,
+    "doctorJson": true,
+    "logsJson": true
+  }
+}
+```
+
+This lets the Menu Bar show/hide actions without hardcoding version checks or parsing human-readable output.
+
+### Medium: npm latest-version lookup should not live in Swift
+
+The Menu Bar currently calls `npm view remodex version --json`. The bridge already has a cached package version reader for mobile status paths.
+
+Risk:
+
+- Slow network/npm calls can affect Menu Bar refresh.
+- Swift duplicates registry lookup behavior.
+- Offline/error behavior may diverge from mobile/bridge behavior.
+
+Recommended fix:
+
+Expose latest package version through `status --json` or a dedicated `remodex version --json`, backed by the existing cached package-version reader.
+
+Preferred:
+
+```json
+{
+  "currentVersion": "1.5.6",
+  "latestVersion": "1.5.7",
+  "latestVersionCheckedAt": "2026-05-22T18:00:00.000Z"
+}
+```
+
+### Medium: lifecycle commands need clearer human/API separation
+
+`up`, `start`, `pair`, and `restart` overlap:
+
+- `up`: human flow, start service and print QR.
+- `start`: service lifecycle, no guaranteed fresh QR.
+- `pair`: pairing flow, starts/restarts enough to publish a fresh QR.
+- `restart`: launchd lifecycle, not necessarily a pairing action.
+
+Recommended policy:
+
+- Menu Bar should use `start --json`, `restart --json`, `pair --json`, `stop --json`, and `status --json`.
+- Terminal users can keep using `up`.
+- Documentation should call `pair` canonical and `qr` an alias.
+
+### Medium: internal commands are publicly visible
+
+`run-service` is required by launchd, but it is not an end-user command. `watch` is diagnostic/development-oriented.
+
+Recommended fix:
+
+Keep both commands for compatibility, but split CLI help into:
+
+- User commands
+- Maintenance commands
+- Developer/internal commands
+
+`run-service` should not appear in primary usage text.
+
+### Medium: no single diagnostic command exists
+
+The Menu Bar currently checks CLI availability and status, but setup failures can come from many layers:
+
+- `remodex` missing
+- Node missing
+- npm unavailable
+- relay missing
+- launchd missing/stale
+- state directory unavailable
+- stale pid/status files
+- pairing file absent/expired
+- logs missing
+
+Recommended fix:
+
+Add `remodex doctor --json`.
+
+Suggested checks:
+
+- CLI path
+- Node path
+- npm path
+- package version
+- latest known version
+- relay config source
+- launchd plist path
+- launchd loaded/pid
+- bridge status file
+- pairing session status
+- stdout/stderr log paths
+- last error
+
+The Menu Bar can then show a compact diagnostic section without duplicating shell logic.
+
+### Low: CLI parser is too permissive
+
+The parser currently recognizes `--json` and otherwise treats tokens as positionals. Unknown flags do not produce structured guidance.
+
+Recommended fix:
+
+Keep the dependency-free parser, but make it explicit:
+
+- `--help`
+- unknown flag error
+- command-specific allowed flags
+- JSON error format when `--json` is passed
+
+### Low: fallback parsing of human status output should be temporary
+
+The Menu Bar has a fallback parser for older human-readable `status` output. That is useful for compatibility, but should not become a long-term contract.
+
+Recommended fix:
+
+Keep fallback only behind a legacy compatibility path and remove it once the minimum supported bridge guarantees `status --json`.
+
+## Recommended Final CLI Taxonomy
+
+### User Commands
+
+- `remodex up`
+- `remodex pair`
+- `remodex status`
+- `remodex stop`
+- `remodex resume`
+
+### Menu Bar / Machine Commands
+
+- `remodex status --json`
+- `remodex start --json`
+- `remodex restart --json`
+- `remodex pair --json`
+- `remodex stop --json`
+- `remodex reset-pairing --json`
+- `remodex update --json`
+- `remodex doctor --json`
+- `remodex logs --json`
+
+### Developer/Internal Commands
+
+- `remodex run`
+- `remodex run-service`
+- `remodex watch [threadId]`
+
+## Recommended Menu Bar Layout
+
+Use only bordered sections and controls, matching the latest UI direction:
+
+1. Status
+   - Daemon
+   - Connection
+   - PID
+   - Relay
+   - Installed/latest version
+
+2. Actions
+   - Start
+   - Restart
+   - Stop
+
+3. Pairing
+   - Pair QR
+   - Reset Pair
+   - QR preview
+
+4. Maintenance
+   - Update
+   - Doctor
+   - Logs
+
+5. Utility
+   - Resume Last Thread
+   - Refresh
+
+Avoid exposing `run`, `run-service`, and `watch` in the Menu Bar.
+
+## Implementation Roadmap
+
+### Phase 1: Stabilize CLI contracts
+
+- Add `update --json`.
+- Add `doctor --json`.
+- Add `logs --json`.
+- Add `capabilities` to `status --json`.
+- Add tests for each JSON contract.
+
+### Phase 2: Simplify Menu Bar service
+
+- Replace direct `npm install -g remodex@latest` with `remodex update --json`.
+- Replace direct `npm view remodex version --json` with `status --json` latest-version fields.
+- Use `capabilities` to enable/disable buttons.
+- Keep legacy fallback parser only for old bridge versions.
+
+### Phase 3: Clean CLI help and command taxonomy
+
+- Add `help`.
+- Hide `run-service` from primary usage.
+- Mark `qr` as alias of `pair`.
+- Separate user, maintenance, and developer/internal commands.
+
+## Current Changes Already Applied
+
+The repository already includes these local changes:
+
+- `pair --json` / `qr --json` support in the CLI.
+- Menu Bar actions for `Restart` and `Pair QR`.
+- Border-only Menu Bar presentation with smaller 8px radii.
+- CLI test coverage for `pair --json`.
+
+Bridge test status:
+
+- `npm test` in `phodex-bridge` passes.
+- 369 tests passing.
+
+Xcode test status:
+
+- Xcode tests were not run, respecting the repository guardrail.
+
+## Residual Risks
+
+- `Package.resolved` is modified in the worktree and should be reviewed separately before committing.
+- Menu Bar build/run should be checked visually on macOS after the Swift package graph has settled.
+- The current Menu Bar still performs npm update/version work directly; this should be removed once `update --json` and latest-version status fields exist.

--- a/phodex-bridge/bin/remodex.js
+++ b/phodex-bridge/bin/remodex.js
@@ -150,10 +150,20 @@ async function main({
       consoleImpl,
       exitImpl,
     });
-    consoleImpl.log("[remodex] Refreshing bridge pairing QR...");
     const result = await deps.startMacOSBridgeService({
       waitForPairing: true,
     });
+    if (jsonOutput) {
+      emitJson({
+        ok: true,
+        currentVersion: version,
+        plistPath: result?.plistPath,
+        pairingSession: result?.pairingSession,
+      });
+      return;
+    }
+
+    consoleImpl.log("[remodex] Refreshing bridge pairing QR...");
     deps.printMacOSBridgePairingQr({
       pairingSession: result.pairingSession,
     });
@@ -265,7 +275,7 @@ async function main({
   consoleImpl.error(
     "Usage: remodex up | remodex run | remodex start | remodex restart | remodex qr | remodex pair | remodex stop | remodex status | "
     + "remodex reset-pairing | remodex resume | remodex watch [threadId] | remodex --version | "
-    + "append --json to start/restart/stop/status/reset-pairing/resume for machine-readable output"
+    + "append --json to start/restart/qr/pair/stop/status/reset-pairing/resume for machine-readable output"
   );
   exitImpl(1);
 }

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -5,7 +5,7 @@
 // Depends on: ws, crypto, os, ./bridge-status, ./codex-desktop-refresher, ./codex-transport, ./rollout-watch, ./voice-handler
 
 const WebSocket = require("ws");
-const { randomBytes } = require("crypto");
+const { createHash, randomBytes } = require("crypto");
 const { execFile, spawn } = require("child_process");
 const fs = require("fs");
 const path = require("path");
@@ -46,6 +46,7 @@ const { createPushNotificationTracker } = require("./push-notification-tracker")
 const { resolveCodexGeneratedImagesRoot } = require("./codex-home");
 const {
   loadOrCreateBridgeDeviceState,
+  rememberLastSeenClientDeviceKind,
   rememberLastSeenPhoneAppVersion,
   resolveBridgeRelaySession,
 } = require("./secure-device-state");
@@ -198,6 +199,7 @@ function startBridge({
     requestId: null,
     startedAt: 0,
   };
+  let activePhoneSummary = null;
   const secureTransport = createBridgeSecureTransport({
     sessionId,
     relayUrl: relayBaseUrl,
@@ -206,6 +208,13 @@ function startBridge({
     onTrustedPhoneUpdate(nextDeviceState) {
       deviceState = nextDeviceState;
       sendRelayRegistrationUpdate(nextDeviceState);
+    },
+    onSecureSessionReady(session) {
+      activePhoneSummary = buildActivePhoneSummary(session, deviceState);
+      const lastPublishedBridgeStatus = bridgeStatusPublisher.latest();
+      if (lastPublishedBridgeStatus) {
+        publishBridgeStatus(lastPublishedBridgeStatus);
+      }
     },
   });
   // Keeps one stable sender identity across reconnects so buffered replay state
@@ -378,6 +387,9 @@ function startBridge({
     }
 
     lastConnectionStatus = status;
+    if (status !== "connected") {
+      activePhoneSummary = null;
+    }
     publishBridgeStatus({
       state: "running",
       connectionStatus: status,
@@ -1139,6 +1151,20 @@ function startBridge({
   function bridgeManagedInitializeCompatibilityError(params) {
     const clientInfo = params && typeof params === "object" ? params.clientInfo : null;
     const clientName = normalizeNonEmptyString(clientInfo?.name);
+    const clientDeviceKind = classifyClientDeviceKind(clientName);
+    if (clientDeviceKind) {
+      deviceState = rememberLastSeenClientDeviceKind(deviceState, clientDeviceKind);
+      if (activePhoneSummary?.connected) {
+        activePhoneSummary = {
+          ...activePhoneSummary,
+          deviceKind: clientDeviceKind,
+        };
+        const lastPublishedBridgeStatus = bridgeStatusPublisher.latest();
+        if (lastPublishedBridgeStatus) {
+          publishBridgeStatus(lastPublishedBridgeStatus);
+        }
+      }
+    }
     if (clientName !== "codexmobile_ios") {
       return null;
     }
@@ -1307,7 +1333,11 @@ function startBridge({
   }
 
   function publishBridgeStatus(status) {
-    bridgeStatusPublisher.publish(status);
+    bridgeStatusPublisher.publish({
+      ...status,
+      activeDevice: activePhoneSummary,
+      activePhone: activePhoneSummary,
+    });
   }
 
   // Refreshes the relay's trusted-mac index after the QR bootstrap locks in a phone identity.
@@ -1534,6 +1564,47 @@ function buildMacRegistration(deviceState, pairingSession) {
       ? pairingSession.pairingPayload.expiresAt
       : 0,
   };
+}
+
+function buildActivePhoneSummary(session, deviceState = null) {
+  const phoneFingerprint = shortFingerprint(session?.phoneDeviceId);
+  if (!phoneFingerprint) {
+    return null;
+  }
+
+  return {
+    connected: true,
+    phoneFingerprint,
+    deviceKind: normalizeNonEmptyString(deviceState?.lastSeenDeviceKind) || null,
+    handshakeMode: normalizeNonEmptyString(session?.handshakeMode) || null,
+    keyEpoch: Number.isFinite(session?.keyEpoch) ? session.keyEpoch : null,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function classifyClientDeviceKind(clientName) {
+  const normalized = normalizeNonEmptyString(clientName).toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  if (normalized.includes("android")) {
+    return "android";
+  }
+  if (normalized.includes("ios") || normalized.includes("iphone")) {
+    return "iphone";
+  }
+  if (normalized.includes("macos") || normalized.includes("mac")) {
+    return "mac";
+  }
+  return null;
+}
+
+function shortFingerprint(value) {
+  const normalized = normalizeNonEmptyString(value);
+  if (!normalized) {
+    return null;
+  }
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 8);
 }
 
 function shutdown(codex, getSocket, beforeExit = () => {}) {

--- a/phodex-bridge/src/macos-launch-agent.js
+++ b/phodex-bridge/src/macos-launch-agent.js
@@ -5,13 +5,14 @@
 // Depends on: child_process, fs, os, path, ./bridge, ./daemon-state, ./codex-desktop-refresher, ./qr, ./secure-device-state
 
 const { execFileSync } = require("child_process");
+const { createHash } = require("crypto");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const { startBridge } = require("./bridge");
 const { readBridgeConfig } = require("./codex-desktop-refresher");
 const { printQR } = require("./qr");
-const { resetBridgeTrustState } = require("./secure-device-state");
+const { readBridgeDeviceState, resetBridgeTrustState } = require("./secure-device-state");
 const {
   clearBridgeStatus,
   clearPairingSession,
@@ -276,6 +277,7 @@ function getMacOSBridgeServiceStatus({
     daemonConfig: readDaemonConfig({ env, fsImpl }),
     bridgeStatus: readBridgeStatus({ env, fsImpl }),
     pairingSession: readPairingSession({ env, fsImpl }),
+    trustedDevice: buildTrustedDeviceSummary(readBridgeDeviceState()),
     stdoutLogPath: resolveBridgeStdoutLogPath({ env }),
     stderrLogPath: resolveBridgeStderrLogPath({ env }),
   };
@@ -286,12 +288,18 @@ function printMacOSBridgeServiceStatus(options = {}) {
   const bridgeState = status.bridgeStatus?.state || "unknown";
   const connectionStatus = status.bridgeStatus?.connectionStatus || "unknown";
   const pairingCreatedAt = status.pairingSession?.createdAt || "none";
+  const activeDevice = status.bridgeStatus?.activeDevice || status.bridgeStatus?.activePhone;
+  const trustedPhoneCount = status.trustedDevice?.trustedPhoneCount || 0;
+  const activeDeviceName = formatDeviceKind(activeDevice?.deviceKind) || "device";
+  const trustedDeviceName = formatDeviceKind(status.trustedDevice?.lastSeenDeviceKind) || "device";
   console.log(`[remodex] Service label: ${status.label}`);
   console.log(`[remodex] Installed: ${status.installed ? "yes" : "no"}`);
   console.log(`[remodex] Launchd loaded: ${status.launchdLoaded ? "yes" : "no"}`);
   console.log(`[remodex] PID: ${status.launchdPid || status.bridgeStatus?.pid || "unknown"}`);
   console.log(`[remodex] Bridge state: ${bridgeState}`);
   console.log(`[remodex] Connection: ${connectionStatus}`);
+  console.log(`[remodex] Active ${activeDeviceName}: ${activeDevice?.connected ? activeDevice.phoneFingerprint || "yes" : "no"}`);
+  console.log(`[remodex] Trusted ${trustedDeviceName}: ${trustedPhoneCount > 0 ? "yes" : "no"}`);
   console.log(`[remodex] Pairing payload: ${pairingCreatedAt}`);
   console.log(`[remodex] Stdout log: ${status.stdoutLogPath}`);
   console.log(`[remodex] Stderr log: ${status.stderrLogPath}`);
@@ -613,7 +621,44 @@ function normalizeNonEmptyString(value) {
   return typeof value === "string" && value.trim() ? value.trim() : "";
 }
 
+function buildTrustedDeviceSummary(deviceState) {
+  const trustedPhoneEntries = Object.entries(deviceState?.trustedPhones || {})
+    .filter(([phoneDeviceId, publicKey]) => normalizeNonEmptyString(phoneDeviceId) && normalizeNonEmptyString(publicKey));
+  const firstTrustedPhoneId = trustedPhoneEntries[0]?.[0] || "";
+  const lastSeenPhoneAppVersion = normalizeNonEmptyString(deviceState?.lastSeenPhoneAppVersion) || null;
+  return {
+    macDeviceFingerprint: shortFingerprint(deviceState?.macDeviceId),
+    trustedPhoneCount: trustedPhoneEntries.length,
+    trustedPhoneFingerprint: shortFingerprint(firstTrustedPhoneId),
+    lastSeenDeviceKind: normalizeNonEmptyString(deviceState?.lastSeenDeviceKind) || (lastSeenPhoneAppVersion ? "iphone" : null),
+    lastSeenPhoneAppVersion,
+  };
+}
+
+function formatDeviceKind(deviceKind) {
+  const normalized = normalizeNonEmptyString(deviceKind).toLowerCase();
+  if (normalized === "iphone") {
+    return "iPhone";
+  }
+  if (normalized === "android") {
+    return "Android";
+  }
+  if (normalized === "mac") {
+    return "Mac";
+  }
+  return "";
+}
+
+function shortFingerprint(value) {
+  const normalized = normalizeNonEmptyString(value);
+  if (!normalized) {
+    return null;
+  }
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 8);
+}
+
 module.exports = {
+  buildTrustedDeviceSummary,
   buildLaunchAgentPlist,
   getMacOSBridgeServiceStatus,
   mergeBridgeStatusForDaemon,

--- a/phodex-bridge/src/secure-device-state.js
+++ b/phodex-bridge/src/secure-device-state.js
@@ -1,7 +1,7 @@
 // FILE: secure-device-state.js
-// Purpose: Persists canonical bridge identity, trusted-phone state, and last seen iPhone app version for local QR pairing.
+// Purpose: Persists canonical bridge identity, trusted mobile state, and last seen companion metadata for local QR pairing.
 // Layer: CLI helper
-// Exports: loadOrCreateBridgeDeviceState, readBridgeDeviceState, resetBridgeDeviceState, resetBridgeTrustState, rememberTrustedPhone, rememberLastSeenPhoneAppVersion, getTrustedPhonePublicKey, resolveBridgeRelaySession
+// Exports: loadOrCreateBridgeDeviceState, readBridgeDeviceState, resetBridgeDeviceState, resetBridgeTrustState, rememberTrustedPhone, rememberLastSeenPhoneAppVersion, rememberLastSeenClientDeviceKind, getTrustedPhonePublicKey, resolveBridgeRelaySession
 // Depends on: fs, os, path, crypto, child_process
 
 const fs = require("fs");
@@ -146,6 +146,22 @@ function rememberLastSeenPhoneAppVersion(state, phoneAppVersion, { persist = tru
   return nextState;
 }
 
+function rememberLastSeenClientDeviceKind(state, deviceKind, { persist = true } = {}) {
+  const normalizedDeviceKind = normalizeDeviceKind(deviceKind);
+  if (!normalizedDeviceKind) {
+    return state;
+  }
+
+  const nextState = normalizeBridgeDeviceState({
+    ...state,
+    lastSeenDeviceKind: normalizedDeviceKind,
+  });
+  if (persist) {
+    writeBridgeDeviceState(nextState);
+  }
+  return nextState;
+}
+
 function getTrustedPhonePublicKey(state, phoneDeviceId) {
   const normalizedDeviceId = normalizeNonEmptyString(phoneDeviceId);
   if (!normalizedDeviceId) {
@@ -169,6 +185,7 @@ function createBridgeDeviceState() {
     macIdentityPublicKey: base64UrlToBase64(publicJwk.x),
     macIdentityPrivateKey: base64UrlToBase64(privateJwk.d),
     trustedPhones: {},
+    lastSeenDeviceKind: null,
     lastSeenPhoneAppVersion: null,
   };
 }
@@ -378,6 +395,8 @@ function normalizeBridgeDeviceState(rawState) {
   const macIdentityPublicKey = normalizeNonEmptyString(rawState?.macIdentityPublicKey);
   const macIdentityPrivateKey = normalizeNonEmptyString(rawState?.macIdentityPrivateKey);
   const lastSeenPhoneAppVersion = normalizeNonEmptyString(rawState?.lastSeenPhoneAppVersion) || null;
+  const lastSeenDeviceKind = normalizeDeviceKind(rawState?.lastSeenDeviceKind)
+    || inferLegacyDeviceKind({ lastSeenPhoneAppVersion });
 
   if (!macDeviceId || !macIdentityPublicKey || !macIdentityPrivateKey) {
     throw new Error("Bridge device state is incomplete");
@@ -401,8 +420,27 @@ function normalizeBridgeDeviceState(rawState) {
     macIdentityPublicKey,
     macIdentityPrivateKey,
     trustedPhones,
+    lastSeenDeviceKind,
     lastSeenPhoneAppVersion,
   };
+}
+
+function normalizeDeviceKind(value) {
+  const normalized = normalizeNonEmptyString(value).toLowerCase();
+  if (normalized === "ios" || normalized === "iphone") {
+    return "iphone";
+  }
+  if (normalized === "android") {
+    return "android";
+  }
+  if (normalized === "mac" || normalized === "macos" || normalized === "darwin") {
+    return "mac";
+  }
+  return normalized || null;
+}
+
+function inferLegacyDeviceKind({ lastSeenPhoneAppVersion } = {}) {
+  return lastSeenPhoneAppVersion ? "iphone" : null;
 }
 
 function bridgeStatesEqual(left, right) {
@@ -446,6 +484,7 @@ module.exports = {
   getTrustedPhonePublicKey,
   loadOrCreateBridgeDeviceState,
   readBridgeDeviceState,
+  rememberLastSeenClientDeviceKind,
   rememberLastSeenPhoneAppVersion,
   rememberTrustedPhone,
   resetBridgeDeviceState,

--- a/phodex-bridge/src/secure-transport.js
+++ b/phodex-bridge/src/secure-transport.js
@@ -39,6 +39,7 @@ function createBridgeSecureTransport({
   deviceState,
   displayName = "",
   onTrustedPhoneUpdate = null,
+  onSecureSessionReady = null,
   persistTrustedPhone = true,
 }) {
   let currentDeviceState = deviceState;
@@ -382,7 +383,13 @@ function createBridgeSecureTransport({
       activeSession.firstOutboundSeq = nextBridgeOutboundSeq;
     }
 
+    const completedHandshakeMode = pendingHandshake.handshakeMode;
     pendingHandshake = null;
+    onSecureSessionReady?.({
+      phoneDeviceId: activeSession.phoneDeviceId,
+      handshakeMode: completedHandshakeMode,
+      keyEpoch: activeSession.keyEpoch,
+    });
     sendControlMessage({
       kind: "secureReady",
       sessionId,

--- a/phodex-bridge/test/remodex-cli.test.js
+++ b/phodex-bridge/test/remodex-cli.test.js
@@ -208,6 +208,61 @@ test("remodex pair is an alias for the QR refresh flow", async () => {
   ]);
 });
 
+test("remodex pair --json exposes the refreshed pairing payload", async () => {
+  const writes = [];
+  const originalWrite = process.stdout.write;
+
+  process.stdout.write = (chunk, encoding, callback) => {
+    writes.push(String(chunk));
+    if (typeof callback === "function") {
+      callback();
+    }
+    return true;
+  };
+
+  try {
+    await main({
+      argv: ["node", "remodex", "pair", "--json"],
+      platform: "darwin",
+      consoleImpl: {
+        log(message) {
+          throw new Error(`unexpected log: ${message}`);
+        },
+        error(message) {
+          throw new Error(`unexpected error: ${message}`);
+        },
+      },
+      exitImpl(code) {
+        throw new Error(`unexpected exit ${code}`);
+      },
+      deps: {
+        async startMacOSBridgeService(options) {
+          assert.deepEqual(options, { waitForPairing: true });
+          return {
+            plistPath: "/tmp/remodex.plist",
+            pairingSession: {
+              pairingPayload: {
+                sessionId: "session-json-pair",
+              },
+            },
+          };
+        },
+        printMacOSBridgePairingQr() {
+          throw new Error("QR printer should not run for --json");
+        },
+      },
+    });
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+
+  const payload = JSON.parse(writes.join("").trim());
+  assert.equal(payload.ok, true);
+  assert.equal(payload.currentVersion, version);
+  assert.equal(payload.plistPath, "/tmp/remodex.plist");
+  assert.equal(payload.pairingSession?.pairingPayload?.sessionId, "session-json-pair");
+});
+
 test("runCli prints expected failures without a Node stack trace", async () => {
   const messages = [];
   let exitCode = null;

--- a/phodex-bridge/test/secure-device-state.test.js
+++ b/phodex-bridge/test/secure-device-state.test.js
@@ -12,6 +12,7 @@ const assert = require("node:assert/strict");
 const {
   loadOrCreateBridgeDeviceState,
   readBridgeDeviceState,
+  rememberLastSeenClientDeviceKind,
   rememberLastSeenPhoneAppVersion,
   rememberTrustedPhone,
   resetBridgeDeviceState,
@@ -79,6 +80,32 @@ test("rememberLastSeenPhoneAppVersion stores the latest App Store version", () =
   );
 
   assert.equal(nextState.lastSeenPhoneAppVersion, "1.0");
+});
+
+test("rememberLastSeenClientDeviceKind stores a normalized companion platform", () => {
+  const state = makeDeviceState();
+
+  const nextState = rememberLastSeenClientDeviceKind(
+    state,
+    "android",
+    { persist: false }
+  );
+
+  assert.equal(nextState.lastSeenDeviceKind, "android");
+});
+
+test("normalizeBridgeDeviceState treats legacy app-version state as iPhone", () => {
+  withTempDeviceStateEnv(() => {
+    const legacyState = makeDeviceState({
+      lastSeenDeviceKind: undefined,
+      lastSeenPhoneAppVersion: "1.6",
+    });
+    writeStateToDisk(legacyState);
+
+    const state = readBridgeDeviceState();
+
+    assert.equal(state.lastSeenDeviceKind, "iphone");
+  });
 });
 
 test("loadOrCreateBridgeDeviceState writes and reloads the canonical file state", () => {
@@ -260,6 +287,7 @@ function makeDeviceState(overrides = {}) {
     macIdentityPublicKey: "mac-public-key",
     macIdentityPrivateKey: "mac-private-key",
     trustedPhones: {},
+    lastSeenDeviceKind: null,
     lastSeenPhoneAppVersion: null,
     ...overrides,
   };


### PR DESCRIPTION
## Summary

- add JSON pairing support and restart/pair controls for the Remodex Menu Bar
- expose active/trusted companion device status from the bridge and CLI without logging raw device IDs
- generalize Menu Bar status from iPhone-only labels to device-aware iPhone/Android/Mac labels
- add a deep audit report for Menu Bar and bridge CLI cleanup opportunities

## Validation

- node --check src/secure-device-state.js && node --check src/macos-launch-agent.js
- node --test ./test/secure-device-state.test.js ./test/macos-launch-agent.test.js ./test/remodex-cli.test.js
- node --test ./test/secure-transport.test.js ./test/bridge-status.test.js ./test/macos-launch-agent.test.js ./test/remodex-cli.test.js
- xcodebuild -project CodexMobile/CodexMobile.xcodeproj -scheme RemodexMenuBar -configuration Debug -derivedDataPath /tmp/remodex-menubar-derived CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build
- git diff --check

## Notes

- Direct push to Emanuele-web04/remodex was denied for this account, so this PR uses the CarmineSgariglia/remodex fork as the head repo.
- CodexMobile/CodexMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved is intentionally left uncommitted because it was an Xcode package-resolution change unrelated to this PR.
