### PR TITLE
Dynamic island Implementation + Quick Actions

### DIFF
--- a/CodexMobile/BuildSupport/CodexMobile-Info.plist
+++ b/CodexMobile/BuildSupport/CodexMobile-Info.plist
@@ -39,6 +39,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>Remodex needs camera access to let you take photos and attach them to your messages.</string>
 	<key>NSAppTransportSecurity</key>

--- a/CodexMobile/CodexMobile/CodexMobileApp.swift
+++ b/CodexMobile/CodexMobile/CodexMobileApp.swift
@@ -67,15 +67,7 @@ struct CodexMobileApp: App {
             return false
         }
 
-        let threadId: String?
-        if url.host?.caseInsensitiveCompare("thread") == .orderedSame {
-            threadId = url.pathComponents.dropFirst().first
-        } else if url.host?.isEmpty != false,
-                  url.pathComponents.dropFirst().first?.caseInsensitiveCompare("thread") == .orderedSame {
-            threadId = url.pathComponents.dropFirst(2).first
-        } else {
-            threadId = nil
-        }
+        let threadId = Self.remodexDeepLinkThreadID(from: url)
 
         let decodedThreadId = threadId?.removingPercentEncoding ?? threadId
         guard let normalizedThreadId = decodedThreadId?
@@ -86,6 +78,34 @@ struct CodexMobileApp: App {
 
         codexService.handleNotificationOpen(threadId: normalizedThreadId, turnId: nil)
         return true
+    }
+
+    private static func remodexDeepLinkThreadID(from url: URL) -> String? {
+        let host = url.host?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let pathComponents = url.pathComponents
+            .dropFirst()
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        if let host, isThreadRouteComponent(host) {
+            return pathComponents.first
+        }
+        if host?.isEmpty != false,
+           let route = pathComponents.first,
+           Self.isThreadRouteComponent(route) {
+            return pathComponents.dropFirst().first
+        }
+
+        let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        return queryItems.first { item in
+            item.name.caseInsensitiveCompare("threadId") == .orderedSame
+                || item.name.caseInsensitiveCompare("thread") == .orderedSame
+        }?.value
+    }
+
+    private static func isThreadRouteComponent(_ value: String) -> Bool {
+        value.caseInsensitiveCompare("thread") == .orderedSame
+            || value.caseInsensitiveCompare("threads") == .orderedSame
     }
 
     // Configures RevenueCat once at launch using the client-safe public SDK key.

--- a/CodexMobile/CodexMobile/CodexMobileApp.swift
+++ b/CodexMobile/CodexMobile/CodexMobileApp.swift
@@ -38,6 +38,9 @@ struct CodexMobileApp: App {
                 }
                 .onOpenURL { url in
                     Task { @MainActor in
+                        guard !routeRemodexDeepLink(url) else {
+                            return
+                        }
                         guard CodexService.legacyGPTLoginCallbackEnabled else {
                             return
                         }
@@ -56,6 +59,33 @@ struct CodexMobileApp: App {
                     TurnCacheManager.resetAll()
                 }
         }
+    }
+
+    @discardableResult
+    private func routeRemodexDeepLink(_ url: URL) -> Bool {
+        guard url.scheme?.caseInsensitiveCompare("phodex") == .orderedSame else {
+            return false
+        }
+
+        let threadId: String?
+        if url.host?.caseInsensitiveCompare("thread") == .orderedSame {
+            threadId = url.pathComponents.dropFirst().first
+        } else if url.host?.isEmpty != false,
+                  url.pathComponents.dropFirst().first?.caseInsensitiveCompare("thread") == .orderedSame {
+            threadId = url.pathComponents.dropFirst(2).first
+        } else {
+            threadId = nil
+        }
+
+        let decodedThreadId = threadId?.removingPercentEncoding ?? threadId
+        guard let normalizedThreadId = decodedThreadId?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !normalizedThreadId.isEmpty else {
+            return false
+        }
+
+        codexService.handleNotificationOpen(threadId: normalizedThreadId, turnId: nil)
+        return true
     }
 
     // Configures RevenueCat once at launch using the client-safe public SDK key.

--- a/CodexMobile/CodexMobile/CodexMobileAppDelegate.swift
+++ b/CodexMobile/CodexMobile/CodexMobileAppDelegate.swift
@@ -13,6 +13,42 @@ extension Notification.Name {
 }
 
 final class CodexMobileAppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        let configuration = UISceneConfiguration(
+            name: nil,
+            sessionRole: connectingSceneSession.role
+        )
+        configuration.delegateClass = CodexMobileSceneDelegate.self
+        return configuration
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        if let shortcutItem = launchOptions?[.shortcutItem] as? UIApplicationShortcutItem {
+            Task { @MainActor in
+                RemodexQuickActionCenter.handleShortcutItem(shortcutItem)
+            }
+        }
+
+        return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        performActionFor shortcutItem: UIApplicationShortcutItem,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        Task { @MainActor in
+            completionHandler(RemodexQuickActionCenter.handleShortcutItem(shortcutItem))
+        }
+    }
+
     // Forwards the APNs token so CodexService can persist and sync it to the paired Mac bridge.
     func application(
         _ application: UIApplication,
@@ -39,5 +75,31 @@ final class CodexMobileAppDelegate: NSObject, UIApplicationDelegate {
                 "error": error,
             ]
         )
+    }
+}
+
+final class CodexMobileSceneDelegate: NSObject, UIWindowSceneDelegate {
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        guard let shortcutItem = connectionOptions.shortcutItem else {
+            return
+        }
+
+        Task { @MainActor in
+            RemodexQuickActionCenter.handleShortcutItem(shortcutItem)
+        }
+    }
+
+    func windowScene(
+        _ windowScene: UIWindowScene,
+        performActionFor shortcutItem: UIApplicationShortcutItem,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        Task { @MainActor in
+            completionHandler(RemodexQuickActionCenter.handleShortcutItem(shortcutItem))
+        }
     }
 }

--- a/CodexMobile/CodexMobile/ContentView.swift
+++ b/CodexMobile/CodexMobile/ContentView.swift
@@ -127,6 +127,9 @@ struct ContentView: View {
             .task(id: rootSheetPresentationFingerprint) {
                 syncRootSheetPresentationIfNeeded()
             }
+            .task(id: codex.externalThreadOpenRequest?.id) {
+                routeExternalThreadOpenIfNeeded()
+            }
             .onChange(of: isSidebarOpen) { wasOpen, isOpen in
                 debugSidebarLog(
                     "open-state changed wasOpen=\(wasOpen) isOpen=\(isOpen) prewarmed=\(isSidebarPrewarmed) "
@@ -170,6 +173,7 @@ struct ContentView: View {
             .onChange(of: codex.threads) { _, threads in
                 debugSidebarLog("threads changed count=\(threads.count) sidebarOpen=\(isSidebarOpen) prewarmed=\(isSidebarPrewarmed)")
                 syncSelectedThread(with: threads)
+                routeExternalThreadOpenIfNeeded()
                 scheduleSidebarPrewarmIfNeeded()
                 syncDisplayIsland()
             }
@@ -1172,6 +1176,39 @@ struct ContentView: View {
         }
     }
 
+    private func routeExternalThreadOpenIfNeeded() {
+        guard let request = codex.externalThreadOpenRequest else {
+            return
+        }
+
+        let threadId = request.threadId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !threadId.isEmpty else {
+            return
+        }
+        let thread: CodexThread
+        if let existingThread = codex.threads.first(where: { $0.id == threadId }) {
+            guard existingThread.syncState != .archivedLocal else {
+                return
+            }
+            thread = existingThread
+        } else {
+            thread = CodexThread(id: threadId, title: CodexThread.defaultDisplayTitle)
+            codex.upsertThread(thread)
+        }
+
+        activeNewChatDraftRoute = nil
+        isOpeningNewChatFromSidebar = false
+        selectedThread = thread
+        codex.activeThreadId = thread.id
+        codex.markThreadAsViewed(thread.id)
+        clearDisplayIslandOutcome(for: thread.id)
+        syncDisplayIsland()
+        if shouldPresentSidebarAsNavigation {
+            navigationPath = [.thread(id: thread.id)]
+        }
+        codex.externalThreadOpenRequest = nil
+    }
+
     // Keeps sidebar chat creation compose-first while preserving which affordance
     // opened it, so the draft UI can distinguish general Chat from folder Chat.
     private func openNewChatDraftFromSidebar(
@@ -1980,16 +2017,21 @@ struct ContentView: View {
 
     private func reconcileDisplayIslandCompletions() {
         let currentRunningIDs = displayIslandCurrentRunningThreadIDs()
-        let completedIDs = displayIslandLastRunningThreadIDs.subtracting(currentRunningIDs)
+        let visibleThreadIDs = displayIslandVisibleThreadIDs()
+        let completedIDs = displayIslandLastRunningThreadIDs
+            .intersection(visibleThreadIDs)
+            .subtracting(currentRunningIDs)
         let terminalStates = codex.latestTurnTerminalStateByThread
 
         displayIslandCompletedBanners.removeAll { banner in
-            currentRunningIDs.contains(banner.threadId)
+            !visibleThreadIDs.contains(banner.threadId)
+                || currentRunningIDs.contains(banner.threadId)
                 || codex.latestTurnTerminalState(for: banner.threadId) == .failed
                 || codex.latestTurnTerminalState(for: banner.threadId) == .stopped
         }
         displayIslandFailedBanners.removeAll { banner in
-            currentRunningIDs.contains(banner.threadId)
+            !visibleThreadIDs.contains(banner.threadId)
+                || currentRunningIDs.contains(banner.threadId)
                 || codex.latestTurnTerminalState(for: banner.threadId) == .completed
                 || codex.latestTurnTerminalState(for: banner.threadId) == .stopped
         }
@@ -2006,7 +2048,10 @@ struct ContentView: View {
             rememberDisplayIslandCompletion(threadId: threadId)
         }
 
-        for (threadId, terminalState) in terminalStates where !currentRunningIDs.contains(threadId) {
+        let visibleTerminalStates = terminalStates.filter { threadId, _ in
+            visibleThreadIDs.contains(threadId) && !currentRunningIDs.contains(threadId)
+        }
+        for (threadId, terminalState) in visibleTerminalStates {
             guard displayIslandLastTerminalStatesByThread[threadId] != terminalState else {
                 continue
             }
@@ -2021,9 +2066,9 @@ struct ContentView: View {
             }
         }
 
-        displayIslandLastRunningThreadIDs = currentRunningIDs
+        displayIslandLastRunningThreadIDs = currentRunningIDs.intersection(visibleThreadIDs)
         displayIslandLastTerminalStatesByThread = terminalStates.filter { threadId, _ in
-            !currentRunningIDs.contains(threadId)
+            visibleThreadIDs.contains(threadId) && !currentRunningIDs.contains(threadId)
         }
     }
 
@@ -2048,7 +2093,13 @@ struct ContentView: View {
     }
 
     private func displayIslandCurrentRunningThreadIDs() -> Set<String> {
-        codex.runningThreadIDs.union(Set(codex.activeTurnIdByThread.keys))
+        codex.runningThreadIDs
+            .union(Set(codex.activeTurnIdByThread.keys))
+            .intersection(displayIslandVisibleThreadIDs())
+    }
+
+    private func displayIslandVisibleThreadIDs() -> Set<String> {
+        Set(codex.threads.map(\.id))
     }
 
     private var displayIslandTimelineFingerprint: String {

--- a/CodexMobile/CodexMobile/ContentView.swift
+++ b/CodexMobile/CodexMobile/ContentView.swift
@@ -76,6 +76,7 @@ struct ContentView: View {
     @State private var sidebarSelectionSuppressedUntil: Date?
     @State private var activeNewChatDraftRoute: NewChatDraftRoute?
     @State private var isOpeningNewChatFromSidebar = false
+    @State private var pendingQuickAction: RemodexQuickAction?
     @State private var threadIDsPendingInitialAssistantAnchor: Set<String> = []
     // Settings is presented as a `fullScreenCover` instead of being pushed
     // onto `navigationPath` so the gear button works even when the sidebar
@@ -89,6 +90,7 @@ struct ContentView: View {
     @State private var displayIslandFailedBanners: [CodexThreadCompletionBanner] = []
     @State private var displayIslandLastRunningThreadIDs: Set<String> = []
     @State private var displayIslandLastTerminalStatesByThread: [String: CodexTurnTerminalState] = [:]
+    @State private var displayIslandRunningStartedAtByThread: [String: Date] = [:]
     @AppStorage("codex.hasSeenOnboarding") private var hasSeenOnboarding = false
     @AppStorage("codex.whatsNew.lastPresentedVersion") private var lastPresentedWhatsNewVersion = ""
 
@@ -111,6 +113,10 @@ struct ContentView: View {
     // Splits lifecycle wiring from presentation modifiers so SwiftUI does not have to type-check one giant body chain.
     private var rootContentWithLifecycleObservers: some View {
         rootContent
+            .task {
+                RemodexQuickActionCenter.updateShortcutItems(for: codex.threads)
+                routePendingQuickActionIfNeeded()
+            }
             // Only resume saved-pairing recovery after onboarding is done and the manual scanner is not in control.
             .task {
                 guard hasSeenOnboarding, !isShowingManualScanner else {
@@ -172,8 +178,10 @@ struct ContentView: View {
             }
             .onChange(of: codex.threads) { _, threads in
                 debugSidebarLog("threads changed count=\(threads.count) sidebarOpen=\(isSidebarOpen) prewarmed=\(isSidebarPrewarmed)")
+                RemodexQuickActionCenter.updateShortcutItems(for: threads)
                 syncSelectedThread(with: threads)
                 routeExternalThreadOpenIfNeeded()
+                routePendingQuickActionIfNeeded()
                 scheduleSidebarPrewarmIfNeeded()
                 syncDisplayIsland()
             }
@@ -182,6 +190,8 @@ struct ContentView: View {
                 codex.setForegroundState(phase != .background)
                 syncDisplayIsland()
                 if phase == .active {
+                    RemodexQuickActionCenter.updateShortcutItems(for: codex.threads)
+                    routePendingQuickActionIfNeeded()
                     Task {
                         async let subscriptionRefresh: Void = subscriptions.refreshCustomerInfoSilently()
 
@@ -199,6 +209,9 @@ struct ContentView: View {
                     resetSavedMacWakeRecoveryState()
                     teardownSidebarPrewarm()
                 }
+            }
+            .onChange(of: horizontalSizeClass) { _, _ in
+                routePendingQuickActionIfNeeded()
             }
             .onChange(of: codex.shouldAutoReconnectOnForeground) { _, shouldReconnect in
                 guard shouldReconnect else {
@@ -237,6 +250,14 @@ struct ContentView: View {
             }
             .onChange(of: codex.latestTurnTerminalStateByThread) { _, _ in
                 syncDisplayIsland()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: RemodexQuickActionCenter.didReceiveQuickAction)) { notification in
+                _ = RemodexQuickActionCenter.consumePendingAction()
+                guard let action = notification.userInfo?["action"] as? RemodexQuickAction else {
+                    return
+                }
+                pendingQuickAction = action
+                routePendingQuickActionIfNeeded()
             }
     }
 
@@ -1209,6 +1230,52 @@ struct ContentView: View {
         codex.externalThreadOpenRequest = nil
     }
 
+    private func routePendingQuickActionIfNeeded() {
+        if pendingQuickAction == nil {
+            pendingQuickAction = RemodexQuickActionCenter.consumePendingAction()
+        }
+
+        guard let action = pendingQuickAction else {
+            return
+        }
+
+        // Shortcut callbacks can arrive before SwiftUI has resolved the size class.
+        // Routing too early chooses drawer mode on iPhone and leaves the user at the sidebar root.
+        guard horizontalSizeClass != nil else {
+            return
+        }
+
+        pendingQuickAction = nil
+        handleQuickAction(action)
+    }
+
+    private func handleQuickAction(_ action: RemodexQuickAction) {
+        switch action {
+        case .newChat:
+            openNewChatDraftFromSidebar(source: .generalChat, preferredProjectPath: nil)
+        case .thread(let threadId):
+            if let thread = codex.threads.first(where: { $0.id == threadId && $0.syncState == .live }) {
+                sidebarSelectionSuppressedUntil = nil
+                openThreadFromSidebar(thread)
+            } else {
+                routeQuickActionThreadPlaceholder(threadId: threadId)
+            }
+        }
+    }
+
+    private func routeQuickActionThreadPlaceholder(threadId: String) {
+        let normalizedThreadId = threadId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedThreadId.isEmpty else {
+            return
+        }
+
+        let thread = codex.threads.first(where: { $0.id == normalizedThreadId })
+            ?? CodexThread(id: normalizedThreadId, title: CodexThread.defaultDisplayTitle)
+        codex.upsertThread(thread)
+        sidebarSelectionSuppressedUntil = nil
+        openThreadFromSidebar(thread)
+    }
+
     // Keeps sidebar chat creation compose-first while preserving which affordance
     // opened it, so the draft UI can distinguish general Chat from folder Chat.
     private func openNewChatDraftFromSidebar(
@@ -2022,6 +2089,16 @@ struct ContentView: View {
             .intersection(visibleThreadIDs)
             .subtracting(currentRunningIDs)
         let terminalStates = codex.latestTurnTerminalStateByThread
+        let now = Date()
+
+        for threadId in currentRunningIDs {
+            if displayIslandRunningStartedAtByThread[threadId] == nil {
+                displayIslandRunningStartedAtByThread[threadId] = now
+            }
+        }
+        displayIslandRunningStartedAtByThread = displayIslandRunningStartedAtByThread.filter { threadId, _ in
+            currentRunningIDs.contains(threadId) && visibleThreadIDs.contains(threadId)
+        }
 
         displayIslandCompletedBanners.removeAll { banner in
             !visibleThreadIDs.contains(banner.threadId)
@@ -2075,7 +2152,13 @@ struct ContentView: View {
     private func displayIslandSnapshot() -> RemodexDisplayIslandSnapshot {
         let runningIDs = displayIslandCurrentRunningThreadIDs()
         let runningConversations = runningIDs
-            .compactMap { displayIslandConversation(threadId: $0, state: displayIslandRunningState(for: $0)) }
+            .compactMap { threadId in
+                displayIslandConversation(
+                    threadId: threadId,
+                    state: displayIslandRunningState(for: threadId),
+                    runningStartedAt: displayIslandRunningStartedAtByThread[threadId]
+                )
+            }
             .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
 
         let completedConversations = displayIslandCompletedBanners.compactMap { banner in
@@ -2127,7 +2210,8 @@ struct ContentView: View {
     private func displayIslandConversation(
         threadId: String,
         fallbackTitle: String? = nil,
-        state: String
+        state: String,
+        runningStartedAt: Date? = nil
     ) -> RemodexDisplayIslandConversation? {
         let thread = codex.threads.first { $0.id == threadId }
         let rawTitle = thread?.displayTitle ?? fallbackTitle ?? CodexThread.defaultDisplayTitle
@@ -2138,7 +2222,8 @@ struct ContentView: View {
             id: threadId,
             title: title.isEmpty ? CodexThread.defaultDisplayTitle : title,
             detail: detail,
-            state: state
+            state: state,
+            runningStartedAt: runningStartedAt
         )
     }
 

--- a/CodexMobile/CodexMobile/ContentView.swift
+++ b/CodexMobile/CodexMobile/ContentView.swift
@@ -6,7 +6,6 @@
 
 import SwiftUI
 import UIKit
-import ActivityKit
 
 private enum RootSheetRoute: Identifiable, Equatable {
     case bridgeUpdate(CodexBridgeUpdatePrompt)
@@ -86,11 +85,6 @@ struct ContentView: View {
     @State private var isShowingSettingsCover = false
     @State private var isShowingDevicesSettingsSheet = false
     @State private var displayIslandCoordinator = RemodexDisplayIslandCoordinator()
-    @State private var displayIslandCompletedBanners: [CodexThreadCompletionBanner] = []
-    @State private var displayIslandFailedBanners: [CodexThreadCompletionBanner] = []
-    @State private var displayIslandLastRunningThreadIDs: Set<String> = []
-    @State private var displayIslandLastTerminalStatesByThread: [String: CodexTurnTerminalState] = [:]
-    @State private var displayIslandRunningStartedAtByThread: [String: Date] = [:]
     @AppStorage("codex.hasSeenOnboarding") private var hasSeenOnboarding = false
     @AppStorage("codex.whatsNew.lastPresentedVersion") private var lastPresentedWhatsNewVersion = ""
 
@@ -235,7 +229,7 @@ struct ContentView: View {
                 resetSavedMacWakeRecoveryState()
             }
             .onChange(of: codex.threadCompletionBanner) { _, banner in
-                rememberDisplayIslandCompletion(from: banner)
+                displayIslandCoordinator.rememberCompletion(from: banner, codex: codex)
                 scheduleThreadCompletionBannerDismiss(for: banner)
                 syncDisplayIsland()
             }
@@ -2011,8 +2005,7 @@ struct ContentView: View {
     private func openCompletedThreadFromBanner(_ banner: CodexThreadCompletionBanner) {
         threadCompletionBannerDismissTask?.cancel()
         codex.threadCompletionBanner = nil
-        displayIslandCompletedBanners.removeAll { $0.threadId == banner.threadId }
-        displayIslandFailedBanners.removeAll { $0.threadId == banner.threadId }
+        clearDisplayIslandOutcome(for: banner.threadId)
         syncDisplayIsland()
 
         guard let thread = codex.threads.first(where: { $0.id == banner.threadId }) else {
@@ -2024,216 +2017,26 @@ struct ContentView: View {
 
     private func dismissThreadCompletionBanner() {
         if let banner = codex.threadCompletionBanner {
-            displayIslandCompletedBanners.removeAll { $0.threadId == banner.threadId }
-            displayIslandFailedBanners.removeAll { $0.threadId == banner.threadId }
+            clearDisplayIslandOutcome(for: banner.threadId)
         }
         threadCompletionBannerDismissTask?.cancel()
         codex.threadCompletionBanner = nil
         syncDisplayIsland()
     }
 
-    private func rememberDisplayIslandCompletion(from banner: CodexThreadCompletionBanner?) {
-        guard let banner else {
-            return
-        }
-
-        rememberDisplayIslandCompletion(threadId: banner.threadId, title: banner.title)
-    }
-
-    private func rememberDisplayIslandCompletion(threadId: String, title: String? = nil) {
-        let resolvedTitle = title
-            ?? codex.threads.first(where: { $0.id == threadId })?.displayTitle
-            ?? CodexThread.defaultDisplayTitle
-        let banner = CodexThreadCompletionBanner(threadId: threadId, title: resolvedTitle)
-
-        displayIslandFailedBanners.removeAll { $0.threadId == banner.threadId }
-        displayIslandCompletedBanners.removeAll { $0.threadId == banner.threadId }
-        displayIslandCompletedBanners.insert(banner, at: 0)
-        if displayIslandCompletedBanners.count > 3 {
-            displayIslandCompletedBanners = Array(displayIslandCompletedBanners.prefix(3))
-        }
-    }
-
-    private func rememberDisplayIslandFailure(threadId: String, title: String? = nil) {
-        let resolvedTitle = title
-            ?? codex.threads.first(where: { $0.id == threadId })?.displayTitle
-            ?? CodexThread.defaultDisplayTitle
-        let banner = CodexThreadCompletionBanner(threadId: threadId, title: resolvedTitle)
-
-        displayIslandCompletedBanners.removeAll { $0.threadId == banner.threadId }
-        displayIslandFailedBanners.removeAll { $0.threadId == banner.threadId }
-        displayIslandFailedBanners.insert(banner, at: 0)
-        if displayIslandFailedBanners.count > 3 {
-            displayIslandFailedBanners = Array(displayIslandFailedBanners.prefix(3))
-        }
-    }
-
     private func clearDisplayIslandOutcome(for threadId: String) {
-        displayIslandCompletedBanners.removeAll { $0.threadId == threadId }
-        displayIslandFailedBanners.removeAll { $0.threadId == threadId }
-        displayIslandLastTerminalStatesByThread[threadId] = codex.latestTurnTerminalState(for: threadId)
+        displayIslandCoordinator.clearOutcome(
+            for: threadId,
+            terminalState: codex.latestTurnTerminalState(for: threadId)
+        )
     }
 
     private func syncDisplayIsland() {
-        reconcileDisplayIslandCompletions()
-        let snapshot = displayIslandSnapshot()
-        Task {
-            await displayIslandCoordinator.sync(snapshot: snapshot)
-        }
-    }
-
-    private func reconcileDisplayIslandCompletions() {
-        let currentRunningIDs = displayIslandCurrentRunningThreadIDs()
-        let visibleThreadIDs = displayIslandVisibleThreadIDs()
-        let completedIDs = displayIslandLastRunningThreadIDs
-            .intersection(visibleThreadIDs)
-            .subtracting(currentRunningIDs)
-        let terminalStates = codex.latestTurnTerminalStateByThread
-        let now = Date()
-
-        for threadId in currentRunningIDs {
-            if displayIslandRunningStartedAtByThread[threadId] == nil {
-                displayIslandRunningStartedAtByThread[threadId] = now
-            }
-        }
-        displayIslandRunningStartedAtByThread = displayIslandRunningStartedAtByThread.filter { threadId, _ in
-            currentRunningIDs.contains(threadId) && visibleThreadIDs.contains(threadId)
-        }
-
-        displayIslandCompletedBanners.removeAll { banner in
-            !visibleThreadIDs.contains(banner.threadId)
-                || currentRunningIDs.contains(banner.threadId)
-                || codex.latestTurnTerminalState(for: banner.threadId) == .failed
-                || codex.latestTurnTerminalState(for: banner.threadId) == .stopped
-        }
-        displayIslandFailedBanners.removeAll { banner in
-            !visibleThreadIDs.contains(banner.threadId)
-                || currentRunningIDs.contains(banner.threadId)
-                || codex.latestTurnTerminalState(for: banner.threadId) == .completed
-                || codex.latestTurnTerminalState(for: banner.threadId) == .stopped
-        }
-
-        for threadId in completedIDs {
-            let terminalState = codex.latestTurnTerminalState(for: threadId)
-            if terminalState == .failed {
-                rememberDisplayIslandFailure(threadId: threadId)
-                continue
-            }
-            guard terminalState != .stopped else {
-                continue
-            }
-            rememberDisplayIslandCompletion(threadId: threadId)
-        }
-
-        let visibleTerminalStates = terminalStates.filter { threadId, _ in
-            visibleThreadIDs.contains(threadId) && !currentRunningIDs.contains(threadId)
-        }
-        for (threadId, terminalState) in visibleTerminalStates {
-            guard displayIslandLastTerminalStatesByThread[threadId] != terminalState else {
-                continue
-            }
-
-            switch terminalState {
-            case .completed:
-                rememberDisplayIslandCompletion(threadId: threadId)
-            case .failed:
-                rememberDisplayIslandFailure(threadId: threadId)
-            case .stopped:
-                clearDisplayIslandOutcome(for: threadId)
-            }
-        }
-
-        displayIslandLastRunningThreadIDs = currentRunningIDs.intersection(visibleThreadIDs)
-        displayIslandLastTerminalStatesByThread = terminalStates.filter { threadId, _ in
-            visibleThreadIDs.contains(threadId) && !currentRunningIDs.contains(threadId)
-        }
-    }
-
-    private func displayIslandSnapshot() -> RemodexDisplayIslandSnapshot {
-        let runningIDs = displayIslandCurrentRunningThreadIDs()
-        let runningConversations = runningIDs
-            .compactMap { threadId in
-                displayIslandConversation(
-                    threadId: threadId,
-                    state: displayIslandRunningState(for: threadId),
-                    runningStartedAt: displayIslandRunningStartedAtByThread[threadId]
-                )
-            }
-            .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
-
-        let completedConversations = displayIslandCompletedBanners.compactMap { banner in
-            displayIslandConversation(threadId: banner.threadId, fallbackTitle: banner.title, state: "Ready")
-        }
-        let failedConversations = displayIslandFailedBanners.compactMap { banner in
-            displayIslandConversation(threadId: banner.threadId, fallbackTitle: banner.title, state: "Failed")
-        }
-
-        return RemodexDisplayIslandSnapshot(
-            runningConversations: Array(runningConversations.prefix(3)),
-            completedConversations: Array(completedConversations.prefix(3)),
-            failedConversations: Array(failedConversations.prefix(3))
-        )
-    }
-
-    private func displayIslandCurrentRunningThreadIDs() -> Set<String> {
-        codex.runningThreadIDs
-            .union(Set(codex.activeTurnIdByThread.keys))
-            .intersection(displayIslandVisibleThreadIDs())
-    }
-
-    private func displayIslandVisibleThreadIDs() -> Set<String> {
-        Set(codex.threads.map(\.id))
+        displayIslandCoordinator.sync(codex: codex)
     }
 
     private var displayIslandTimelineFingerprint: String {
-        displayIslandCurrentRunningThreadIDs()
-            .sorted()
-            .map { threadId in
-                let snapshot = codex.timelineState(for: threadId).renderSnapshot
-                return "\(threadId):\(snapshot.timelineChangeToken):\(displayIslandRunningState(for: threadId))"
-            }
-            .joined(separator: "|")
-    }
-
-    private func displayIslandRunningState(for threadId: String) -> String {
-        let messages = codex.timelineState(for: threadId).renderSnapshot.messages
-        let isFinalAnswerStreaming = messages.contains { message in
-            message.role == .assistant
-                && message.kind == .chat
-                && message.isStreaming
-                && message.assistantPhase == "final_answer"
-                && !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        }
-        return isFinalAnswerStreaming ? "Finishing" : "Running"
-    }
-
-    private func displayIslandConversation(
-        threadId: String,
-        fallbackTitle: String? = nil,
-        state: String,
-        runningStartedAt: Date? = nil
-    ) -> RemodexDisplayIslandConversation? {
-        let thread = codex.threads.first { $0.id == threadId }
-        let rawTitle = thread?.displayTitle ?? fallbackTitle ?? CodexThread.defaultDisplayTitle
-        let title = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
-        let detail = displayIslandDetail(for: thread)
-
-        return RemodexDisplayIslandConversation(
-            id: threadId,
-            title: title.isEmpty ? CodexThread.defaultDisplayTitle : title,
-            detail: detail,
-            state: state,
-            runningStartedAt: runningStartedAt
-        )
-    }
-
-    private func displayIslandDetail(for thread: CodexThread?) -> String {
-        guard let cwd = thread?.cwd?.trimmingCharacters(in: .whitespacesAndNewlines), !cwd.isEmpty else {
-            return "Remodex"
-        }
-
-        let lastPathComponent = URL(fileURLWithPath: cwd).lastPathComponent
-        return lastPathComponent.isEmpty ? "Remodex" : lastPathComponent
+        displayIslandCoordinator.timelineFingerprint(codex: codex)
     }
 
     // Keeps selected thread coherent with server list updates.
@@ -2416,84 +2219,6 @@ private struct HorizontalRevealViewportShape: Shape {
             height: rect.height + (verticalOverflow * 2)
         )
         return Path(expandedRect)
-    }
-}
-
-private struct RemodexDisplayIslandSnapshot: Equatable {
-    let runningConversations: [RemodexDisplayIslandConversation]
-    let completedConversations: [RemodexDisplayIslandConversation]
-    let failedConversations: [RemodexDisplayIslandConversation]
-
-    var isEmpty: Bool {
-        runningConversations.isEmpty && completedConversations.isEmpty && failedConversations.isEmpty
-    }
-}
-
-@MainActor
-private final class RemodexDisplayIslandCoordinator {
-    private var activityID: String?
-    private var lastSnapshot: RemodexDisplayIslandSnapshot?
-
-    func sync(snapshot: RemodexDisplayIslandSnapshot) async {
-        guard ActivityAuthorizationInfo().areActivitiesEnabled else {
-            await endAllActivities()
-            lastSnapshot = nil
-            return
-        }
-
-        guard !snapshot.isEmpty else {
-            await endAllActivities()
-            lastSnapshot = nil
-            return
-        }
-
-        guard snapshot != lastSnapshot || currentActivity == nil else {
-            return
-        }
-
-        let content = ActivityContent(
-            state: RemodexDisplayIslandAttributes.ContentState(
-                runningConversations: snapshot.runningConversations,
-                completedConversations: snapshot.completedConversations,
-                failedConversations: snapshot.failedConversations,
-                updatedAt: Date()
-            ),
-            staleDate: Date().addingTimeInterval(30 * 60)
-        )
-
-        if let activity = currentActivity {
-            await activity.update(content)
-            activityID = activity.id
-        } else {
-            do {
-                let activity = try Activity<RemodexDisplayIslandAttributes>.request(
-                    attributes: RemodexDisplayIslandAttributes(title: "Remodex"),
-                    content: content,
-                    pushType: nil
-                )
-                activityID = activity.id
-            } catch {
-                activityID = nil
-            }
-        }
-
-        lastSnapshot = snapshot
-    }
-
-    private var currentActivity: Activity<RemodexDisplayIslandAttributes>? {
-        if let activityID,
-           let matchingActivity = Activity<RemodexDisplayIslandAttributes>.activities.first(where: { $0.id == activityID }) {
-            return matchingActivity
-        }
-
-        return Activity<RemodexDisplayIslandAttributes>.activities.first
-    }
-
-    private func endAllActivities() async {
-        for activity in Activity<RemodexDisplayIslandAttributes>.activities {
-            await activity.end(nil, dismissalPolicy: .immediate)
-        }
-        activityID = nil
     }
 }
 

--- a/CodexMobile/CodexMobile/ContentView.swift
+++ b/CodexMobile/CodexMobile/ContentView.swift
@@ -6,6 +6,7 @@
 
 import SwiftUI
 import UIKit
+import ActivityKit
 
 private enum RootSheetRoute: Identifiable, Equatable {
     case bridgeUpdate(CodexBridgeUpdatePrompt)
@@ -83,6 +84,10 @@ struct ContentView: View {
     // inside the bar.
     @State private var isShowingSettingsCover = false
     @State private var isShowingDevicesSettingsSheet = false
+    @State private var displayIslandCoordinator = RemodexDisplayIslandCoordinator()
+    @State private var displayIslandCompletedBanners: [CodexThreadCompletionBanner] = []
+    @State private var displayIslandFailedBanners: [CodexThreadCompletionBanner] = []
+    @State private var displayIslandLastRunningThreadIDs: Set<String> = []
     @AppStorage("codex.hasSeenOnboarding") private var hasSeenOnboarding = false
     @AppStorage("codex.whatsNew.lastPresentedVersion") private var lastPresentedWhatsNewVersion = ""
 
@@ -161,10 +166,12 @@ struct ContentView: View {
                 debugSidebarLog("threads changed count=\(threads.count) sidebarOpen=\(isSidebarOpen) prewarmed=\(isSidebarPrewarmed)")
                 syncSelectedThread(with: threads)
                 scheduleSidebarPrewarmIfNeeded()
+                syncDisplayIsland()
             }
             .onChange(of: scenePhase) { _, phase in
                 debugSidebarLog("scenePhase changed phase=\(String(describing: phase))")
                 codex.setForegroundState(phase != .background)
+                syncDisplayIsland()
                 if phase == .active {
                     Task {
                         async let subscriptionRefresh: Void = subscriptions.refreshCustomerInfoSilently()
@@ -206,7 +213,18 @@ struct ContentView: View {
                 resetSavedMacWakeRecoveryState()
             }
             .onChange(of: codex.threadCompletionBanner) { _, banner in
+                rememberDisplayIslandCompletion(from: banner)
                 scheduleThreadCompletionBannerDismiss(for: banner)
+                syncDisplayIsland()
+            }
+            .onChange(of: codex.runningThreadIDs) { _, _ in
+                syncDisplayIsland()
+            }
+            .onChange(of: codex.activeTurnIdByThread) { _, _ in
+                syncDisplayIsland()
+            }
+            .onChange(of: codex.latestTurnTerminalStateByThread) { _, _ in
+                syncDisplayIsland()
             }
     }
 
@@ -1877,6 +1895,9 @@ struct ContentView: View {
     private func openCompletedThreadFromBanner(_ banner: CodexThreadCompletionBanner) {
         threadCompletionBannerDismissTask?.cancel()
         codex.threadCompletionBanner = nil
+        displayIslandCompletedBanners.removeAll { $0.threadId == banner.threadId }
+        displayIslandFailedBanners.removeAll { $0.threadId == banner.threadId }
+        syncDisplayIsland()
 
         guard let thread = codex.threads.first(where: { $0.id == banner.threadId }) else {
             return
@@ -1886,8 +1907,138 @@ struct ContentView: View {
     }
 
     private func dismissThreadCompletionBanner() {
+        if let banner = codex.threadCompletionBanner {
+            displayIslandCompletedBanners.removeAll { $0.threadId == banner.threadId }
+            displayIslandFailedBanners.removeAll { $0.threadId == banner.threadId }
+        }
         threadCompletionBannerDismissTask?.cancel()
         codex.threadCompletionBanner = nil
+        syncDisplayIsland()
+    }
+
+    private func rememberDisplayIslandCompletion(from banner: CodexThreadCompletionBanner?) {
+        guard let banner else {
+            return
+        }
+
+        rememberDisplayIslandCompletion(threadId: banner.threadId, title: banner.title)
+    }
+
+    private func rememberDisplayIslandCompletion(threadId: String, title: String? = nil) {
+        let resolvedTitle = title
+            ?? codex.threads.first(where: { $0.id == threadId })?.displayTitle
+            ?? CodexThread.defaultDisplayTitle
+        let banner = CodexThreadCompletionBanner(threadId: threadId, title: resolvedTitle)
+
+        displayIslandFailedBanners.removeAll { $0.threadId == banner.threadId }
+        displayIslandCompletedBanners.removeAll { $0.threadId == banner.threadId }
+        displayIslandCompletedBanners.insert(banner, at: 0)
+        if displayIslandCompletedBanners.count > 3 {
+            displayIslandCompletedBanners = Array(displayIslandCompletedBanners.prefix(3))
+        }
+    }
+
+    private func rememberDisplayIslandFailure(threadId: String, title: String? = nil) {
+        let resolvedTitle = title
+            ?? codex.threads.first(where: { $0.id == threadId })?.displayTitle
+            ?? CodexThread.defaultDisplayTitle
+        let banner = CodexThreadCompletionBanner(threadId: threadId, title: resolvedTitle)
+
+        displayIslandCompletedBanners.removeAll { $0.threadId == banner.threadId }
+        displayIslandFailedBanners.removeAll { $0.threadId == banner.threadId }
+        displayIslandFailedBanners.insert(banner, at: 0)
+        if displayIslandFailedBanners.count > 3 {
+            displayIslandFailedBanners = Array(displayIslandFailedBanners.prefix(3))
+        }
+    }
+
+    private func syncDisplayIsland() {
+        reconcileDisplayIslandCompletions()
+        let snapshot = displayIslandSnapshot()
+        Task {
+            await displayIslandCoordinator.sync(snapshot: snapshot)
+        }
+    }
+
+    private func reconcileDisplayIslandCompletions() {
+        let currentRunningIDs = displayIslandCurrentRunningThreadIDs()
+        let completedIDs = displayIslandLastRunningThreadIDs.subtracting(currentRunningIDs)
+
+        displayIslandCompletedBanners.removeAll { banner in
+            currentRunningIDs.contains(banner.threadId)
+                || codex.latestTurnTerminalState(for: banner.threadId) == .failed
+                || codex.latestTurnTerminalState(for: banner.threadId) == .stopped
+        }
+        displayIslandFailedBanners.removeAll { banner in
+            currentRunningIDs.contains(banner.threadId)
+                || codex.latestTurnTerminalState(for: banner.threadId) == .completed
+                || codex.latestTurnTerminalState(for: banner.threadId) == .stopped
+        }
+
+        for threadId in completedIDs {
+            let terminalState = codex.latestTurnTerminalState(for: threadId)
+            if terminalState == .failed {
+                rememberDisplayIslandFailure(threadId: threadId)
+                continue
+            }
+            guard terminalState != .stopped else {
+                continue
+            }
+            rememberDisplayIslandCompletion(threadId: threadId)
+        }
+
+        displayIslandLastRunningThreadIDs = currentRunningIDs
+    }
+
+    private func displayIslandSnapshot() -> RemodexDisplayIslandSnapshot {
+        let runningIDs = displayIslandCurrentRunningThreadIDs()
+        let runningConversations = runningIDs
+            .compactMap { displayIslandConversation(threadId: $0, state: "Running") }
+            .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+
+        let completedConversations = displayIslandCompletedBanners.compactMap { banner in
+            displayIslandConversation(threadId: banner.threadId, fallbackTitle: banner.title, state: "Ready")
+        }
+        let failedConversations = displayIslandFailedBanners.compactMap { banner in
+            displayIslandConversation(threadId: banner.threadId, fallbackTitle: banner.title, state: "Failed")
+        }
+
+        return RemodexDisplayIslandSnapshot(
+            runningConversations: Array(runningConversations.prefix(3)),
+            completedConversations: Array(completedConversations.prefix(3)),
+            failedConversations: Array(failedConversations.prefix(3))
+        )
+    }
+
+    private func displayIslandCurrentRunningThreadIDs() -> Set<String> {
+        codex.runningThreadIDs.union(Set(codex.activeTurnIdByThread.keys))
+    }
+
+    private func displayIslandConversation(
+        threadId: String,
+        fallbackTitle: String? = nil,
+        state: String
+    ) -> RemodexDisplayIslandConversation? {
+        let thread = codex.threads.first { $0.id == threadId }
+        let rawTitle = thread?.displayTitle ?? fallbackTitle ?? CodexThread.defaultDisplayTitle
+        let title = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let detail = displayIslandDetail(for: thread)
+
+        return RemodexDisplayIslandConversation(
+            id: threadId,
+            title: title.isEmpty ? CodexThread.defaultDisplayTitle : title,
+            detail: detail,
+            state: state
+        )
+    }
+
+    private func displayIslandDetail(for thread: CodexThread?) -> String {
+        guard let cwd = thread?.cwd?.trimmingCharacters(in: .whitespacesAndNewlines), !cwd.isEmpty else {
+            return "Remodex"
+        }
+
+        let lastPathComponent = URL(fileURLWithPath: cwd).lastPathComponent
+        return lastPathComponent.isEmpty ? "Remodex" : lastPathComponent
     }
 
     // Keeps selected thread coherent with server list updates.
@@ -2070,6 +2221,84 @@ private struct HorizontalRevealViewportShape: Shape {
             height: rect.height + (verticalOverflow * 2)
         )
         return Path(expandedRect)
+    }
+}
+
+private struct RemodexDisplayIslandSnapshot: Equatable {
+    let runningConversations: [RemodexDisplayIslandConversation]
+    let completedConversations: [RemodexDisplayIslandConversation]
+    let failedConversations: [RemodexDisplayIslandConversation]
+
+    var isEmpty: Bool {
+        runningConversations.isEmpty && completedConversations.isEmpty && failedConversations.isEmpty
+    }
+}
+
+@MainActor
+private final class RemodexDisplayIslandCoordinator {
+    private var activityID: String?
+    private var lastSnapshot: RemodexDisplayIslandSnapshot?
+
+    func sync(snapshot: RemodexDisplayIslandSnapshot) async {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+            await endAllActivities()
+            lastSnapshot = nil
+            return
+        }
+
+        guard !snapshot.isEmpty else {
+            await endAllActivities()
+            lastSnapshot = nil
+            return
+        }
+
+        guard snapshot != lastSnapshot || currentActivity == nil else {
+            return
+        }
+
+        let content = ActivityContent(
+            state: RemodexDisplayIslandAttributes.ContentState(
+                runningConversations: snapshot.runningConversations,
+                completedConversations: snapshot.completedConversations,
+                failedConversations: snapshot.failedConversations,
+                updatedAt: Date()
+            ),
+            staleDate: Date().addingTimeInterval(30 * 60)
+        )
+
+        if let activity = currentActivity {
+            await activity.update(content)
+            activityID = activity.id
+        } else {
+            do {
+                let activity = try Activity<RemodexDisplayIslandAttributes>.request(
+                    attributes: RemodexDisplayIslandAttributes(title: "Remodex"),
+                    content: content,
+                    pushType: nil
+                )
+                activityID = activity.id
+            } catch {
+                activityID = nil
+            }
+        }
+
+        lastSnapshot = snapshot
+    }
+
+    private var currentActivity: Activity<RemodexDisplayIslandAttributes>? {
+        if let activityID,
+           let matchingActivity = Activity<RemodexDisplayIslandAttributes>.activities.first(where: { $0.id == activityID }) {
+            return matchingActivity
+        }
+
+        return Activity<RemodexDisplayIslandAttributes>.activities.first
+    }
+
+    private func endAllActivities() async {
+        for activity in Activity<RemodexDisplayIslandAttributes>.activities {
+            await activity.end(nil, dismissalPolicy: .immediate)
+        }
+        activityID = nil
     }
 }
 

--- a/CodexMobile/CodexMobile/ContentView.swift
+++ b/CodexMobile/CodexMobile/ContentView.swift
@@ -149,6 +149,10 @@ struct ContentView: View {
                     to: thread?.id
                 )
                 codex.activeThreadId = thread?.id
+                if let thread {
+                    clearDisplayIslandOutcome(for: thread.id)
+                    syncDisplayIsland()
+                }
                 if thread != nil {
                     suppressAutomaticThreadSelection = false
                 }
@@ -218,6 +222,9 @@ struct ContentView: View {
                 syncDisplayIsland()
             }
             .onChange(of: codex.runningThreadIDs) { _, _ in
+                syncDisplayIsland()
+            }
+            .onChange(of: displayIslandTimelineFingerprint) { _, _ in
                 syncDisplayIsland()
             }
             .onChange(of: codex.activeTurnIdByThread) { _, _ in
@@ -1141,6 +1148,8 @@ struct ContentView: View {
         selectedThread = thread
         codex.activeThreadId = thread.id
         codex.markThreadAsViewed(thread.id)
+        clearDisplayIslandOutcome(for: thread.id)
+        syncDisplayIsland()
         if shouldPresentSidebarAsNavigation {
             navigationPath = [.thread(id: thread.id)]
         }
@@ -1194,6 +1203,8 @@ struct ContentView: View {
         selectedThread = thread
         codex.activeThreadId = thread.id
         codex.markThreadAsViewed(thread.id)
+        clearDisplayIslandOutcome(for: thread.id)
+        syncDisplayIsland()
 
         if shouldPresentSidebarAsNavigation {
             Task { @MainActor in
@@ -1952,6 +1963,11 @@ struct ContentView: View {
         }
     }
 
+    private func clearDisplayIslandOutcome(for threadId: String) {
+        displayIslandCompletedBanners.removeAll { $0.threadId == threadId }
+        displayIslandFailedBanners.removeAll { $0.threadId == threadId }
+    }
+
     private func syncDisplayIsland() {
         reconcileDisplayIslandCompletions()
         let snapshot = displayIslandSnapshot()
@@ -1993,7 +2009,7 @@ struct ContentView: View {
     private func displayIslandSnapshot() -> RemodexDisplayIslandSnapshot {
         let runningIDs = displayIslandCurrentRunningThreadIDs()
         let runningConversations = runningIDs
-            .compactMap { displayIslandConversation(threadId: $0, state: "Running") }
+            .compactMap { displayIslandConversation(threadId: $0, state: displayIslandRunningState(for: $0)) }
             .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
 
         let completedConversations = displayIslandCompletedBanners.compactMap { banner in
@@ -2012,6 +2028,28 @@ struct ContentView: View {
 
     private func displayIslandCurrentRunningThreadIDs() -> Set<String> {
         codex.runningThreadIDs.union(Set(codex.activeTurnIdByThread.keys))
+    }
+
+    private var displayIslandTimelineFingerprint: String {
+        displayIslandCurrentRunningThreadIDs()
+            .sorted()
+            .map { threadId in
+                let snapshot = codex.timelineState(for: threadId).renderSnapshot
+                return "\(threadId):\(snapshot.timelineChangeToken):\(displayIslandRunningState(for: threadId))"
+            }
+            .joined(separator: "|")
+    }
+
+    private func displayIslandRunningState(for threadId: String) -> String {
+        let messages = codex.timelineState(for: threadId).renderSnapshot.messages
+        let isFinalAnswerStreaming = messages.contains { message in
+            message.role == .assistant
+                && message.kind == .chat
+                && message.isStreaming
+                && message.assistantPhase == "final_answer"
+                && !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        return isFinalAnswerStreaming ? "Finishing" : "Running"
     }
 
     private func displayIslandConversation(

--- a/CodexMobile/CodexMobile/ContentView.swift
+++ b/CodexMobile/CodexMobile/ContentView.swift
@@ -88,6 +88,7 @@ struct ContentView: View {
     @State private var displayIslandCompletedBanners: [CodexThreadCompletionBanner] = []
     @State private var displayIslandFailedBanners: [CodexThreadCompletionBanner] = []
     @State private var displayIslandLastRunningThreadIDs: Set<String> = []
+    @State private var displayIslandLastTerminalStatesByThread: [String: CodexTurnTerminalState] = [:]
     @AppStorage("codex.hasSeenOnboarding") private var hasSeenOnboarding = false
     @AppStorage("codex.whatsNew.lastPresentedVersion") private var lastPresentedWhatsNewVersion = ""
 
@@ -1966,6 +1967,7 @@ struct ContentView: View {
     private func clearDisplayIslandOutcome(for threadId: String) {
         displayIslandCompletedBanners.removeAll { $0.threadId == threadId }
         displayIslandFailedBanners.removeAll { $0.threadId == threadId }
+        displayIslandLastTerminalStatesByThread[threadId] = codex.latestTurnTerminalState(for: threadId)
     }
 
     private func syncDisplayIsland() {
@@ -1979,6 +1981,7 @@ struct ContentView: View {
     private func reconcileDisplayIslandCompletions() {
         let currentRunningIDs = displayIslandCurrentRunningThreadIDs()
         let completedIDs = displayIslandLastRunningThreadIDs.subtracting(currentRunningIDs)
+        let terminalStates = codex.latestTurnTerminalStateByThread
 
         displayIslandCompletedBanners.removeAll { banner in
             currentRunningIDs.contains(banner.threadId)
@@ -2003,7 +2006,25 @@ struct ContentView: View {
             rememberDisplayIslandCompletion(threadId: threadId)
         }
 
+        for (threadId, terminalState) in terminalStates where !currentRunningIDs.contains(threadId) {
+            guard displayIslandLastTerminalStatesByThread[threadId] != terminalState else {
+                continue
+            }
+
+            switch terminalState {
+            case .completed:
+                rememberDisplayIslandCompletion(threadId: threadId)
+            case .failed:
+                rememberDisplayIslandFailure(threadId: threadId)
+            case .stopped:
+                clearDisplayIslandOutcome(for: threadId)
+            }
+        }
+
         displayIslandLastRunningThreadIDs = currentRunningIDs
+        displayIslandLastTerminalStatesByThread = terminalStates.filter { threadId, _ in
+            !currentRunningIDs.contains(threadId)
+        }
     }
 
     private func displayIslandSnapshot() -> RemodexDisplayIslandSnapshot {

--- a/CodexMobile/CodexMobile/RemodexQuickActionCenter.swift
+++ b/CodexMobile/CodexMobile/RemodexQuickActionCenter.swift
@@ -1,0 +1,102 @@
+// FILE: RemodexQuickActionCenter.swift
+// Purpose: Publishes Home Screen quick actions and routes selected shortcuts
+//          back into the SwiftUI root.
+// Layer: App
+// Exports: RemodexQuickAction, RemodexQuickActionCenter
+
+import Foundation
+import UIKit
+
+enum RemodexQuickAction: Equatable, Sendable {
+    case newChat
+    case thread(id: String)
+}
+
+@MainActor
+enum RemodexQuickActionCenter {
+    static let didReceiveQuickAction = Notification.Name("remodex.didReceiveQuickAction")
+
+    private static let newChatType = "com.emanueledipietro.Remodex.quickAction.newChat"
+    private static let threadType = "com.emanueledipietro.Remodex.quickAction.thread"
+    private static let threadIDUserInfoKey = "threadId"
+    private static var pendingAction: RemodexQuickAction?
+
+    static func updateShortcutItems(for threads: [CodexThread]) {
+        UIApplication.shared.shortcutItems = shortcutItems(for: threads)
+    }
+
+    @discardableResult
+    static func handleShortcutItem(_ shortcutItem: UIApplicationShortcutItem) -> Bool {
+        guard let action = action(from: shortcutItem) else {
+            return false
+        }
+
+        pendingAction = action
+        NotificationCenter.default.post(
+            name: didReceiveQuickAction,
+            object: nil,
+            userInfo: ["action": action]
+        )
+        return true
+    }
+
+    static func consumePendingAction() -> RemodexQuickAction? {
+        let action = pendingAction
+        pendingAction = nil
+        return action
+    }
+
+    private static func shortcutItems(for threads: [CodexThread]) -> [UIApplicationShortcutItem] {
+        let recentThreads = threads
+            .filter { $0.syncState == .live }
+            .prefix(2)
+
+        return [newChatShortcutItem()] + recentThreads.map(threadShortcutItem)
+    }
+
+    private static func newChatShortcutItem() -> UIApplicationShortcutItem {
+        UIApplicationShortcutItem(
+            type: newChatType,
+            localizedTitle: "New Chat",
+            localizedSubtitle: nil,
+            icon: UIApplicationShortcutIcon(systemImageName: "square.and.pencil"),
+            userInfo: nil
+        )
+    }
+
+    private static func threadShortcutItem(for thread: CodexThread) -> UIApplicationShortcutItem {
+        UIApplicationShortcutItem(
+            type: threadType,
+            localizedTitle: thread.displayTitle,
+            localizedSubtitle: projectSubtitle(for: thread),
+            icon: UIApplicationShortcutIcon(systemImageName: "bubble.left.and.bubble.right"),
+            userInfo: [threadIDUserInfoKey: thread.id as NSString]
+        )
+    }
+
+    private static func projectSubtitle(for thread: CodexThread) -> String {
+        let projectName = thread.projectDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !projectName.isEmpty, projectName != CodexThread.noProjectDisplayName else {
+            return "Chats"
+        }
+        return projectName
+    }
+
+    private static func action(from shortcutItem: UIApplicationShortcutItem) -> RemodexQuickAction? {
+        switch shortcutItem.type {
+        case newChatType:
+            return .newChat
+        case threadType:
+            guard let threadID = shortcutItem.userInfo?[threadIDUserInfoKey] as? String else {
+                return nil
+            }
+            let normalizedThreadID = threadID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalizedThreadID.isEmpty else {
+                return nil
+            }
+            return .thread(id: normalizedThreadID)
+        default:
+            return nil
+        }
+    }
+}

--- a/CodexMobile/CodexMobile/Services/CodexService+Notifications.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Notifications.swift
@@ -266,6 +266,7 @@ extension CodexService {
         }
 
         pendingNotificationOpenThreadID = normalizedThreadId
+        externalThreadOpenRequest = CodexExternalThreadOpenRequest(threadId: normalizedThreadId)
         Task { @MainActor [weak self] in
             guard let self else { return }
 
@@ -367,6 +368,9 @@ private extension CodexService {
 
         if pendingNotificationOpenThreadID == threadId {
             pendingNotificationOpenThreadID = nil
+        }
+        if externalThreadOpenRequest?.threadId == threadId {
+            externalThreadOpenRequest = nil
         }
         if activeThreadId == nil || activeThreadId == threadId {
             activeThreadId = firstLiveThreadID()

--- a/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
@@ -550,9 +550,15 @@ extension CodexService {
 
     // Centralizes local-only thread cleanup so repo-group deletion can reuse it safely.
     private func removeThreadLocally(_ threadId: String, persistAsDeleted: Bool, persistMessages: Bool = true) {
-        clearRunningState(for: threadId)
-        removeThreadTimelineState(for: threadId)
+        if let turnId = activeTurnID(for: threadId) {
+            setActiveTurnID(nil, for: threadId)
+            threadIdByTurnID.removeValue(forKey: turnId)
+            if activeTurnId == turnId { activeTurnId = nil }
+        }
+        threadIdByTurnID = threadIdByTurnID.filter { $0.value != threadId }
+
         clearOutcomeBadge(for: threadId)
+        latestTurnTerminalStateByThread.removeValue(forKey: threadId)
         persistThreadRename(nil, for: threadId)
 
         // Drop local-only runtime overrides once a chat is fully removed from the device.
@@ -560,6 +566,10 @@ extension CodexService {
         clearThreadServiceTierOverride(for: threadId)
 
         threads.removeAll { $0.id == threadId }
+
+        clearRunningState(for: threadId)
+        removeThreadTimelineState(for: threadId)
+
         messagesByThread.removeValue(forKey: threadId)
         if persistMessages {
             persistCurrentMacMessages()
@@ -571,13 +581,6 @@ extension CodexService {
         streamingSystemMessageByItemID = streamingSystemMessageByItemID.filter { key, _ in
             !key.hasPrefix("\(threadId)|item:")
         }
-
-        if let turnId = activeTurnID(for: threadId) {
-            setActiveTurnID(nil, for: threadId)
-            threadIdByTurnID.removeValue(forKey: turnId)
-            if activeTurnId == turnId { activeTurnId = nil }
-        }
-        threadIdByTurnID = threadIdByTurnID.filter { $0.value != threadId }
 
         if activeThreadId == threadId { activeThreadId = nil }
 

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -179,6 +179,11 @@ struct CodexMissingNotificationThreadPrompt: Identifiable, Equatable, Sendable {
     let threadId: String
 }
 
+struct CodexExternalThreadOpenRequest: Identifiable, Equatable, Sendable {
+    let id = UUID()
+    let threadId: String
+}
+
 enum CodexThreadRunBadgeState: Hashable, Sendable {
     case running
     case ready
@@ -413,6 +418,7 @@ final class CodexService {
     var modelsErrorMessage: String?
     var notificationAuthorizationStatus: UNAuthorizationStatus = .notDetermined
     var pendingNotificationOpenThreadID: String?
+    var externalThreadOpenRequest: CodexExternalThreadOpenRequest?
     var supportsStructuredSkillInput = true
     var supportsStructuredMentionInput = true
     // Runtime compatibility flag for `turn/start.collaborationMode` plan turns.

--- a/CodexMobile/CodexMobile/Services/RemodexDisplayIslandCoordinator.swift
+++ b/CodexMobile/CodexMobile/Services/RemodexDisplayIslandCoordinator.swift
@@ -108,9 +108,13 @@ final class RemodexDisplayIslandCoordinator {
 
         let currentRunningIDs = currentRunningThreadIDs(codex: codex)
         let visibleThreadIDs = visibleThreadIDs(codex: codex)
-        let completedIDs = lastRunningThreadIDs
-            .intersection(visibleThreadIDs)
+        let activeThreadIDs = currentActiveThreadIDs(codex: codex)
+        // The active chat is already visible in-app, so only off-screen outcomes should become Island badges.
+        let outcomeEligibleThreadIDs = visibleThreadIDs
             .subtracting(currentRunningIDs)
+            .subtracting(activeThreadIDs)
+        let completedIDs = lastRunningThreadIDs
+            .intersection(outcomeEligibleThreadIDs)
         let terminalStates = codex.latestTurnTerminalStateByThread
 
         for threadId in currentRunningIDs where runningStartedAtByThread[threadId] == nil {
@@ -126,7 +130,13 @@ final class RemodexDisplayIslandCoordinator {
             now: now
         )
 
-        pruneOutcomes(codex: codex, currentRunningIDs: currentRunningIDs, visibleThreadIDs: visibleThreadIDs, now: now)
+        pruneOutcomes(
+            codex: codex,
+            currentRunningIDs: currentRunningIDs,
+            activeThreadIDs: activeThreadIDs,
+            visibleThreadIDs: visibleThreadIDs,
+            now: now
+        )
 
         for threadId in completedIDs {
             let terminalState = codex.latestTurnTerminalState(for: threadId)
@@ -141,7 +151,7 @@ final class RemodexDisplayIslandCoordinator {
         }
 
         let visibleTerminalStates = terminalStates.filter { threadId, _ in
-            visibleThreadIDs.contains(threadId) && !currentRunningIDs.contains(threadId)
+            outcomeEligibleThreadIDs.contains(threadId)
         }
         for (threadId, terminalState) in visibleTerminalStates {
             guard lastTerminalStatesByThread[threadId] != terminalState else {
@@ -167,12 +177,14 @@ final class RemodexDisplayIslandCoordinator {
     private func pruneOutcomes(
         codex: CodexService,
         currentRunningIDs: Set<String>,
+        activeThreadIDs: Set<String>,
         visibleThreadIDs: Set<String>,
         now: Date
     ) {
         completedOutcomes.removeAll { outcome in
             !visibleThreadIDs.contains(outcome.threadId)
                 || currentRunningIDs.contains(outcome.threadId)
+                || activeThreadIDs.contains(outcome.threadId)
                 || codex.latestTurnTerminalState(for: outcome.threadId) == .failed
                 || codex.latestTurnTerminalState(for: outcome.threadId) == .stopped
                 || now.timeIntervalSince(outcome.createdAt) >= Self.completedLifetime
@@ -180,6 +192,7 @@ final class RemodexDisplayIslandCoordinator {
         failedOutcomes.removeAll { outcome in
             !visibleThreadIDs.contains(outcome.threadId)
                 || currentRunningIDs.contains(outcome.threadId)
+                || activeThreadIDs.contains(outcome.threadId)
                 || codex.latestTurnTerminalState(for: outcome.threadId) == .completed
                 || codex.latestTurnTerminalState(for: outcome.threadId) == .stopped
                 || now.timeIntervalSince(outcome.createdAt) >= Self.failedLifetime
@@ -289,6 +302,15 @@ final class RemodexDisplayIslandCoordinator {
 
     private func visibleThreadIDs(codex: CodexService) -> Set<String> {
         Set(codex.threads.map(\.id))
+    }
+
+    private func currentActiveThreadIDs(codex: CodexService) -> Set<String> {
+        guard let activeThreadId = codex.activeThreadId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !activeThreadId.isEmpty else {
+            return []
+        }
+
+        return [activeThreadId]
     }
 
     private func runningState(for threadId: String, codex: CodexService) -> String {

--- a/CodexMobile/CodexMobile/Services/RemodexDisplayIslandCoordinator.swift
+++ b/CodexMobile/CodexMobile/Services/RemodexDisplayIslandCoordinator.swift
@@ -92,10 +92,15 @@ final class RemodexDisplayIslandCoordinator {
 
     private func performSync(codex: CodexService) async {
         let now = Date()
-        reconcileCompletions(codex: codex, now: now)
-        let snapshot = makeSnapshot(codex: codex, now: now)
+        let snapshot = makeReconciledSnapshot(codex: codex, now: now)
         scheduleNextExpirationSyncIfNeeded(codex: codex, snapshot: snapshot, now: now)
         await apply(snapshot: snapshot, now: now)
+    }
+
+    // Reconciles transient run/outcome caches before producing ActivityKit content.
+    func makeReconciledSnapshot(codex: CodexService, now: Date) -> RemodexDisplayIslandSnapshot {
+        reconcileCompletions(codex: codex, now: now)
+        return makeSnapshot(codex: codex, now: now)
     }
 
     private func reconcileCompletions(codex: CodexService, now: Date) {
@@ -125,14 +130,14 @@ final class RemodexDisplayIslandCoordinator {
 
         for threadId in completedIDs {
             let terminalState = codex.latestTurnTerminalState(for: threadId)
-            if terminalState == .failed {
+            switch terminalState {
+            case .completed:
+                rememberCompletion(threadId: threadId, codex: codex, now: now)
+            case .failed:
                 rememberFailure(threadId: threadId, codex: codex, now: now)
+            case .stopped, nil:
                 continue
             }
-            guard terminalState != .stopped else {
-                continue
-            }
-            rememberCompletion(threadId: threadId, codex: codex, now: now)
         }
 
         let visibleTerminalStates = terminalStates.filter { threadId, _ in

--- a/CodexMobile/CodexMobile/Services/RemodexDisplayIslandCoordinator.swift
+++ b/CodexMobile/CodexMobile/Services/RemodexDisplayIslandCoordinator.swift
@@ -1,0 +1,454 @@
+// FILE: RemodexDisplayIslandCoordinator.swift
+// Purpose: Owns Remodex Live Activity state, coalescing, and expiration.
+// Layer: Service
+
+import ActivityKit
+import Foundation
+
+struct RemodexDisplayIslandSnapshot: Equatable {
+    let runningConversations: [RemodexDisplayIslandConversation]
+    let completedConversations: [RemodexDisplayIslandConversation]
+    let failedConversations: [RemodexDisplayIslandConversation]
+    let nextExpirationDate: Date?
+
+    var isEmpty: Bool {
+        runningConversations.isEmpty && completedConversations.isEmpty && failedConversations.isEmpty
+    }
+}
+
+@MainActor
+final class RemodexDisplayIslandCoordinator {
+    private struct Outcome: Equatable {
+        let threadId: String
+        let title: String
+        let createdAt: Date
+    }
+
+    private static let maxDisplayedConversations = 3
+    private static let syncDelayNanoseconds: UInt64 = 350_000_000
+    private static let completedLifetime: TimeInterval = 5 * 60
+    private static let failedLifetime: TimeInterval = 15 * 60
+    private static let defaultStaleInterval: TimeInterval = 30 * 60
+    private static let runningStartRetentionInterval: TimeInterval = 2 * 60 * 60
+
+    private var activityID: String?
+    private var lastSnapshot: RemodexDisplayIslandSnapshot?
+    private var scheduledSyncTask: Task<Void, Never>?
+    private var expirationSyncTask: Task<Void, Never>?
+
+    private var completedOutcomes: [Outcome] = []
+    private var failedOutcomes: [Outcome] = []
+    private var lastRunningThreadIDs: Set<String> = []
+    private var lastTerminalStatesByThread: [String: CodexTurnTerminalState] = [:]
+    private var runningStartedAtByThread: [String: Date] = [:]
+    private var runningLastSeenAtByThread: [String: Date] = [:]
+
+    func rememberCompletion(from banner: CodexThreadCompletionBanner?, codex: CodexService) {
+        guard let banner else {
+            return
+        }
+
+        rememberCompletion(threadId: banner.threadId, title: banner.title, codex: codex)
+    }
+
+    func clearOutcome(for threadId: String, terminalState: CodexTurnTerminalState?) {
+        completedOutcomes.removeAll { $0.threadId == threadId }
+        failedOutcomes.removeAll { $0.threadId == threadId }
+        lastTerminalStatesByThread[threadId] = terminalState
+    }
+
+    func sync(codex: CodexService, immediately: Bool = false) {
+        if immediately {
+            scheduledSyncTask?.cancel()
+            scheduledSyncTask = nil
+            Task { @MainActor [weak self, weak codex] in
+                guard let self, let codex else {
+                    return
+                }
+                await self.performSync(codex: codex)
+            }
+            return
+        }
+
+        scheduledSyncTask?.cancel()
+        scheduledSyncTask = Task { @MainActor [weak self, weak codex] in
+            try? await Task.sleep(nanoseconds: Self.syncDelayNanoseconds)
+            guard !Task.isCancelled, let self, let codex else {
+                return
+            }
+            await self.performSync(codex: codex)
+        }
+    }
+
+    func timelineFingerprint(codex: CodexService) -> String {
+        currentRunningThreadIDs(codex: codex)
+            .sorted()
+            .map { threadId in
+                let snapshot = codex.timelineState(for: threadId).renderSnapshot
+                return "\(threadId):\(snapshot.timelineChangeToken):\(runningState(for: threadId, codex: codex))"
+            }
+            .joined(separator: "|")
+    }
+
+    private func performSync(codex: CodexService) async {
+        let now = Date()
+        reconcileCompletions(codex: codex, now: now)
+        let snapshot = makeSnapshot(codex: codex, now: now)
+        scheduleNextExpirationSyncIfNeeded(codex: codex, snapshot: snapshot, now: now)
+        await apply(snapshot: snapshot, now: now)
+    }
+
+    private func reconcileCompletions(codex: CodexService, now: Date) {
+        hydrateRunningStartsFromCurrentActivity(now: now)
+
+        let currentRunningIDs = currentRunningThreadIDs(codex: codex)
+        let visibleThreadIDs = visibleThreadIDs(codex: codex)
+        let completedIDs = lastRunningThreadIDs
+            .intersection(visibleThreadIDs)
+            .subtracting(currentRunningIDs)
+        let terminalStates = codex.latestTurnTerminalStateByThread
+
+        for threadId in currentRunningIDs where runningStartedAtByThread[threadId] == nil {
+            runningStartedAtByThread[threadId] = now
+        }
+        for threadId in currentRunningIDs {
+            runningLastSeenAtByThread[threadId] = now
+        }
+        pruneRunningStarts(
+            currentRunningIDs: currentRunningIDs,
+            visibleThreadIDs: visibleThreadIDs,
+            terminalStates: terminalStates,
+            now: now
+        )
+
+        pruneOutcomes(codex: codex, currentRunningIDs: currentRunningIDs, visibleThreadIDs: visibleThreadIDs, now: now)
+
+        for threadId in completedIDs {
+            let terminalState = codex.latestTurnTerminalState(for: threadId)
+            if terminalState == .failed {
+                rememberFailure(threadId: threadId, codex: codex, now: now)
+                continue
+            }
+            guard terminalState != .stopped else {
+                continue
+            }
+            rememberCompletion(threadId: threadId, codex: codex, now: now)
+        }
+
+        let visibleTerminalStates = terminalStates.filter { threadId, _ in
+            visibleThreadIDs.contains(threadId) && !currentRunningIDs.contains(threadId)
+        }
+        for (threadId, terminalState) in visibleTerminalStates {
+            guard lastTerminalStatesByThread[threadId] != terminalState else {
+                continue
+            }
+
+            switch terminalState {
+            case .completed:
+                rememberCompletion(threadId: threadId, codex: codex, now: now)
+            case .failed:
+                rememberFailure(threadId: threadId, codex: codex, now: now)
+            case .stopped:
+                clearOutcome(for: threadId, terminalState: terminalState)
+            }
+        }
+
+        lastRunningThreadIDs = currentRunningIDs.intersection(visibleThreadIDs)
+        lastTerminalStatesByThread = terminalStates.filter { threadId, _ in
+            visibleThreadIDs.contains(threadId) && !currentRunningIDs.contains(threadId)
+        }
+    }
+
+    private func pruneOutcomes(
+        codex: CodexService,
+        currentRunningIDs: Set<String>,
+        visibleThreadIDs: Set<String>,
+        now: Date
+    ) {
+        completedOutcomes.removeAll { outcome in
+            !visibleThreadIDs.contains(outcome.threadId)
+                || currentRunningIDs.contains(outcome.threadId)
+                || codex.latestTurnTerminalState(for: outcome.threadId) == .failed
+                || codex.latestTurnTerminalState(for: outcome.threadId) == .stopped
+                || now.timeIntervalSince(outcome.createdAt) >= Self.completedLifetime
+        }
+        failedOutcomes.removeAll { outcome in
+            !visibleThreadIDs.contains(outcome.threadId)
+                || currentRunningIDs.contains(outcome.threadId)
+                || codex.latestTurnTerminalState(for: outcome.threadId) == .completed
+                || codex.latestTurnTerminalState(for: outcome.threadId) == .stopped
+                || now.timeIntervalSince(outcome.createdAt) >= Self.failedLifetime
+        }
+    }
+
+    private func pruneRunningStarts(
+        currentRunningIDs: Set<String>,
+        visibleThreadIDs: Set<String>,
+        terminalStates: [String: CodexTurnTerminalState],
+        now: Date
+    ) {
+        let retainedThreadIDs = Set(runningStartedAtByThread.keys.filter { threadId in
+            guard visibleThreadIDs.contains(threadId) else {
+                return false
+            }
+            if currentRunningIDs.contains(threadId) {
+                return true
+            }
+            if terminalStates[threadId] != nil {
+                return false
+            }
+            guard let lastSeenAt = runningLastSeenAtByThread[threadId] else {
+                return false
+            }
+            return now.timeIntervalSince(lastSeenAt) < Self.runningStartRetentionInterval
+        })
+
+        runningStartedAtByThread = runningStartedAtByThread.filter { threadId, _ in
+            retainedThreadIDs.contains(threadId)
+        }
+        runningLastSeenAtByThread = runningLastSeenAtByThread.filter { threadId, _ in
+            retainedThreadIDs.contains(threadId)
+        }
+    }
+
+    private func makeSnapshot(codex: CodexService, now: Date) -> RemodexDisplayIslandSnapshot {
+        let runningConversations = currentRunningThreadIDs(codex: codex)
+            .compactMap { threadId in
+                conversation(
+                    threadId: threadId,
+                    state: runningState(for: threadId, codex: codex),
+                    runningStartedAt: runningStartedAtByThread[threadId],
+                    codex: codex
+                )
+            }
+            .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+
+        let completedConversations = completedOutcomes.compactMap { outcome in
+            conversation(threadId: outcome.threadId, fallbackTitle: outcome.title, state: "Ready", codex: codex)
+        }
+        let failedConversations = failedOutcomes.compactMap { outcome in
+            conversation(threadId: outcome.threadId, fallbackTitle: outcome.title, state: "Failed", codex: codex)
+        }
+
+        return RemodexDisplayIslandSnapshot(
+            runningConversations: Array(runningConversations.prefix(Self.maxDisplayedConversations)),
+            completedConversations: Array(completedConversations.prefix(Self.maxDisplayedConversations)),
+            failedConversations: Array(failedConversations.prefix(Self.maxDisplayedConversations)),
+            nextExpirationDate: nextExpirationDate(now: now)
+        )
+    }
+
+    private func rememberCompletion(
+        threadId: String,
+        title: String? = nil,
+        codex: CodexService,
+        now: Date = Date()
+    ) {
+        let resolvedTitle = title
+            ?? codex.threads.first(where: { $0.id == threadId })?.displayTitle
+            ?? CodexThread.defaultDisplayTitle
+        let outcome = Outcome(threadId: threadId, title: resolvedTitle, createdAt: now)
+
+        failedOutcomes.removeAll { $0.threadId == outcome.threadId }
+        completedOutcomes.removeAll { $0.threadId == outcome.threadId }
+        completedOutcomes.insert(outcome, at: 0)
+        if completedOutcomes.count > Self.maxDisplayedConversations {
+            completedOutcomes = Array(completedOutcomes.prefix(Self.maxDisplayedConversations))
+        }
+    }
+
+    private func rememberFailure(
+        threadId: String,
+        title: String? = nil,
+        codex: CodexService,
+        now: Date = Date()
+    ) {
+        let resolvedTitle = title
+            ?? codex.threads.first(where: { $0.id == threadId })?.displayTitle
+            ?? CodexThread.defaultDisplayTitle
+        let outcome = Outcome(threadId: threadId, title: resolvedTitle, createdAt: now)
+
+        completedOutcomes.removeAll { $0.threadId == outcome.threadId }
+        failedOutcomes.removeAll { $0.threadId == outcome.threadId }
+        failedOutcomes.insert(outcome, at: 0)
+        if failedOutcomes.count > Self.maxDisplayedConversations {
+            failedOutcomes = Array(failedOutcomes.prefix(Self.maxDisplayedConversations))
+        }
+    }
+
+    private func currentRunningThreadIDs(codex: CodexService) -> Set<String> {
+        codex.runningThreadIDs
+            .union(Set(codex.activeTurnIdByThread.keys))
+            .intersection(visibleThreadIDs(codex: codex))
+    }
+
+    private func visibleThreadIDs(codex: CodexService) -> Set<String> {
+        Set(codex.threads.map(\.id))
+    }
+
+    private func runningState(for threadId: String, codex: CodexService) -> String {
+        let messages = codex.timelineState(for: threadId).renderSnapshot.messages
+        let isFinalAnswerStreaming = messages.contains { message in
+            message.role == .assistant
+                && message.kind == .chat
+                && message.isStreaming
+                && message.assistantPhase == "final_answer"
+                && !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        return isFinalAnswerStreaming ? "Finishing" : "Running"
+    }
+
+    private func conversation(
+        threadId: String,
+        fallbackTitle: String? = nil,
+        state: String,
+        runningStartedAt: Date? = nil,
+        codex: CodexService
+    ) -> RemodexDisplayIslandConversation? {
+        let thread = codex.threads.first { $0.id == threadId }
+        let rawTitle = thread?.displayTitle ?? fallbackTitle ?? CodexThread.defaultDisplayTitle
+        let title = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let detail = detail(for: thread)
+
+        return RemodexDisplayIslandConversation(
+            id: threadId,
+            title: title.isEmpty ? CodexThread.defaultDisplayTitle : title,
+            detail: detail,
+            state: state,
+            runningStartedAt: runningStartedAt
+        )
+    }
+
+    private func detail(for thread: CodexThread?) -> String {
+        guard let cwd = thread?.cwd?.trimmingCharacters(in: .whitespacesAndNewlines), !cwd.isEmpty else {
+            return "Remodex"
+        }
+
+        let lastPathComponent = URL(fileURLWithPath: cwd).lastPathComponent
+        return lastPathComponent.isEmpty ? "Remodex" : lastPathComponent
+    }
+
+    private func nextExpirationDate(now: Date) -> Date? {
+        let completedExpiration = completedOutcomes
+            .map { $0.createdAt.addingTimeInterval(Self.completedLifetime) }
+            .filter { $0 > now }
+            .min()
+        let failedExpiration = failedOutcomes
+            .map { $0.createdAt.addingTimeInterval(Self.failedLifetime) }
+            .filter { $0 > now }
+            .min()
+
+        switch (completedExpiration, failedExpiration) {
+        case (.some(let completed), .some(let failed)):
+            return min(completed, failed)
+        case (.some(let completed), .none):
+            return completed
+        case (.none, .some(let failed)):
+            return failed
+        case (.none, .none):
+            return nil
+        }
+    }
+
+    private func scheduleNextExpirationSyncIfNeeded(
+        codex: CodexService,
+        snapshot: RemodexDisplayIslandSnapshot,
+        now: Date
+    ) {
+        expirationSyncTask?.cancel()
+        guard let nextExpirationDate = snapshot.nextExpirationDate else {
+            expirationSyncTask = nil
+            return
+        }
+
+        let delay = max(0, nextExpirationDate.timeIntervalSince(now))
+        let nanoseconds = UInt64(delay * 1_000_000_000)
+        expirationSyncTask = Task { @MainActor [weak self, weak codex] in
+            try? await Task.sleep(nanoseconds: nanoseconds)
+            guard !Task.isCancelled, let self, let codex else {
+                return
+            }
+            self.sync(codex: codex, immediately: true)
+        }
+    }
+
+    private func hydrateRunningStartsFromCurrentActivity(now: Date) {
+        guard let activity = currentActivity else {
+            return
+        }
+
+        for conversation in activity.content.state.runningConversations {
+            guard let runningStartedAt = conversation.runningStartedAt else {
+                continue
+            }
+            if let existingStartedAt = runningStartedAtByThread[conversation.id] {
+                runningStartedAtByThread[conversation.id] = min(existingStartedAt, runningStartedAt)
+            } else {
+                runningStartedAtByThread[conversation.id] = runningStartedAt
+            }
+            runningLastSeenAtByThread[conversation.id] = now
+        }
+    }
+
+    private func apply(snapshot: RemodexDisplayIslandSnapshot, now: Date) async {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+            await endAllActivities()
+            lastSnapshot = nil
+            return
+        }
+
+        guard !snapshot.isEmpty else {
+            await endAllActivities()
+            lastSnapshot = nil
+            return
+        }
+
+        guard snapshot != lastSnapshot || currentActivity == nil else {
+            return
+        }
+
+        let content = ActivityContent(
+            state: RemodexDisplayIslandAttributes.ContentState(
+                runningConversations: snapshot.runningConversations,
+                completedConversations: snapshot.completedConversations,
+                failedConversations: snapshot.failedConversations,
+                updatedAt: now
+            ),
+            staleDate: snapshot.nextExpirationDate ?? now.addingTimeInterval(Self.defaultStaleInterval)
+        )
+
+        if let activity = currentActivity {
+            await activity.update(content)
+            activityID = activity.id
+        } else {
+            do {
+                let activity = try Activity<RemodexDisplayIslandAttributes>.request(
+                    attributes: RemodexDisplayIslandAttributes(title: "Remodex"),
+                    content: content,
+                    pushType: nil
+                )
+                activityID = activity.id
+            } catch {
+                activityID = nil
+            }
+        }
+
+        lastSnapshot = snapshot
+    }
+
+    private var currentActivity: Activity<RemodexDisplayIslandAttributes>? {
+        if let activityID,
+           let matchingActivity = Activity<RemodexDisplayIslandAttributes>.activities.first(where: { $0.id == activityID }) {
+            return matchingActivity
+        }
+
+        return Activity<RemodexDisplayIslandAttributes>.activities.first
+    }
+
+    private func endAllActivities() async {
+        for activity in Activity<RemodexDisplayIslandAttributes>.activities {
+            await activity.end(nil, dismissalPolicy: .immediate)
+        }
+        activityID = nil
+    }
+}

--- a/CodexMobile/CodexMobileTests/CodexPushNotificationRegistrationTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexPushNotificationRegistrationTests.swift
@@ -127,6 +127,7 @@ final class CodexPushNotificationRegistrationTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 30_000_000)
 
         XCTAssertEqual(service.pendingNotificationOpenThreadID, "thread-pending")
+        XCTAssertEqual(service.externalThreadOpenRequest?.threadId, "thread-pending")
         XCTAssertNil(service.activeThreadId)
 
         service.threads = [CodexThread(id: "thread-pending", title: "Pending thread")]
@@ -203,6 +204,7 @@ final class CodexPushNotificationRegistrationTests: XCTestCase {
         )
         service.isConnected = true
         service.pendingNotificationOpenThreadID = "thread-deleted"
+        service.externalThreadOpenRequest = CodexExternalThreadOpenRequest(threadId: "thread-deleted")
         service.threads = [
             CodexThread(id: "thread-deleted", title: "Deleted thread", syncState: .archivedLocal),
             CodexThread(id: "thread-live", title: "Live thread"),
@@ -212,6 +214,7 @@ final class CodexPushNotificationRegistrationTests: XCTestCase {
 
         XCTAssertFalse(routed)
         XCTAssertNil(service.pendingNotificationOpenThreadID)
+        XCTAssertNil(service.externalThreadOpenRequest)
         XCTAssertEqual(service.activeThreadId, "thread-live")
         XCTAssertEqual(service.missingNotificationThreadPrompt?.threadId, "thread-deleted")
     }

--- a/CodexMobile/CodexMobileTests/CodexServiceIncomingRunIndicatorTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceIncomingRunIndicatorTests.swift
@@ -661,6 +661,39 @@ final class CodexServiceIncomingRunIndicatorTests: XCTestCase {
         XCTAssertEqual(completedSnapshot.completedConversations.map(\.id), [threadID])
     }
 
+    func testDisplayIslandDoesNotMarkActiveRunReadyAfterCompletion() {
+        let service = makeService()
+        let coordinator = RemodexDisplayIslandCoordinator()
+        let threadID = "thread-\(UUID().uuidString)"
+        let startedAt = Date(timeIntervalSince1970: 1_000)
+        service.threads = [
+            CodexThread(id: threadID, title: "Active chat", cwd: "/tmp/remodex"),
+        ]
+        service.activeThreadId = threadID
+        service.runningThreadIDs.insert(threadID)
+
+        let runningSnapshot = coordinator.makeReconciledSnapshot(codex: service, now: startedAt)
+        XCTAssertEqual(runningSnapshot.runningConversations.map(\.id), [threadID])
+
+        service.runningThreadIDs.remove(threadID)
+        service.latestTurnTerminalStateByThread[threadID] = .completed
+        let activeCompletedSnapshot = coordinator.makeReconciledSnapshot(
+            codex: service,
+            now: startedAt.addingTimeInterval(1)
+        )
+
+        XCTAssertTrue(activeCompletedSnapshot.runningConversations.isEmpty)
+        XCTAssertTrue(activeCompletedSnapshot.completedConversations.isEmpty)
+        XCTAssertTrue(activeCompletedSnapshot.failedConversations.isEmpty)
+
+        service.activeThreadId = nil
+        let laterInactiveSnapshot = coordinator.makeReconciledSnapshot(
+            codex: service,
+            now: startedAt.addingTimeInterval(2)
+        )
+        XCTAssertTrue(laterInactiveSnapshot.completedConversations.isEmpty)
+    }
+
     func testThreadHasActiveOrRunningTurnUsesRunningFallback() {
         let service = makeService()
         let threadID = "thread-\(UUID().uuidString)"

--- a/CodexMobile/CodexMobileTests/CodexServiceIncomingRunIndicatorTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceIncomingRunIndicatorTests.swift
@@ -605,6 +605,31 @@ final class CodexServiceIncomingRunIndicatorTests: XCTestCase {
         XCTAssertNil(service.threadRunBadgeState(for: threadID))
     }
 
+    func testDeletingRunningThreadClearsRuntimeState() {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let turnID = "turn-\(UUID().uuidString)"
+        service.threads = [
+            CodexThread(id: threadID, title: "Running chat", cwd: "/tmp/remodex"),
+        ]
+        service.runningThreadIDs.insert(threadID)
+        service.activeTurnIdByThread[threadID] = turnID
+        service.threadIdByTurnID[turnID] = threadID
+        service.activeTurnId = turnID
+        service.latestTurnTerminalStateByThread[threadID] = .completed
+        service.readyThreadIDs.insert(threadID)
+
+        service.deleteThreadLocally(threadID)
+
+        XCTAssertFalse(service.runningThreadIDs.contains(threadID))
+        XCTAssertNil(service.activeTurnID(for: threadID))
+        XCTAssertNil(service.threadIdByTurnID[turnID])
+        XCTAssertNil(service.activeTurnId)
+        XCTAssertNil(service.latestTurnTerminalState(for: threadID))
+        XCTAssertNil(service.threadRunBadgeState(for: threadID))
+        XCTAssertFalse(service.threads.contains { $0.id == threadID })
+    }
+
     func testThreadHasActiveOrRunningTurnUsesRunningFallback() {
         let service = makeService()
         let threadID = "thread-\(UUID().uuidString)"

--- a/CodexMobile/CodexMobileTests/CodexServiceIncomingRunIndicatorTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceIncomingRunIndicatorTests.swift
@@ -630,6 +630,37 @@ final class CodexServiceIncomingRunIndicatorTests: XCTestCase {
         XCTAssertFalse(service.threads.contains { $0.id == threadID })
     }
 
+    func testDisplayIslandDoesNotMarkDisconnectedRunReadyWithoutTerminalState() {
+        let service = makeService()
+        let coordinator = RemodexDisplayIslandCoordinator()
+        let threadID = "thread-\(UUID().uuidString)"
+        let startedAt = Date(timeIntervalSince1970: 1_000)
+        service.threads = [
+            CodexThread(id: threadID, title: "Running chat", cwd: "/tmp/remodex"),
+        ]
+        service.runningThreadIDs.insert(threadID)
+
+        let runningSnapshot = coordinator.makeReconciledSnapshot(codex: service, now: startedAt)
+        XCTAssertEqual(runningSnapshot.runningConversations.map(\.id), [threadID])
+
+        service.runningThreadIDs.remove(threadID)
+        let disconnectedSnapshot = coordinator.makeReconciledSnapshot(
+            codex: service,
+            now: startedAt.addingTimeInterval(1)
+        )
+
+        XCTAssertTrue(disconnectedSnapshot.runningConversations.isEmpty)
+        XCTAssertTrue(disconnectedSnapshot.completedConversations.isEmpty)
+        XCTAssertTrue(disconnectedSnapshot.failedConversations.isEmpty)
+
+        service.latestTurnTerminalStateByThread[threadID] = .completed
+        let completedSnapshot = coordinator.makeReconciledSnapshot(
+            codex: service,
+            now: startedAt.addingTimeInterval(2)
+        )
+        XCTAssertEqual(completedSnapshot.completedConversations.map(\.id), [threadID])
+    }
+
     func testThreadHasActiveOrRunningTurnUsesRunningFallback() {
         let service = makeService()
         let threadID = "thread-\(UUID().uuidString)"

--- a/CodexMobile/RemodexWidget/RemodexLaunchIntent.swift
+++ b/CodexMobile/RemodexWidget/RemodexLaunchIntent.swift
@@ -39,6 +39,7 @@ struct RemodexDisplayIslandConversation: Codable, Hashable, Identifiable, Sendab
     let title: String
     let detail: String
     let state: String
+    var runningStartedAt: Date?
 
     var threadURL: URL? {
         var components = URLComponents()

--- a/CodexMobile/RemodexWidget/RemodexLaunchIntent.swift
+++ b/CodexMobile/RemodexWidget/RemodexLaunchIntent.swift
@@ -5,7 +5,9 @@
 //          before an intent can open the parent app.
 // Layer: Widget Extension
 
+import ActivityKit
 import AppIntents
+import Foundation
 
 enum RemodexLaunchTarget: String, AppEnum {
     case home
@@ -30,4 +32,36 @@ struct RemodexLaunchIntent: OpenIntent {
     init(target: RemodexLaunchTarget) {
         self.target = target
     }
+}
+
+struct RemodexDisplayIslandConversation: Codable, Hashable, Identifiable, Sendable {
+    let id: String
+    let title: String
+    let detail: String
+    let state: String
+
+    var threadURL: URL? {
+        var components = URLComponents()
+        components.scheme = "phodex"
+        components.host = "thread"
+        components.percentEncodedPath = "/" + (id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id)
+        return components.url
+    }
+}
+
+struct RemodexDisplayIslandAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+        var runningConversations: [RemodexDisplayIslandConversation]
+        var completedConversations: [RemodexDisplayIslandConversation]
+        var failedConversations: [RemodexDisplayIslandConversation]
+        var updatedAt: Date
+
+        var primaryThreadURL: URL? {
+            runningConversations.first?.threadURL
+                ?? failedConversations.first?.threadURL
+                ?? completedConversations.first?.threadURL
+        }
+    }
+
+    let title: String
 }

--- a/CodexMobile/RemodexWidget/RemodexLockScreenWidget.swift
+++ b/CodexMobile/RemodexWidget/RemodexLockScreenWidget.swift
@@ -131,6 +131,7 @@ struct RemodexDisplayIslandLiveActivity: Widget {
                 }
                 DynamicIslandExpandedRegion(.bottom) {
                     RemodexDisplayIslandExpandedList(state: context.state)
+                        .padding(.horizontal, 8)
                 }
             } compactLeading: {
                 RemodexDisplayIslandMark()
@@ -230,7 +231,7 @@ private struct RemodexDisplayIslandRow: View {
     let conversation: RemodexDisplayIslandConversation
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 7) {
             Circle()
                 .fill(tint)
                 .frame(width: 7, height: 7)
@@ -245,13 +246,23 @@ private struct RemodexDisplayIslandRow: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
-            Spacer(minLength: 0)
+            VStack(alignment: .trailing, spacing: 1) {
+                Text(conversation.state)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(tint)
+                    .lineLimit(1)
 
-            Text(conversation.state)
-                .font(.caption2.weight(.medium))
-                .foregroundStyle(tint)
-                .frame(minWidth: 58, alignment: .trailing)
+                if let runningStartedAt = conversation.runningStartedAt {
+                    Text(runningStartedAt, style: .timer)
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .multilineTextAlignment(.trailing)
+                }
+            }
+            .frame(width: 62, alignment: .trailing)
         }
     }
 

--- a/CodexMobile/RemodexWidget/RemodexLockScreenWidget.swift
+++ b/CodexMobile/RemodexWidget/RemodexLockScreenWidget.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import WidgetKit
+import ActivityKit
 
 struct RemodexLockScreenEntry: TimelineEntry {
     let date: Date
@@ -100,6 +101,192 @@ struct RemodexLockScreenWidget: Widget {
         .configurationDisplayName("Remodex")
         .description("Quick access to Remodex from your Lock Screen.")
         .supportedFamilies([.accessoryCircular, .accessoryRectangular, .accessoryInline])
+    }
+}
+
+struct RemodexDisplayIslandLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: RemodexDisplayIslandAttributes.self) { context in
+            RemodexDisplayIslandLockScreenView(state: context.state)
+                .activityBackgroundTint(Color(red: 0.05, green: 0.055, blue: 0.06))
+                .activitySystemActionForegroundColor(.white)
+                .widgetURL(context.state.primaryThreadURL)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    RemodexDisplayIslandCountView(
+                        value: context.state.runningConversations.count,
+                        title: "Running",
+                        tint: .green
+                    )
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    RemodexDisplayIslandCountView(
+                        value: context.state.completedConversations.count + context.state.failedConversations.count,
+                        title: "Review",
+                        tint: context.state.failedConversations.isEmpty ? .cyan : .orange
+                    )
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    RemodexDisplayIslandExpandedList(state: context.state)
+                }
+            } compactLeading: {
+                RemodexDisplayIslandMark()
+            } compactTrailing: {
+                Text(compactStatusText(for: context.state))
+                    .font(.caption2.weight(.semibold))
+                    .monospacedDigit()
+            } minimal: {
+                RemodexDisplayIslandMark()
+            }
+            .keylineTint(.green)
+            .widgetURL(context.state.primaryThreadURL)
+        }
+    }
+
+    private func compactStatusText(for state: RemodexDisplayIslandAttributes.ContentState) -> String {
+        let runningCount = state.runningConversations.count
+        if runningCount > 0 {
+            return "\(runningCount)"
+        }
+        if !state.failedConversations.isEmpty {
+            return "!"
+        }
+        return "\(state.completedConversations.count)"
+    }
+}
+
+private struct RemodexDisplayIslandLockScreenView: View {
+    let state: RemodexDisplayIslandAttributes.ContentState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                RemodexDisplayIslandMark()
+                    .frame(width: 28, height: 28)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Remodex")
+                        .font(.headline.weight(.semibold))
+                    Text(headerSubtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            RemodexDisplayIslandExpandedList(state: state)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var headerSubtitle: String {
+        let running = state.runningConversations.count
+        let completed = state.completedConversations.count
+        let failed = state.failedConversations.count
+        if failed > 0, running > 0 {
+            return "\(running) running, \(failed) failed"
+        }
+        if failed > 0 {
+            return failed == 1 ? "1 conversation failed" : "\(failed) conversations failed"
+        }
+        if running > 0, completed > 0 {
+            return "\(running) running, \(completed) ready"
+        }
+        if running > 0 {
+            return running == 1 ? "1 conversation running" : "\(running) conversations running"
+        }
+        return completed == 1 ? "1 conversation ready" : "\(completed) conversations ready"
+    }
+}
+
+private struct RemodexDisplayIslandExpandedList: View {
+    let state: RemodexDisplayIslandAttributes.ContentState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(displayRows) { row in
+                if let url = row.threadURL {
+                    Link(destination: url) {
+                        RemodexDisplayIslandRow(conversation: row)
+                    }
+                } else {
+                    RemodexDisplayIslandRow(conversation: row)
+                }
+            }
+        }
+    }
+
+    private var displayRows: [RemodexDisplayIslandConversation] {
+        Array((state.runningConversations + state.failedConversations + state.completedConversations).prefix(3))
+    }
+}
+
+private struct RemodexDisplayIslandRow: View {
+    let conversation: RemodexDisplayIslandConversation
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(tint)
+                .frame(width: 7, height: 7)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(conversation.title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Text(conversation.detail.isEmpty ? conversation.state : conversation.detail)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 0)
+
+            Text(conversation.state)
+                .font(.caption2.weight(.medium))
+                .foregroundStyle(tint)
+        }
+    }
+
+    private var tint: Color {
+        switch conversation.state {
+        case "Ready":
+            return .cyan
+        case "Failed":
+            return .orange
+        default:
+            return .green
+        }
+    }
+}
+
+private struct RemodexDisplayIslandCountView: View {
+    let value: Int
+    let title: String
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text("\(value)")
+                .font(.headline.weight(.bold))
+                .monospacedDigit()
+            Text(title)
+                .font(.caption2)
+                .foregroundStyle(tint)
+        }
+    }
+}
+
+private struct RemodexDisplayIslandMark: View {
+    var body: some View {
+        Image("remodex-outline")
+            .resizable()
+            .renderingMode(.template)
+            .scaledToFit()
+            .foregroundStyle(.white)
     }
 }
 

--- a/CodexMobile/RemodexWidget/RemodexLockScreenWidget.swift
+++ b/CodexMobile/RemodexWidget/RemodexLockScreenWidget.swift
@@ -119,6 +119,7 @@ struct RemodexDisplayIslandLiveActivity: Widget {
                         title: "Running",
                         tint: .green
                     )
+                    .padding(.leading, 8)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
                     RemodexDisplayIslandCountView(
@@ -126,6 +127,7 @@ struct RemodexDisplayIslandLiveActivity: Widget {
                         title: "Review",
                         tint: context.state.failedConversations.isEmpty ? .cyan : .orange
                     )
+                    .padding(.trailing, 8)
                 }
                 DynamicIslandExpandedRegion(.bottom) {
                     RemodexDisplayIslandExpandedList(state: context.state)

--- a/CodexMobile/RemodexWidget/RemodexLockScreenWidget.swift
+++ b/CodexMobile/RemodexWidget/RemodexLockScreenWidget.swift
@@ -162,10 +162,10 @@ private struct RemodexDisplayIslandLockScreenView: View {
     let state: RemodexDisplayIslandAttributes.ContentState
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 10) {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 12) {
                 RemodexDisplayIslandMark()
-                    .frame(width: 28, height: 28)
+                    .frame(width: 32, height: 32)
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Remodex")
@@ -180,7 +180,8 @@ private struct RemodexDisplayIslandLockScreenView: View {
 
             RemodexDisplayIslandExpandedList(state: state)
         }
-        .padding(.vertical, 4)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
     }
 
     private var headerSubtitle: String {
@@ -250,6 +251,7 @@ private struct RemodexDisplayIslandRow: View {
             Text(conversation.state)
                 .font(.caption2.weight(.medium))
                 .foregroundStyle(tint)
+                .frame(minWidth: 58, alignment: .trailing)
         }
     }
 

--- a/CodexMobile/RemodexWidget/RemodexWidgetBundle.swift
+++ b/CodexMobile/RemodexWidget/RemodexWidgetBundle.swift
@@ -12,6 +12,7 @@ struct RemodexWidgetBundle: WidgetBundle {
     @WidgetBundleBuilder
     var body: some Widget {
         RemodexLockScreenWidget()
+        RemodexDisplayIslandLiveActivity()
         if #available(iOS 18.0, *) {
             RemodexLaunchControl()
         }


### PR DESCRIPTION
## Summary

Adds Dynamic Island / Live Activity support for conversation status on iOS, including clearer running/completed states, persistent completion display, and reliable routing back into the correct conversation.

## Changes

- Add a conversation status Live Activity for the Dynamic Island and Lock Screen.
- Polish the displayed conversation states so active, completed, and stale runs are easier to distinguish.
- Keep completion state visible long enough after a run finishes instead of clearing it immediately.
- Fix deep link handling from the widget/Live Activity so it routes back to the expected thread.
- Clear stale Dynamic Island state when incoming run state changes or reconnects.
- Add coverage around push notification registration and incoming run indicators.

## Testing

- Added/updated unit coverage for notification registration and incoming run indicator behavior.
- Manual validation recommended on a physical iPhone with Dynamic Island / Live Activities enabled.