### PR TITLE
Optimize chat mirroring replay

### DIFF
--- a/CodexMobile/CodexMobile/ContentView.swift
+++ b/CodexMobile/CodexMobile/ContentView.swift
@@ -60,6 +60,7 @@ struct ContentView: View {
     @State private var isRetryingBridgeUpdate = false
     @State private var isPreparingManualScanner = false
     @State private var macSwitchTask: Task<Void, Never>?
+    @State private var threadSelectionSyncTask: Task<Void, Never>?
     @State private var isWakingSavedMacDisplay = false
     @State private var hasAttemptedAutomaticWakeSavedMacDisplay = false
     @State private var threadCompletionBannerDismissTask: Task<Void, Never>?
@@ -159,7 +160,7 @@ struct ContentView: View {
             }
             .onChange(of: codex.threads) { _, threads in
                 debugSidebarLog("threads changed count=\(threads.count) sidebarOpen=\(isSidebarOpen) prewarmed=\(isSidebarPrewarmed)")
-                syncSelectedThread(with: threads)
+                scheduleSelectedThreadSync()
                 scheduleSidebarPrewarmIfNeeded()
             }
             .onChange(of: scenePhase) { _, phase in
@@ -1891,6 +1892,15 @@ struct ContentView: View {
     }
 
     // Keeps selected thread coherent with server list updates.
+    private func scheduleSelectedThreadSync() {
+        threadSelectionSyncTask?.cancel()
+        threadSelectionSyncTask = Task { @MainActor in
+            await Task.yield()
+            guard !Task.isCancelled else { return }
+            syncSelectedThread(with: codex.threads)
+        }
+    }
+
     private func syncSelectedThread(with threads: [CodexThread]) {
         guard !isOpeningNewChatFromSidebar else { return }
 

--- a/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
@@ -172,6 +172,7 @@ extension CodexService {
         assistantRevertStateRevision = 0
         workspaceCheckpointCopyTaskByTurnID.values.forEach { $0.cancel() }
         workspaceCheckpointCopyTaskByTurnID.removeAll()
+        cancelAllRolloutBootstrapReplayWork()
         supportsServiceTier = true
         hasPresentedServiceTierBridgeUpdatePrompt = false
         supportsBridgeVoiceTranscription = true

--- a/CodexMobile/CodexMobile/Services/CodexService+Incoming.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Incoming.swift
@@ -10,6 +10,10 @@ typealias IncomingParamsObject = [String: JSONValue]
 
 private let desktopIpcActionSource = "desktop-ipc-action-follower"
 
+private enum RolloutBootstrapReplayPolicy {
+    static let appliedBatchKeyLimit = 512
+}
+
 private struct CommandExecutionMessageContext {
     let threadId: String
     let turnId: String?
@@ -188,6 +192,9 @@ extension CodexService {
         }
 
         switch method {
+        case "remodex/rollout/bootstrapReplay":
+            handleRolloutBootstrapReplay(paramsObject)
+
         case "thread/started":
             handleThreadStarted(paramsObject)
 
@@ -318,6 +325,193 @@ extension CodexService {
                 return
             }
         }
+    }
+
+    // Applies desktop rollout catch-up as a batch so old activity stays visible
+    // without arriving as thousands of separate live transport frames.
+    private func handleRolloutBootstrapReplay(_ paramsObject: IncomingParamsObject?) {
+        let notifications = paramsObject?["notifications"]?.arrayValue ?? []
+        guard !notifications.isEmpty else {
+            return
+        }
+
+        guard let threadId = rolloutBootstrapReplayThreadId(
+            paramsObject: paramsObject,
+            notifications: notifications
+        ) else {
+            applyRolloutBootstrapReplayNotifications(
+                notifications,
+                flushDeferredWork: true
+            )
+            return
+        }
+
+        let flushDeferredWork = rolloutBootstrapReplayIsFinalBatch(paramsObject)
+        if let replayBatchKey = rolloutBootstrapReplayBatchKey(
+            paramsObject: paramsObject,
+            threadId: threadId
+        ) {
+            guard rememberAppliedRolloutBootstrapReplayBatchKey(replayBatchKey) else {
+                return
+            }
+        }
+
+        applyRolloutBootstrapReplayNotifications(
+            notifications,
+            flushDeferredWork: flushDeferredWork
+        )
+    }
+
+    private func rememberAppliedRolloutBootstrapReplayBatchKey(_ key: String) -> Bool {
+        guard !appliedRolloutBootstrapReplayBatchKeys.contains(key) else {
+            return false
+        }
+
+        appliedRolloutBootstrapReplayBatchKeys.insert(key)
+        appliedRolloutBootstrapReplayBatchKeyOrder.append(key)
+        while appliedRolloutBootstrapReplayBatchKeyOrder.count > RolloutBootstrapReplayPolicy.appliedBatchKeyLimit {
+            let oldestKey = appliedRolloutBootstrapReplayBatchKeyOrder.removeFirst()
+            appliedRolloutBootstrapReplayBatchKeys.remove(oldestKey)
+        }
+        return true
+    }
+
+    private func rolloutBootstrapReplayBatchKey(
+        paramsObject: IncomingParamsObject?,
+        threadId: String
+    ) -> String? {
+        guard let replayId = normalizedIdentifier(paramsObject?["replayId"]?.stringValue) else {
+            return nil
+        }
+
+        let batchIndex = paramsObject?["batchIndex"]?.intValue
+            ?? Int(paramsObject?["batchIndex"]?.stringValue ?? "")
+            ?? 0
+        return "\(threadId)|\(replayId)|\(batchIndex)"
+    }
+
+    private func rolloutBootstrapReplayIsFinalBatch(_ paramsObject: IncomingParamsObject?) -> Bool {
+        let batchIndex = paramsObject?["batchIndex"]?.intValue
+            ?? Int(paramsObject?["batchIndex"]?.stringValue ?? "")
+            ?? 0
+        guard let batchCount = paramsObject?["batchCount"]?.intValue
+            ?? Int(paramsObject?["batchCount"]?.stringValue ?? ""),
+              batchCount > 0 else {
+            return true
+        }
+
+        return batchIndex >= batchCount - 1
+    }
+
+    private func rolloutBootstrapReplayThreadId(
+        paramsObject: IncomingParamsObject?,
+        notifications: [JSONValue]
+    ) -> String? {
+        if let threadId = normalizedIdentifier(paramsObject?["threadId"]?.stringValue) {
+            return threadId
+        }
+
+        for notificationValue in notifications {
+            guard let notification = notificationValue.objectValue,
+                  let params = notification["params"]?.objectValue,
+                  let threadId = resolveThreadID(from: params) else {
+                continue
+            }
+            return threadId
+        }
+        return nil
+    }
+
+    private func applyRolloutBootstrapReplayNotifications(
+        _ notifications: [JSONValue],
+        flushDeferredWork: Bool
+    ) {
+        beginRolloutBootstrapReplayCoalescing()
+        defer {
+            endRolloutBootstrapReplayCoalescing(flushDeferredWork: flushDeferredWork)
+        }
+
+        for notificationValue in notifications {
+            guard let notification = notificationValue.objectValue,
+                  let method = notification["method"]?.stringValue,
+                  method != "remodex/rollout/bootstrapReplay" else {
+                continue
+            }
+            handleNotification(
+                method: normalizedIncomingMethodName(method),
+                params: notification["params"]
+            )
+        }
+    }
+
+    private func beginRolloutBootstrapReplayCoalescing() {
+        rolloutBootstrapReplayCoalescingDepth += 1
+    }
+
+    private func endRolloutBootstrapReplayCoalescing(flushDeferredWork: Bool) {
+        guard rolloutBootstrapReplayCoalescingDepth > 0 else {
+            return
+        }
+
+        rolloutBootstrapReplayCoalescingDepth -= 1
+        guard rolloutBootstrapReplayCoalescingDepth == 0 else {
+            return
+        }
+
+        let threadIDs = rolloutBootstrapReplayDeferredTimelineThreadIDs
+        let syncThreadIDs = rolloutBootstrapReplayDeferredSyncThreadIDs
+        let historyReconcileThreadIDs = rolloutBootstrapReplayDeferredHistoryReconcileThreadIDs
+        let shouldPersistMessages = rolloutBootstrapReplayNeedsMessagePersist
+        rolloutBootstrapReplayDeferredTimelineThreadIDs.removeAll()
+        if flushDeferredWork {
+            rolloutBootstrapReplayDeferredSyncThreadIDs.removeAll()
+            rolloutBootstrapReplayDeferredHistoryReconcileThreadIDs.removeAll()
+        }
+        rolloutBootstrapReplayNeedsMessagePersist = false
+
+        for threadId in threadIDs {
+            let latestAssistantText = syncLatestAssistantOutputCache(for: threadId)
+            refreshThreadTimelineState(for: threadId)
+            if activeThreadId == threadId {
+                currentOutput = latestAssistantText
+            }
+        }
+
+        if shouldPersistMessages {
+            persistMessages()
+        }
+        if flushDeferredWork {
+            for threadId in syncThreadIDs {
+                requestImmediateSync(threadId: threadId)
+            }
+            for threadId in historyReconcileThreadIDs {
+                requestThreadHistoryReconcile(threadId: threadId)
+            }
+        }
+    }
+
+    func cancelRolloutBootstrapReplayWork(for threadId: String) {
+        rolloutBootstrapReplayDeferredTimelineThreadIDs.remove(threadId)
+        rolloutBootstrapReplayDeferredSyncThreadIDs.remove(threadId)
+        rolloutBootstrapReplayDeferredHistoryReconcileThreadIDs.remove(threadId)
+        let keyPrefix = "\(threadId)|"
+        appliedRolloutBootstrapReplayBatchKeyOrder.removeAll { key in
+            if key.hasPrefix(keyPrefix) {
+                appliedRolloutBootstrapReplayBatchKeys.remove(key)
+                return true
+            }
+            return false
+        }
+    }
+
+    func cancelAllRolloutBootstrapReplayWork() {
+        appliedRolloutBootstrapReplayBatchKeys.removeAll()
+        appliedRolloutBootstrapReplayBatchKeyOrder.removeAll()
+        rolloutBootstrapReplayCoalescingDepth = 0
+        rolloutBootstrapReplayNeedsMessagePersist = false
+        rolloutBootstrapReplayDeferredTimelineThreadIDs.removeAll()
+        rolloutBootstrapReplayDeferredSyncThreadIDs.removeAll()
+        rolloutBootstrapReplayDeferredHistoryReconcileThreadIDs.removeAll()
     }
 
     private func noteDesktopMirroredActivityIfNeeded(

--- a/CodexMobile/CodexMobile/Services/CodexService+Messages.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Messages.swift
@@ -20,9 +20,9 @@ private enum StreamingDeltaCoalescingPolicy {
     // them readable without invalidating the timeline on every transport chunk.
     static let flushDelayNanoseconds: UInt64 = 50_000_000
     // Assistant prose gets one quick first paint, then a calmer cadence once text is visible.
-    static let assistantInitialFlushDelayNanoseconds: UInt64 = 50_000_000
-    static let assistantStreamingFlushDelayNanoseconds: UInt64 = 80_000_000
-    static let assistantLargeStreamingFlushDelayNanoseconds: UInt64 = 100_000_000
+    static let assistantInitialFlushDelayNanoseconds: UInt64 = 16_000_000
+    static let assistantStreamingFlushDelayNanoseconds: UInt64 = 40_000_000
+    static let assistantLargeStreamingFlushDelayNanoseconds: UInt64 = 60_000_000
     static let assistantLargePendingDeltaByteCount = 12_000
     static let assistantLargeVisibleTextByteCount = 32_000
 }
@@ -235,6 +235,10 @@ extension CodexService {
     // Refreshes the derived output cache and bumps the thread timeline revision.
     func updateCurrentOutput(for threadId: String) {
         noteMessagesChanged(for: threadId)
+        guard rolloutBootstrapReplayCoalescingDepth == 0 else {
+            rolloutBootstrapReplayDeferredTimelineThreadIDs.insert(threadId)
+            return
+        }
 
         let latestAssistantText = syncLatestAssistantOutputCache(for: threadId)
         refreshThreadTimelineState(for: threadId)
@@ -250,6 +254,10 @@ extension CodexService {
     // Falls back to the full projection path whenever the visible snapshot shape changed underneath us.
     func updateStreamingAssistantOutput(for threadId: String, messageId: String, rawMessageIndex: Int? = nil) {
         noteMessagesChanged(for: threadId)
+        guard rolloutBootstrapReplayCoalescingDepth == 0 else {
+            rolloutBootstrapReplayDeferredTimelineThreadIDs.insert(threadId)
+            return
+        }
 
         // Keep the visible output anchored to the latest assistant bubble, even if a late
         // delta updates an older item inside the same turn.
@@ -2989,6 +2997,16 @@ extension CodexService {
             return
         }
 
+        if adoptDuplicateAssistantDeltaIfNeeded(
+            threadId: threadId,
+            turnId: turnId,
+            itemId: itemId,
+            assistantPhase: assistantPhase,
+            delta: delta
+        ) {
+            return
+        }
+
         let messageID = ensureStreamingAssistantMessage(
             threadId: threadId,
             turnId: turnId,
@@ -3027,6 +3045,69 @@ extension CodexService {
 
         persistMessages()
         updateStreamingAssistantOutput(for: threadId, messageId: messageID, rawMessageIndex: messageIndex)
+    }
+
+    // Desktop live state and rollout history can both publish the same commentary with different item IDs.
+    private func adoptDuplicateAssistantDeltaIfNeeded(
+        threadId: String,
+        turnId: String,
+        itemId: String?,
+        assistantPhase: String?,
+        delta: String
+    ) -> Bool {
+        guard normalizedAssistantPhase(assistantPhase) == "commentary",
+              delta.utf8.count <= MessageTextProcessingPolicy.largeTextByteLimit,
+              let threadMessages = messagesByThread[threadId] else {
+            return false
+        }
+
+        let normalizedDelta = Self.normalizedMessageText(delta)
+        guard Self.hasMeaningfulHistoryText(normalizedDelta) else {
+            return false
+        }
+
+        guard let duplicateIndex = threadMessages.indices.reversed().first(where: { index in
+            let candidate = threadMessages[index]
+            guard candidate.role == .assistant,
+                  candidate.turnId == turnId,
+                  candidate.text.utf8.count <= MessageTextProcessingPolicy.largeTextByteLimit,
+                  Self.normalizedMessageText(candidate.text) == normalizedDelta else {
+                return false
+            }
+
+            let candidatePhase = normalizedAssistantPhase(candidate.assistantPhase)
+            return candidatePhase == "commentary" || candidatePhase == nil
+        }) else {
+            return false
+        }
+
+        let messageID = threadMessages[duplicateIndex].id
+        var didMutate = false
+        if let normalizedItemId = normalizedStreamingItemID(itemId) {
+            let itemKey = assistantStreamingMessageKey(
+                threadId: threadId,
+                turnId: turnId,
+                itemId: normalizedItemId
+            )
+            streamingAssistantMessageByItemKey[itemKey] = messageID
+            if messagesByThread[threadId]?[duplicateIndex].itemId == nil {
+                messagesByThread[threadId]?[duplicateIndex].itemId = normalizedItemId
+                didMutate = true
+            }
+        }
+        if applyAssistantPhaseIfNeeded(
+            threadId: threadId,
+            messageIndex: duplicateIndex,
+            assistantPhase: assistantPhase
+        ) {
+            didMutate = true
+        }
+
+        if didMutate {
+            persistMessages()
+            updateStreamingAssistantOutput(for: threadId, messageId: messageID, rawMessageIndex: duplicateIndex)
+        }
+        return true
     }
 
     // Late replay deltas for a closed turn should patch the closed assistant row, not reopen streaming.
@@ -4226,6 +4307,11 @@ extension CodexService {
 
 extension CodexService {
     func persistMessages() {
+        guard rolloutBootstrapReplayCoalescingDepth == 0 else {
+            rolloutBootstrapReplayNeedsMessagePersist = true
+            return
+        }
+
         messagePersistenceDebounceTask?.cancel()
         messagePersistenceDebounceTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 250_000_000)
@@ -4522,6 +4608,11 @@ extension CodexService {
 
     // Rebuilds one thread's render snapshot from service-owned caches after any timeline mutation.
     func refreshThreadTimelineState(for threadId: String) {
+        guard rolloutBootstrapReplayCoalescingDepth == 0 else {
+            rolloutBootstrapReplayDeferredTimelineThreadIDs.insert(threadId)
+            return
+        }
+
         let state = timelineState(for: threadId)
         let messages = messagesByThread[threadId] ?? []
         let revision = messageRevisionByThread[threadId] ?? 0

--- a/CodexMobile/CodexMobile/Services/CodexService+SecureTransport.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+SecureTransport.swift
@@ -386,64 +386,36 @@ extension CodexService {
             throw CodexSecureTransportError.invalidQR("Enter a valid pairing code.")
         }
 
-        guard let relayURL = preferredPairingCodeRelayURL,
-              let resolveURL = pairingCodeResolveURL(from: relayURL) else {
+        guard let relayURL = preferredPairingCodeRelayURL else {
             throw CodexSecureTransportError.invalidQR(
                 "This iPhone does not know which relay to ask for that pairing code yet. Scan the QR code instead."
             )
         }
 
-        var request = URLRequest(url: resolveURL)
-        request.httpMethod = "POST"
-        request.timeoutInterval = 8
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONEncoder().encode(["code": normalizedCode])
-
-        let session = trustedSessionResolveURLSession(for: resolveURL)
-        defer { session.invalidateAndCancel() }
-
-        let data: Data
-        let response: URLResponse
-        do {
-            (data, response) = try await session.data(for: request)
-        } catch is CancellationError {
-            throw CancellationError()
-        } catch {
-            throw CodexSecureTransportError.invalidQR("Could not reach the relay for this pairing code. Try again or scan the QR code.")
+        let resolveURLs = CodexPairingCodeResolveURLBuilder.candidates(from: relayURL)
+        guard !resolveURLs.isEmpty else {
+            throw CodexSecureTransportError.invalidQR("The relay URL for pairing codes is invalid.")
         }
 
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CodexSecureTransportError.invalidQR("The relay returned an invalid response for this pairing code.")
-        }
-
-        if (200..<300).contains(httpResponse.statusCode),
-           let resolved = try? JSONDecoder().decode(CodexPairingCodeResolveResponse.self, from: data),
-           resolved.ok {
-            return CodexPairingQRPayload(
-                v: resolved.v,
-                relay: relayURL,
-                sessionId: resolved.sessionId,
-                macDeviceId: resolved.macDeviceId,
-                macIdentityPublicKey: resolved.macIdentityPublicKey,
-                expiresAt: resolved.expiresAt,
-                displayName: resolved.displayName
-            )
-        }
-
-        let errorResponse = try? JSONDecoder().decode(CodexRelayErrorResponse.self, from: data)
-        switch errorResponse?.code {
-        case "pairing_code_expired":
-            throw CodexSecureTransportError.invalidQR("This pairing code has expired. Generate a new one from the Mac bridge.")
-        case "pairing_code_unavailable":
-            throw CodexSecureTransportError.invalidQR("That pairing code is not available right now. Make sure your Mac bridge is running and try again.")
-        default:
-            if httpResponse.statusCode == 404 {
-                throw CodexSecureTransportError.invalidQR("This relay does not support pairing codes yet. Scan the QR code instead.")
+        var lastRetriableError: CodexSecureTransportError?
+        for (index, resolveURL) in resolveURLs.enumerated() {
+            do {
+                return try await sendPairingCodeResolveRequest(
+                    code: normalizedCode,
+                    relayURL: relayURL,
+                    resolveURL: resolveURL
+                )
+            } catch let error as CodexSecureTransportError {
+                guard shouldTryNextPairingCodeResolveCandidate(after: error),
+                      index < resolveURLs.count - 1 else {
+                    throw error
+                }
+                lastRetriableError = error
+                continue
             }
-            throw CodexSecureTransportError.invalidQR(
-                errorResponse?.error ?? "The relay could not resolve that pairing code."
-            )
         }
+
+        throw lastRetriableError ?? CodexSecureTransportError.invalidQR("The relay could not resolve that pairing code.")
     }
 }
 
@@ -793,45 +765,77 @@ extension CodexService {
 enum CodexTrustedSessionResolveURLBuilder {
     // Builds both proxy-relative and root HTTP resolve routes from the remembered WebSocket relay URL.
     static func candidates(from relayURL: String) -> [URL] {
-        guard var components = URLComponents(string: relayURL) else {
-            return []
-        }
+        relayResolveCandidates(
+            from: relayURL,
+            route: ["v1", "trusted", "session", "resolve"],
+            includePathPreservingRoute: false
+        )
+    }
+}
 
-        normalizeRelayResolveComponents(&components)
+enum CodexPairingCodeResolveURLBuilder {
+    // Tries path-preserving, proxy-stripped, and root resolve routes without exposing the relay URL in UI errors.
+    static func candidates(from relayURL: String) -> [URL] {
+        relayResolveCandidates(
+            from: relayURL,
+            route: ["v1", "pairing", "code", "resolve"],
+            includePathPreservingRoute: true
+        )
+    }
+}
 
-        var candidates: [URL] = []
-        let pathComponents = components.path.split(separator: "/").map(String.init)
-        if pathComponents.last == "relay" {
-            let prefix = pathComponents.dropLast()
-            components.path = "/" + (prefix + ["v1", "trusted", "session", "resolve"]).joined(separator: "/")
-        } else {
-            components.path = "/v1/trusted/session/resolve"
-        }
-        if let url = components.url {
-            candidates.append(url)
-        }
-
-        if var rootComponents = URLComponents(string: relayURL) {
-            normalizeRelayResolveComponents(&rootComponents)
-            rootComponents.path = "/v1/trusted/session/resolve"
-            if let rootURL = rootComponents.url,
-               !candidates.contains(where: { $0.absoluteString == rootURL.absoluteString }) {
-                candidates.append(rootURL)
-            }
-        }
-
-        return candidates
+private func relayResolveCandidates(
+    from relayURL: String,
+    route: [String],
+    includePathPreservingRoute: Bool
+) -> [URL] {
+    guard var components = URLComponents(string: relayURL) else {
+        return []
     }
 
-    private static func normalizeRelayResolveComponents(_ components: inout URLComponents) {
-        if components.scheme == "wss" {
-            components.scheme = "https"
-        } else if components.scheme == "ws" {
-            components.scheme = "http"
-        }
-        components.query = nil
-        components.fragment = nil
+    normalizeRelayResolveComponents(&components)
+
+    var candidates: [URL] = []
+    let pathComponents = components.path.split(separator: "/").map(String.init)
+
+    if includePathPreservingRoute, !pathComponents.isEmpty {
+        var preservingComponents = components
+        preservingComponents.path = "/" + (pathComponents + route).joined(separator: "/")
+        appendUniqueURL(preservingComponents.url, to: &candidates)
     }
+
+    var proxyComponents = components
+    if pathComponents.last == "relay" {
+        let prefix = pathComponents.dropLast()
+        proxyComponents.path = "/" + (prefix + route).joined(separator: "/")
+    } else {
+        proxyComponents.path = "/" + route.joined(separator: "/")
+    }
+    appendUniqueURL(proxyComponents.url, to: &candidates)
+
+    var rootComponents = components
+    rootComponents.path = "/" + route.joined(separator: "/")
+    appendUniqueURL(rootComponents.url, to: &candidates)
+
+    return candidates
+}
+
+private func normalizeRelayResolveComponents(_ components: inout URLComponents) {
+    if components.scheme == "wss" {
+        components.scheme = "https"
+    } else if components.scheme == "ws" {
+        components.scheme = "http"
+    }
+    components.query = nil
+    components.fragment = nil
+}
+
+private func appendUniqueURL(_ url: URL?, to candidates: inout [URL]) {
+    guard let url,
+          !candidates.contains(where: { $0.absoluteString == url.absoluteString }) else {
+        return
+    }
+    candidates.append(url)
 }
 
 private extension CodexService {
@@ -1200,26 +1204,70 @@ private extension CodexService {
         return defaultRelayURL.isEmpty ? nil : defaultRelayURL
     }
 
-    private func pairingCodeResolveURL(from relayURL: String) -> URL? {
-        guard var components = URLComponents(string: relayURL) else {
-            return nil
+    private func sendPairingCodeResolveRequest(
+        code: String,
+        relayURL: String,
+        resolveURL: URL
+    ) async throws -> CodexPairingQRPayload {
+        var request = URLRequest(url: resolveURL)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 8
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(["code": code])
+
+        let session = trustedSessionResolveURLSession(for: resolveURL)
+        defer { session.invalidateAndCancel() }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw CodexSecureTransportError.invalidQR("Could not reach the relay for this pairing code. Try again or scan the QR code.")
         }
 
-        if components.scheme == "wss" {
-            components.scheme = "https"
-        } else if components.scheme == "ws" {
-            components.scheme = "http"
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CodexSecureTransportError.invalidQR("The relay returned an invalid response for this pairing code.")
         }
 
-        let pathComponents = components.path.split(separator: "/").map(String.init)
-        if pathComponents.last == "relay" {
-            let prefix = pathComponents.dropLast()
-            components.path = "/" + (prefix + ["v1", "pairing", "code", "resolve"]).joined(separator: "/")
-        } else {
-            components.path = "/v1/pairing/code/resolve"
+        if (200..<300).contains(httpResponse.statusCode),
+           let resolved = try? JSONDecoder().decode(CodexPairingCodeResolveResponse.self, from: data),
+           resolved.ok {
+            return CodexPairingQRPayload(
+                v: resolved.v,
+                relay: relayURL,
+                sessionId: resolved.sessionId,
+                macDeviceId: resolved.macDeviceId,
+                macIdentityPublicKey: resolved.macIdentityPublicKey,
+                expiresAt: resolved.expiresAt,
+                displayName: resolved.displayName
+            )
         }
 
-        return components.url
+        let errorResponse = try? JSONDecoder().decode(CodexRelayErrorResponse.self, from: data)
+        switch errorResponse?.code {
+        case "pairing_code_expired":
+            throw CodexSecureTransportError.invalidQR("This pairing code has expired. Generate a new one from the Mac bridge.")
+        case "pairing_code_unavailable":
+            throw CodexSecureTransportError.invalidQR("That pairing code is not available right now. Make sure your Mac bridge is running and try again.")
+        default:
+            if httpResponse.statusCode == 404 {
+                throw CodexSecureTransportError.invalidQR("This relay does not support pairing codes yet. Scan the QR code instead.")
+            }
+            throw CodexSecureTransportError.invalidQR(
+                errorResponse?.error ?? "The relay could not resolve that pairing code."
+            )
+        }
+    }
+
+    private func shouldTryNextPairingCodeResolveCandidate(after error: CodexSecureTransportError) -> Bool {
+        guard case .invalidQR(let message) = error else {
+            return false
+        }
+        return message == "This relay does not support pairing codes yet. Scan the QR code instead."
+            || message == "Could not reach the relay for this pairing code. Try again or scan the QR code."
     }
 
     // Uses a non-proxying URLSession for local/private-overlay relays so trusted reconnect

--- a/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
@@ -130,6 +130,12 @@ extension CodexService {
         guard canRunRealtimeSyncLoop else {
             return
         }
+        guard rolloutBootstrapReplayCoalescingDepth == 0 else {
+            if let threadId = threadId ?? activeThreadId {
+                rolloutBootstrapReplayDeferredSyncThreadIDs.insert(threadId)
+            }
+            return
+        }
 
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -161,6 +167,10 @@ extension CodexService {
     // Re-reads canonical history after terminal/open events so missed bridge-live rows can be repaired.
     func requestThreadHistoryReconcile(threadId: String, delayNanoseconds: UInt64 = 250_000_000) {
         guard canRunRealtimeSyncLoop else {
+            return
+        }
+        guard rolloutBootstrapReplayCoalescingDepth == 0 else {
+            rolloutBootstrapReplayDeferredHistoryReconcileThreadIDs.insert(threadId)
             return
         }
 
@@ -627,6 +637,7 @@ extension CodexService {
         turnStateRefreshTaskByThreadID.removeValue(forKey: threadId)
         runningThreadCatchupTaskByThreadID[threadId]?.cancel()
         runningThreadCatchupTaskByThreadID.removeValue(forKey: threadId)
+        cancelRolloutBootstrapReplayWork(for: threadId)
         forcedRunningCatchupEscalationThreadIDs.remove(threadId)
         lastForcedRunningResumeAtByThread.removeValue(forKey: threadId)
         canonicalHistoryReconcileRetryTaskByThreadID[threadId]?.cancel()
@@ -660,6 +671,7 @@ extension CodexService {
         turnStateRefreshTaskByThreadID.removeAll()
         runningThreadCatchupTaskByThreadID.values.forEach { $0.cancel() }
         runningThreadCatchupTaskByThreadID.removeAll()
+        cancelAllRolloutBootstrapReplayWork()
         forcedRunningCatchupEscalationThreadIDs.removeAll()
         lastForcedRunningResumeAtByThread.removeAll()
         workspaceCheckpointCopyTaskByTurnID.values.forEach { $0.cancel() }

--- a/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
@@ -1243,6 +1243,11 @@ extension CodexService {
                         markTurnPaginationUnsupportedForCurrentRuntime()
                         didRequestExcludedTurns = false
                     }
+                    let historyTerminalStates = decodeTurnTerminalStatesFromThreadRead(threadObject)
+                    let didUpdateTerminalStates = mergeHistoryTurnTerminalStates(
+                        threadId: threadId,
+                        terminalStatesByTurnID: historyTerminalStates
+                    )
                     let historyMessages = decodeMessagesFromThreadRead(threadId: threadId, threadObject: threadObject)
                     registerSubagentThreads(from: historyMessages, parentThreadId: threadId)
                     if !historyMessages.isEmpty {
@@ -1286,12 +1291,16 @@ extension CodexService {
                             messagesByThread[threadId] = merged
                             persistMessages()
                             updateCurrentOutput(for: threadId)
+                        } else if didUpdateTerminalStates {
+                            refreshThreadTimelineState(for: threadId)
                         }
                         if usedRecentWindow, !threadHasActiveOrRunningTurn(threadId) {
                             scheduleCanonicalHistoryReconcileIfNeeded(for: threadId)
                         } else if !threadHasActiveOrRunningTurn(threadId) {
                             markThreadCanonicalHistoryReconciled(threadId)
                         }
+                    } else if didUpdateTerminalStates {
+                        refreshThreadTimelineState(for: threadId)
                     }
                 }
             } else if let index = threadIndex(for: threadId) {
@@ -2661,7 +2670,16 @@ extension CodexService {
         }
 
         let message = rpcError.message.lowercased()
-        guard message.contains("image_url") else {
+        let mentionsImageURLField = message.contains("image_url")
+        let rejectsURLField = message.contains("url")
+            && (
+                message.contains("unknown field")
+                    || message.contains("unexpected field")
+                    || message.contains("unrecognized field")
+                    || message.contains("invalid field")
+            )
+
+        guard mentionsImageURLField || rejectsURLField else {
             return false
         }
 

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -542,6 +542,14 @@ final class CodexService {
     @ObservationIgnored var turnStateRefreshTaskByThreadID: [String: Task<Bool, Never>] = [:]
     // Coalesces the full running-thread catch-up pipeline so open/foreground/reconnect share one path.
     @ObservationIgnored var runningThreadCatchupTaskByThreadID: [String: Task<RunningThreadCatchupOutcome, Never>] = [:]
+    // Tracks rollout bootstrap batches so desktop catch-up can stay compact without duplicate replay.
+    @ObservationIgnored var appliedRolloutBootstrapReplayBatchKeys: Set<String> = []
+    @ObservationIgnored var appliedRolloutBootstrapReplayBatchKeyOrder: [String] = []
+    @ObservationIgnored var rolloutBootstrapReplayCoalescingDepth = 0
+    @ObservationIgnored var rolloutBootstrapReplayNeedsMessagePersist = false
+    @ObservationIgnored var rolloutBootstrapReplayDeferredTimelineThreadIDs: Set<String> = []
+    @ObservationIgnored var rolloutBootstrapReplayDeferredSyncThreadIDs: Set<String> = []
+    @ObservationIgnored var rolloutBootstrapReplayDeferredHistoryReconcileThreadIDs: Set<String> = []
     // Lets a late foreground/open caller upgrade an in-flight running catch-up into a forced resume.
     @ObservationIgnored var forcedRunningCatchupEscalationThreadIDs: Set<String> = []
     // Invalidates stale async completions after archive/delete/reconnect tears refresh work down.

--- a/CodexMobile/CodexMobile/Views/AboutRemodexView.swift
+++ b/CodexMobile/CodexMobile/Views/AboutRemodexView.swift
@@ -6,44 +6,35 @@
 import SwiftUI
 
 struct AboutRemodexView: View {
-    @Environment(\.dismiss) private var dismiss
-
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 36) {
-                    header
-                    howItWorksSection
-                    Divider().opacity(0.3)
-                    architectureDiagram
-                    Divider().opacity(0.3)
-                    relaySection
-                    Divider().opacity(0.3)
-                    appServerSection
-                    Divider().opacity(0.3)
-                    pairingSection
-                    Divider().opacity(0.3)
-                    encryptionSection
-                    Divider().opacity(0.3)
-                    gitSection
-                    Divider().opacity(0.3)
-                    resilienceSection
-                    Divider().opacity(0.3)
-                    desktopSection
-                    footer
-                }
-                .padding(.horizontal, 20)
-                .padding(.bottom, 40)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 36) {
+                header
+                howItWorksSection
+                Divider().opacity(0.3)
+                architectureDiagram
+                Divider().opacity(0.3)
+                relaySection
+                Divider().opacity(0.3)
+                appServerSection
+                Divider().opacity(0.3)
+                pairingSection
+                Divider().opacity(0.3)
+                encryptionSection
+                Divider().opacity(0.3)
+                gitSection
+                Divider().opacity(0.3)
+                resilienceSection
+                Divider().opacity(0.3)
+                desktopSection
+                footer
             }
-            .font(AppFont.body())
-            .navigationTitle("About Remodex")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Done") { dismiss() }
-                }
-            }
+            .padding(.horizontal, 20)
+            .padding(.bottom, 40)
         }
+        .font(AppFont.body())
+        .navigationTitle("About Remodex")
+        .navigationBarTitleDisplayMode(.inline)
     }
 
     // MARK: - Header
@@ -405,5 +396,7 @@ struct AboutRemodexView: View {
 }
 
 #Preview {
-    AboutRemodexView()
+    NavigationStack {
+        AboutRemodexView()
+    }
 }

--- a/CodexMobile/CodexMobile/Views/Settings/SettingsCommandReferenceCard.swift
+++ b/CodexMobile/CodexMobile/Views/Settings/SettingsCommandReferenceCard.swift
@@ -1,0 +1,89 @@
+// FILE: SettingsCommandReferenceCard.swift
+// Purpose: Shows the local Remodex CLI commands users may need while pairing or managing the Mac bridge.
+// Layer: Settings UI component
+// Exports: SettingsCommandReferenceCard
+// Depends on: SwiftUI, SettingsBaseComponents
+
+import SwiftUI
+
+struct SettingsCommandReferenceCard: View {
+    private let commands = [
+        SettingsCommandReference(
+            command: "remodex up",
+            detail: "Starts Remodex on your Mac, refreshes the bridge service, and prints a pairing QR for first-time setup or recovery."
+        ),
+        SettingsCommandReference(
+            command: "remodex start",
+            detail: "Starts the background bridge service without printing a QR in the current Terminal window."
+        ),
+        SettingsCommandReference(
+            command: "remodex restart",
+            detail: "Restarts the background bridge service when the Mac is paired but the app cannot reconnect cleanly."
+        ),
+        SettingsCommandReference(
+            command: "remodex qr / remodex pair",
+            detail: "Refreshes the bridge and prints a new QR code so this iPhone can scan and trust the Mac again."
+        ),
+        SettingsCommandReference(
+            command: "remodex status",
+            detail: "Shows whether the Mac bridge service is loaded and whether a recent pairing payload is available."
+        ),
+        SettingsCommandReference(
+            command: "remodex stop",
+            detail: "Stops the background bridge service on your Mac and clears its transient runtime status."
+        ),
+        SettingsCommandReference(
+            command: "remodex reset-pairing",
+            detail: "Clears saved pairing trust so the next connection requires a fresh QR scan."
+        ),
+        SettingsCommandReference(
+            command: "remodex resume",
+            detail: "Reopens the last active Remodex thread in Codex on your Mac."
+        ),
+        SettingsCommandReference(
+            command: "remodex watch [threadId]",
+            detail: "Tails a thread event log in real time from Terminal."
+        ),
+        SettingsCommandReference(
+            command: "remodex --version",
+            detail: "Prints the installed Remodex CLI version."
+        )
+    ]
+
+    var body: some View {
+        SettingsCard(title: "Mac commands") {
+            Text("Run these in Terminal on your paired Mac when you need to start, repair, or inspect the local Remodex bridge.")
+                .font(AppFont.caption())
+                .foregroundStyle(.secondary)
+
+            ForEach(commands) { command in
+                SettingsCommandReferenceRow(command: command)
+            }
+        }
+    }
+}
+
+private struct SettingsCommandReference: Identifiable {
+    let command: String
+    let detail: String
+
+    var id: String { command }
+}
+
+private struct SettingsCommandReferenceRow: View {
+    let command: SettingsCommandReference
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(command.command)
+                .font(AppFont.mono(.caption))
+                .foregroundStyle(.primary)
+
+            Text(command.detail)
+                .font(AppFont.caption())
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/CodexMobile/CodexMobile/Views/Settings/SettingsConnectionCard.swift
+++ b/CodexMobile/CodexMobile/Views/Settings/SettingsConnectionCard.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 struct SettingsConnectionCard: View {
     @Environment(CodexService.self) private var codex
-    @State private var isShowingComputerNameSheet = false
+    let onEditComputerName: () -> Void
 
     var body: some View {
         SettingsCard(title: "Connection") {
@@ -16,9 +16,7 @@ struct SettingsConnectionCard: View {
                 SettingsTrustedComputerCard(
                     presentation: trustedPairPresentation,
                     connectionStatusLabel: connectionStatusLabel,
-                    onEditName: {
-                        isShowingComputerNameSheet = true
-                    }
+                    onEditName: onEditComputerName
                 )
             } else {
                 Text("No paired device")
@@ -75,15 +73,6 @@ struct SettingsConnectionCard: View {
                     HapticFeedback.shared.triggerImpactFeedback()
                     codex.forgetTrustedMac()
                 }
-            }
-        }
-        .sheet(isPresented: $isShowingComputerNameSheet) {
-            if let trustedPairPresentation = codex.trustedPairPresentation {
-                SettingsComputerNameSheet(
-                    nickname: sidebarComputerNicknameBinding(for: trustedPairPresentation),
-                    currentName: trustedPairPresentation.name,
-                    systemName: trustedPairPresentation.systemName ?? trustedPairPresentation.name
-                )
             }
         }
     }
@@ -146,11 +135,4 @@ struct SettingsConnectionCard: View {
         }
     }
 
-    // Writes nicknames against the active trusted computer so switching pairs does not reuse the wrong alias.
-    private func sidebarComputerNicknameBinding(for presentation: CodexTrustedPairPresentation) -> Binding<String> {
-        Binding(
-            get: { SidebarComputerNicknameStore.nickname(for: presentation.deviceId) },
-            set: { SidebarComputerNicknameStore.setNickname($0, for: presentation.deviceId) }
-        )
-    }
 }

--- a/CodexMobile/CodexMobile/Views/Settings/SettingsSupportCards.swift
+++ b/CodexMobile/CodexMobile/Views/Settings/SettingsSupportCards.swift
@@ -8,25 +8,28 @@ import SwiftUI
 import UIKit
 
 struct SettingsAboutCard: View {
-    @State private var isShowingAbout = false
-
     var body: some View {
         SettingsCard(title: "About") {
             Text("Chats are End-to-end encrypted between your iPhone and paired device. The relay only sees ciphertext and connection metadata after the secure handshake completes.")
                 .font(AppFont.caption())
                 .foregroundStyle(.secondary)
 
-            Button {
-                HapticFeedback.shared.triggerImpactFeedback(style: .light)
-                isShowingAbout = true
+            // Keep About inside the Settings navigation stack so List row refreshes
+            // cannot dismiss a nested full-screen cover back to the app root.
+            NavigationLink {
+                AboutRemodexView()
             } label: {
                 settingsAccessoryRow(
                     title: "How Remodex Works",
+                    showsDisclosure: false,
                     leading: {
                         RemodexIcon.image(systemName: "info.circle")
                     }
                 )
             }
+            .simultaneousGesture(TapGesture().onEnded {
+                HapticFeedback.shared.triggerImpactFeedback(style: .light)
+            })
 
             Button {
                 HapticFeedback.shared.triggerImpactFeedback(style: .light)
@@ -70,15 +73,13 @@ struct SettingsAboutCard: View {
                 )
             }
         }
-        .fullScreenCover(isPresented: $isShowingAbout) {
-            AboutRemodexView()
-        }
     }
 
     // Mimics a native disclosure-style List row while supporting both
     // SF Symbols and custom asset icons in the leading slot.
     private func settingsAccessoryRow<Leading: View>(
         title: String,
+        showsDisclosure: Bool = true,
         @ViewBuilder leading: () -> Leading
     ) -> some View {
         HStack(spacing: 12) {
@@ -86,9 +87,11 @@ struct SettingsAboutCard: View {
                 .frame(width: 22, alignment: .center)
             Text(title)
             Spacer()
-            RemodexIcon.image(systemName: "chevron.right")
-                .font(AppFont.caption(weight: .semibold))
-                .foregroundStyle(.tertiary)
+            if showsDisclosure {
+                RemodexIcon.image(systemName: "chevron.right")
+                    .font(AppFont.caption(weight: .semibold))
+                    .foregroundStyle(.tertiary)
+            }
         }
         .foregroundStyle(.primary)
         .contentShape(Rectangle())

--- a/CodexMobile/CodexMobile/Views/Settings/SettingsView.swift
+++ b/CodexMobile/CodexMobile/Views/Settings/SettingsView.swift
@@ -6,8 +6,18 @@
 import SwiftUI
 import UIKit
 
+private struct SettingsComputerNamePresentation: Identifiable {
+    let deviceId: String?
+    let currentName: String
+    let systemName: String
+
+    var id: String { deviceId ?? currentName }
+}
+
 struct SettingsView: View {
+    @Environment(CodexService.self) private var codex
     @AppStorage("codex.appFontStyle") private var appFontStyleRawValue = AppFont.defaultStoredStyleRawValue
+    @State private var computerNamePresentation: SettingsComputerNamePresentation?
 
     var body: some View {
         List {
@@ -18,21 +28,54 @@ struct SettingsView: View {
             SettingsGPTAccountCard()
             SettingsSubscriptionCard()
             SettingsBridgeVersionCard()
+            SettingsCommandReferenceCard()
             SettingsRuntimeDefaultsCard()
             SettingsAboutCard()
             SettingsUsageCard()
-            SettingsConnectionCard()
+            SettingsConnectionCard {
+                presentComputerNameSheet()
+            }
         }
         .listStyle(.insetGrouped)
         .font(AppFont.body())
         .tint(.primary)
         .navigationTitle("Settings")
+        // Own settings modals from the stable screen root; List rows can be
+        // rebuilt while connection status changes and should not own sheets.
+        .sheet(item: $computerNamePresentation) { presentation in
+            SettingsComputerNameSheet(
+                nickname: sidebarComputerNicknameBinding(for: presentation.deviceId),
+                currentName: presentation.currentName,
+                systemName: presentation.systemName
+            )
+        }
     }
 
     private var appFontStyleBinding: Binding<AppFont.Style> {
         Binding(
             get: { AppFont.Style(rawValue: appFontStyleRawValue) ?? AppFont.defaultStyle },
             set: { appFontStyleRawValue = $0.rawValue }
+        )
+    }
+
+    // Captures the visible device details before presenting so reconnect updates cannot dismiss the editor.
+    private func presentComputerNameSheet() {
+        guard let trustedPairPresentation = codex.trustedPairPresentation else {
+            return
+        }
+
+        computerNamePresentation = SettingsComputerNamePresentation(
+            deviceId: trustedPairPresentation.deviceId,
+            currentName: trustedPairPresentation.name,
+            systemName: trustedPairPresentation.systemName ?? trustedPairPresentation.name
+        )
+    }
+
+    // Writes nicknames against the tapped trusted computer so switching pairs does not reuse the wrong alias.
+    private func sidebarComputerNicknameBinding(for deviceId: String?) -> Binding<String> {
+        Binding(
+            get: { SidebarComputerNicknameStore.nickname(for: deviceId) },
+            set: { SidebarComputerNicknameStore.setNickname($0, for: deviceId) }
         )
     }
 }

--- a/CodexMobile/CodexMobile/Views/Shared/UsageStatusSummaryContent.swift
+++ b/CodexMobile/CodexMobile/Views/Shared/UsageStatusSummaryContent.swift
@@ -82,7 +82,7 @@ struct UsageStatusSummaryContent: View {
 
                     Spacer(minLength: 12)
 
-                    if isLoadingRateLimits {
+                    if isLoadingRateLimits && refreshControl?.isRefreshing != true {
                         ProgressView()
                             .controlSize(.small)
                     }

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/FileAutocompletePanel.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/FileAutocompletePanel.swift
@@ -17,7 +17,8 @@ struct FileAutocompletePanel: View {
     var onSelectPlugin: (CodexPluginMetadata) -> Void = { _ in }
 
     private static let rowHeight: CGFloat = 38
-    private static let maxVisibleRows = 6
+    // Keep the floating composer menu compact above the iOS keyboard.
+    private static let maxVisibleRows = 4
     private static let sectionHeaderHeight: CGFloat = 24
 
     private static func visibleListHeight(for count: Int) -> CGFloat {

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/SkillAutocompletePanel.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/SkillAutocompletePanel.swift
@@ -14,7 +14,8 @@ struct SkillAutocompletePanel: View {
     let onSelect: (CodexSkillMetadata) -> Void
 
     private static let rowHeight: CGFloat = 50
-    private static let maxVisibleRows = 6
+    // Keep the floating composer menu compact above the iOS keyboard.
+    private static let maxVisibleRows = 4
 
     private static func visibleListHeight(for count: Int) -> CGFloat {
         rowHeight * CGFloat(min(count, maxVisibleRows))

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/SlashCommandAutocompletePanel.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/SlashCommandAutocompletePanel.swift
@@ -22,7 +22,8 @@ struct SlashCommandAutocompletePanel: View {
     let onClose: () -> Void
 
     private static let rowHeight: CGFloat = 50
-    private static let maxVisibleRows = 6
+    // Keep the floating composer menu compact above the iOS keyboard.
+    private static let maxVisibleRows = 4
 
     private static func visibleListHeight(for count: Int) -> CGFloat {
         rowHeight * CGFloat(min(count, maxVisibleRows))

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerCollapsibleContextCluster.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerCollapsibleContextCluster.swift
@@ -168,14 +168,16 @@ struct TurnComposerCollapsibleContextCluster: View {
     }
 }
 
-// Scale-from-leading makes the pills appear to grow out of (and collapse back
-// into) the chevron rather than sliding from the screen edge. Because the
-// pills are conditionally rendered, the Menu hosting view is destroyed between
-// states, so the earlier scaleEffect glitch (half-rendered label) cannot
-// re-appear.
+// Scale-from-leading makes the pills appear to grow out of the chevron, while
+// removal fades in place to avoid the row visually sliding across the composer.
+// Because the pills are conditionally rendered, the Menu hosting view is
+// destroyed between states, so the earlier scaleEffect glitch cannot re-appear.
 private extension AnyTransition {
     static var contextClusterReveal: AnyTransition {
-        .scale(scale: 0, anchor: .leading).combined(with: .opacity)
+        .asymmetric(
+            insertion: .scale(scale: 0, anchor: .leading).combined(with: .opacity),
+            removal: .opacity
+        )
     }
 }
 

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerHostView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerHostView.swift
@@ -15,6 +15,7 @@ struct TurnComposerHostView: View {
     let isThreadRunning: Bool
     let isEmptyThread: Bool
     let isWorktreeProject: Bool
+    var activeFileChangeStatus: FileChangeStatusSnapshot? = nil
     let canForkLocally: Bool
     let isInputFocused: Binding<Bool>
     let orderedModelOptions: [CodexModelOption]
@@ -129,6 +130,7 @@ struct TurnComposerHostView: View {
             isEmptyThread: isEmptyThread,
             hasWorkingDirectory: hasComposerWorkingDirectory,
             isWorktreeProject: isWorktreeProject,
+            activeFileChangeStatus: activeFileChangeStatus,
             orderedModelOptions: orderedModelOptions,
             selectedModelID: selectedModelID,
             selectedModelTitle: selectedModelTitle,

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerInputTextView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerInputTextView.swift
@@ -58,16 +58,17 @@ struct TurnComposerInputTextView: UIViewRepresentable {
         let currentFont = uiView.font
         let fontChanged = currentFont?.fontName != nextFont.fontName
             || abs((currentFont?.pointSize ?? 0) - nextFont.pointSize) > 0.5
-        let textChanged = uiView.text != text
-        if textChanged {
-            uiView.text = text
-        }
-
         context.coordinator.updateBindings(
             text: $text,
             isFocused: $isFocused,
             dynamicHeight: $dynamicHeight
         )
+        let shouldApplyBindingText = context.coordinator.shouldApplyBindingText(text, to: uiView)
+        let textChanged = shouldApplyBindingText && uiView.text != text
+        if textChanged {
+            uiView.text = text
+            context.coordinator.noteAppliedBindingText(text)
+        }
         let shouldDeferEditabilityLock = !isEditable && uiView.isEditable && uiView.isFirstResponder
         if !shouldDeferEditabilityLock {
             uiView.isEditable = isEditable
@@ -129,6 +130,8 @@ struct TurnComposerInputTextView: UIViewRepresentable {
         private var isHeightCommitScheduled = false
         private var lastHeightMeasurementSignature: HeightMeasurementSignature?
         private var lastIsEditable: Bool
+        private var pendingUIKitText: String?
+        private var staleBindingTextDuringPendingEdit: String?
 
         init(
             text: Binding<String>,
@@ -159,16 +162,44 @@ struct TurnComposerInputTextView: UIViewRepresentable {
         func textViewDidChange(_ textView: UITextView) {
             let newText = textView.text ?? ""
             if text.wrappedValue != newText {
+                pendingUIKitText = newText
+                staleBindingTextDuringPendingEdit = text.wrappedValue
+                let targetText = text
                 // Defer the binding write out of UIKit's edit transaction to avoid
                 // AttributeGraph cycles.
                 DispatchQueue.main.async { [weak self] in
                     guard let self else { return }
-                    if self.text.wrappedValue != newText {
-                        self.text.wrappedValue = newText
+                    guard self.pendingUIKitText == newText else { return }
+                    if targetText.wrappedValue != newText {
+                        targetText.wrappedValue = newText
                     }
+                    self.pendingUIKitText = nil
+                    self.staleBindingTextDuringPendingEdit = nil
                 }
             }
             updateHeightIfNeeded(for: textView, force: true)
+        }
+
+        // Prevents SwiftUI re-renders from writing an older binding value over
+        // fresh UIKit edits while the deferred binding update is still queued.
+        fileprivate func shouldApplyBindingText(_ bindingText: String, to textView: UITextView) -> Bool {
+            guard
+                textView.isFirstResponder,
+                let pendingUIKitText,
+                textView.text == pendingUIKitText,
+                bindingText == staleBindingTextDuringPendingEdit
+            else {
+                return true
+            }
+            return false
+        }
+
+        fileprivate func noteAppliedBindingText(_ bindingText: String) {
+            guard pendingUIKitText != nil else { return }
+            if bindingText != pendingUIKitText || bindingText == staleBindingTextDuringPendingEdit {
+                pendingUIKitText = nil
+                staleBindingTextDuringPendingEdit = nil
+            }
         }
 
         func textViewDidBeginEditing(_ textView: UITextView) {
@@ -202,12 +233,10 @@ struct TurnComposerInputTextView: UIViewRepresentable {
                 textLayoutManager.ensureLayout(for: textLayoutManager.documentRange)
             }
             let lineHeight = (textView.font ?? UIFont.preferredFont(forTextStyle: .body)).lineHeight
+            let minHeight = lineHeight * minVisibleLines
+            let maxHeight = lineHeight * maxVisibleLines
             let targetWidth = max(textView.bounds.width, textView.textContainer.size.width, 1)
             let fitSize = CGSize(width: targetWidth, height: .greatestFiniteMagnitude)
-            let viewportPadding = (textView as? TurnComposerPasteInterceptingTextView)?
-                .viewportPaddingBeyondLineHeight(targetWidth: targetWidth) ?? 0
-            let minHeight = ceil(lineHeight * minVisibleLines + viewportPadding)
-            let maxHeight = ceil(lineHeight * maxVisibleLines + viewportPadding)
             var measured = textView.sizeThatFits(fitSize).height
             let shouldScroll = measured > maxHeight + 0.5
             if textView.isScrollEnabled != shouldScroll {
@@ -262,31 +291,13 @@ struct TurnComposerInputTextView: UIViewRepresentable {
         // Keeps the newest typed line visible once the composer switches from growing to internal scrolling.
         private func keepCaretVisible(in textView: UITextView) {
             guard textView.isScrollEnabled else { return }
-            DispatchQueue.main.async { [weak self, weak textView] in
-                guard let self, let textView else { return }
+            DispatchQueue.main.async { [weak textView] in
+                guard let textView else { return }
                 textView.layoutIfNeeded()
                 guard let selectionEnd = textView.selectedTextRange?.end else { return }
                 let caretRect = textView.caretRect(for: selectionEnd).insetBy(dx: 0, dy: -8)
                 textView.scrollRectToVisible(caretRect, animated: false)
-                self.alignVisibleTopToLineBoundary(in: textView)
             }
-        }
-
-        // Keeps the internal scroll viewport from stopping between line boxes, which clips the first visible line.
-        private func alignVisibleTopToLineBoundary(in textView: UITextView) {
-            let lineHeight = (textView.font ?? UIFont.preferredFont(forTextStyle: .body)).lineHeight
-            guard lineHeight > 0 else { return }
-
-            let adjustedInset = textView.adjustedContentInset
-            let minY = -adjustedInset.top
-            let maxY = max(minY, textView.contentSize.height - textView.bounds.height + adjustedInset.bottom)
-            let lineOrigin = minY + textView.textContainerInset.top
-            let currentY = textView.contentOffset.y
-            let snappedY = lineOrigin + ((currentY - lineOrigin) / lineHeight).rounded() * lineHeight
-            let clampedY = min(max(snappedY, minY), maxY)
-
-            guard abs(currentY - clampedY) > 0.5 else { return }
-            textView.setContentOffset(CGPoint(x: textView.contentOffset.x, y: clampedY), animated: false)
         }
 
         // Resets/clamps the text viewport after Return inserts can nudge UITextView
@@ -362,27 +373,12 @@ struct TurnComposerInputTextView: UIViewRepresentable {
     }
 }
 
-private struct ViewportPaddingSignature: Equatable {
-    let widthBucket: Int
-    let fontName: String
-    let fontPointSizeBucket: Int
-    let topInsetBucket: Int
-    let bottomInsetBucket: Int
-    let lineFragmentPaddingBucket: Int
-}
-
-private struct ViewportPaddingCacheEntry {
-    let signature: ViewportPaddingSignature
-    let value: CGFloat
-}
-
 // Internal (not fileprivate) because UIViewRepresentable protocol methods expose the type.
 // Only used by TurnComposerInputTextView in this file.
 final class TurnComposerPasteInterceptingTextView: UITextView {
     var onPasteImageData: (([Data]) -> Void)?
     var runtimeState: TurnComposerRuntimeState?
     var runtimeActions: TurnComposerRuntimeActions?
-    private var cachedViewportPadding: ViewportPaddingCacheEntry?
 
     override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
@@ -396,35 +392,6 @@ final class TurnComposerPasteInterceptingTextView: UITextView {
     // Without this, SwiftUI uses the full text width as the ideal size.
     override var intrinsicContentSize: CGSize {
         CGSize(width: UIView.noIntrinsicMetric, height: super.intrinsicContentSize.height)
-    }
-
-    // TextKit needs a small viewport allowance beyond raw font line height; measuring it avoids clipped final lines.
-    func viewportPaddingBeyondLineHeight(targetWidth: CGFloat) -> CGFloat {
-        let signature = ViewportPaddingSignature(
-            widthBucket: Int((targetWidth * 2).rounded()),
-            fontName: font?.fontName ?? "",
-            fontPointSizeBucket: Int(((font?.pointSize ?? 0) * 10).rounded()),
-            topInsetBucket: Int((textContainerInset.top * 2).rounded()),
-            bottomInsetBucket: Int((textContainerInset.bottom * 2).rounded()),
-            lineFragmentPaddingBucket: Int((textContainer.lineFragmentPadding * 2).rounded())
-        )
-        if let cachedViewportPadding, cachedViewportPadding.signature == signature {
-            return cachedViewportPadding.value
-        }
-
-        let measuringView = UITextView(frame: CGRect(x: 0, y: 0, width: targetWidth, height: 1))
-        measuringView.font = font
-        measuringView.textContainerInset = textContainerInset
-        measuringView.textContainer.lineFragmentPadding = textContainer.lineFragmentPadding
-        measuringView.textContainer.widthTracksTextView = true
-        measuringView.text = " "
-        let measured = measuringView.sizeThatFits(
-            CGSize(width: targetWidth, height: .greatestFiniteMagnitude)
-        ).height
-        let lineHeight = (font ?? UIFont.preferredFont(forTextStyle: .body)).lineHeight
-        let value = max(0, measured - lineHeight)
-        cachedViewportPadding = ViewportPaddingCacheEntry(signature: signature, value: value)
-        return value
     }
 
     override func layoutSubviews() {

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerSecondaryBar.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerSecondaryBar.swift
@@ -11,6 +11,7 @@ struct TurnComposerSecondaryBar: View {
     let isEmptyThread: Bool
     let hasWorkingDirectory: Bool
     let isWorktreeProject: Bool
+    var activeFileChangeStatus: FileChangeStatusSnapshot? = nil
 
     let showsGitBranchSelector: Bool
     let isGitBranchSelectorEnabled: Bool
@@ -58,10 +59,16 @@ struct TurnComposerSecondaryBar: View {
                         onTapCreateWorktree: onTapCreateWorktree
                     )
 
-                    Spacer(minLength: 0)
+                    Spacer(minLength: 12)
+
+                    if let activeFileChangeStatus {
+                        FileChangeStatusCapsule(snapshot: activeFileChangeStatus)
+                            .transition(.opacity.combined(with: .scale(scale: 0.94, anchor: .trailing)))
+                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
+                .animation(.spring(response: 0.28, dampingFraction: 0.88), value: activeFileChangeStatus)
             }
         }
     }

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerView.swift
@@ -41,6 +41,7 @@ struct TurnComposerView: View {
     let isEmptyThread: Bool
     let hasWorkingDirectory: Bool
     let isWorktreeProject: Bool
+    var activeFileChangeStatus: FileChangeStatusSnapshot? = nil
 
     let orderedModelOptions: [CodexModelOption]
     let selectedModelID: String?
@@ -134,6 +135,7 @@ struct TurnComposerView: View {
                         isEmptyThread: isEmptyThread,
                         hasWorkingDirectory: hasWorkingDirectory,
                         isWorktreeProject: isWorktreeProject,
+                        activeFileChangeStatus: activeFileChangeStatus,
                         showsGitBranchSelector: showsGitBranchSelector,
                         isGitBranchSelectorEnabled: isGitBranchSelectorEnabled,
                         availableGitBranchTargets: availableGitBranchTargets,
@@ -253,6 +255,7 @@ struct TurnComposerView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .adaptiveGlass(.regular, in: RoundedRectangle(cornerRadius: 26))
+                .clipShape(RoundedRectangle(cornerRadius: 26))
                 .overlay(alignment: .topLeading) {
                     Color.clear
                         .frame(maxWidth: .infinity, maxHeight: 0, alignment: .topLeading)

--- a/CodexMobile/CodexMobile/Views/Turn/Core/TurnView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Core/TurnView.swift
@@ -91,6 +91,11 @@ struct TurnView: View {
             || viewModel.isSkillAutocompleteVisible
             || viewModel.isPluginAutocompleteVisible
             || viewModel.slashCommandPanelState != .hidden
+        let activeFileChangeStatus = FileChangeStatusSnapshot.activeTurnSnapshot(
+            from: renderSnapshot.messages,
+            activeTurnID: activeTurnID,
+            isThreadRunning: isThreadRunning
+        )
         let isWorktreeHandoffAvailable = isWorktreeHandoffAvailable(
             isThreadRunning: isThreadRunning,
             gitWorkingDirectory: gitWorkingDirectory
@@ -163,6 +168,7 @@ struct TurnView: View {
                     isThreadRunning: isThreadRunning,
                     isEmptyThread: isEmptyThread,
                     isWorktreeProject: isWorktreeProject,
+                    activeFileChangeStatus: activeFileChangeStatus,
                     showsGitControls: showsGitControls,
                     gitWorkingDirectory: gitWorkingDirectory
                 )),
@@ -762,6 +768,14 @@ struct TurnView: View {
 
     @ViewBuilder
     private func composerStructuredPromptReplacement(message: CodexMessage) -> some View {
+        let activeTurnID = codex.activeTurnID(for: thread.id)
+        let renderSnapshot = codex.timelineState(for: thread.id).renderSnapshot
+        let activeFileChangeStatus = FileChangeStatusSnapshot.activeTurnSnapshot(
+            from: renderSnapshot.messages,
+            activeTurnID: activeTurnID,
+            isThreadRunning: renderSnapshot.isThreadRunning
+        )
+
         if let request = message.structuredUserInputRequest {
             let isDismissed = viewModel.isStructuredPlanPromptDismissed(request.requestID, codex: codex)
             let isDismissing = viewModel.isStructuredPlanPromptDismissing(request.requestID, codex: codex)
@@ -782,10 +796,11 @@ struct TurnView: View {
             } else {
                 composerWithSubagentAccessory(
                     currentThread: currentResolvedThread,
-                    activeTurnID: codex.activeTurnID(for: thread.id),
-                    isThreadRunning: codex.timelineState(for: thread.id).renderSnapshot.isThreadRunning,
-                    isEmptyThread: codex.timelineState(for: thread.id).renderSnapshot.messages.isEmpty,
+                    activeTurnID: activeTurnID,
+                    isThreadRunning: renderSnapshot.isThreadRunning,
+                    isEmptyThread: renderSnapshot.messages.isEmpty,
                     isWorktreeProject: currentResolvedThread.isManagedWorktreeProject,
+                    activeFileChangeStatus: activeFileChangeStatus,
                     showsGitControls: codex.isConnected && currentResolvedThread.gitWorkingDirectory != nil,
                     gitWorkingDirectory: currentResolvedThread.gitWorkingDirectory
                 )
@@ -793,10 +808,11 @@ struct TurnView: View {
         } else {
             composerWithSubagentAccessory(
                 currentThread: currentResolvedThread,
-                activeTurnID: codex.activeTurnID(for: thread.id),
-                isThreadRunning: codex.timelineState(for: thread.id).renderSnapshot.isThreadRunning,
-                isEmptyThread: codex.timelineState(for: thread.id).renderSnapshot.messages.isEmpty,
+                activeTurnID: activeTurnID,
+                isThreadRunning: renderSnapshot.isThreadRunning,
+                isEmptyThread: renderSnapshot.messages.isEmpty,
                 isWorktreeProject: currentResolvedThread.isManagedWorktreeProject,
+                activeFileChangeStatus: activeFileChangeStatus,
                 showsGitControls: codex.isConnected && currentResolvedThread.gitWorkingDirectory != nil,
                 gitWorkingDirectory: currentResolvedThread.gitWorkingDirectory
             )
@@ -1325,6 +1341,7 @@ struct TurnView: View {
         isThreadRunning: Bool,
         isEmptyThread: Bool,
         isWorktreeProject: Bool,
+        activeFileChangeStatus: FileChangeStatusSnapshot?,
         showsGitControls: Bool,
         gitWorkingDirectory: String?
     ) -> some View {
@@ -1354,6 +1371,7 @@ struct TurnView: View {
                 isThreadRunning: isThreadRunning,
                 isEmptyThread: isEmptyThread,
                 isWorktreeProject: isWorktreeProject,
+                activeFileChangeStatus: activeFileChangeStatus,
                 canForkLocally: gitWorkingDirectory != nil && WorktreeFlowCoordinator.localForkProjectPath(
                     for: currentThread,
                     localCheckoutPath: viewModel.gitLocalCheckoutPath

--- a/CodexMobile/CodexMobile/Views/Turn/Diff/TurnFileChangeSummaryViews.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Diff/TurnFileChangeSummaryViews.swift
@@ -57,74 +57,70 @@ struct FileChangeSummaryBox: View {
     let detailBodyText: String
     let messageID: String
 
-    // Default to expanded so the recap stays informative without an extra tap;
-    // collapse remains available for long lists or visual decluttering.
-    @State private var isExpanded: Bool = true
-    @State private var activeDiffPresentation: FileChangeSummaryDiffPresentation?
+    @Environment(\.colorScheme) private var colorScheme
 
-    private var canCollapse: Bool {
-        !entries.isEmpty || !fallbackText.isEmpty
-    }
+    @State private var activeDiffPresentation: FileChangeSummaryDiffPresentation?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
 
-            if isExpanded {
-                if !entries.isEmpty {
-                    softDivider
+            if !entries.isEmpty {
+                softDivider
 
-                    ForEach(entries.indices, id: \.self) { index in
-                        let entry = entries[index]
-                        let isLastEntry = index == entries.index(before: entries.endIndex)
+                ForEach(entries.indices, id: \.self) { index in
+                    let entry = entries[index]
+                    let isLastEntry = index == entries.index(before: entries.endIndex)
 
-                        Button {
-                            activeDiffPresentation = .singleEntry(entry)
-                        } label: {
-                            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                                Text(entry.compactPath)
-                                    .font(AppFont.subheadline())
-                                    .foregroundStyle(.primary)
-                                    .lineLimit(1)
-                                    .truncationMode(.middle)
+                    Button {
+                        activeDiffPresentation = .singleEntry(entry)
+                    } label: {
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Text(entry.compactPath)
+                                .font(AppFont.body())
+                                .foregroundStyle(.primary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
 
-                                Spacer(minLength: 8)
+                            Spacer(minLength: 8)
 
-                                if entry.additions > 0 || entry.deletions > 0 {
-                                    DiffCountsLabel(additions: entry.additions, deletions: entry.deletions)
-                                        .font(AppFont.subheadline())
-                                }
+                            if entry.additions > 0 || entry.deletions > 0 {
+                                DiffCountsLabel(additions: entry.additions, deletions: entry.deletions)
+                                    .font(AppFont.body())
                             }
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 9)
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
 
-                        if !isLastEntry {
-                            softDivider
-                                .padding(.leading, 12)
+                            RemodexIcon.image(systemName: "chevron.down")
+                                .font(AppFont.system(size: 12, weight: .semibold))
+                                .foregroundStyle(.secondary)
                         }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 11)
+                        .contentShape(Rectangle())
                     }
-                } else if !fallbackText.isEmpty {
-                    Text(fallbackText)
-                        .font(AppFont.footnote())
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 12)
-                        .padding(.bottom, 10)
+                    .buttonStyle(.plain)
+
+                    if !isLastEntry {
+                        softDivider
+                            .padding(.leading, 16)
+                    }
                 }
+            } else if !fallbackText.isEmpty {
+                Text(fallbackText)
+                    .font(AppFont.footnote())
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 12)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
-            .regularMaterial,
+            cardBackgroundColor,
             in: RoundedRectangle(cornerRadius: 12, style: .continuous)
         )
         .overlay {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(softDividerColor, lineWidth: 0.5)
+                .stroke(cardOutlineColor, lineWidth: 1)
         }
-        .padding(2)
         .sheet(item: $activeDiffPresentation) { presentation in
             switch presentation {
             case .singleEntry(let entry):
@@ -148,21 +144,26 @@ struct FileChangeSummaryBox: View {
 
     @ViewBuilder
     private var header: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: 12) {
             Image("changes")
                 .renderingMode(.template)
                 .resizable()
                 .scaledToFit()
-                .frame(width: 16, height: 16)
+                .frame(width: 18, height: 18)
                 .foregroundStyle(.secondary)
+                .frame(width: 40, height: 40)
+                .background(iconBackgroundColor, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
 
-            Text("File changes")
-                .font(AppFont.footnote(weight: .medium))
-                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(summaryTitle)
+                    .font(AppFont.body(weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
 
-            if totalAdditions > 0 || totalDeletions > 0 {
-                DiffCountsLabel(additions: totalAdditions, deletions: totalDeletions)
-                    .font(AppFont.subheadline())
+                if totalAdditions > 0 || totalDeletions > 0 {
+                    DiffCountsLabel(additions: totalAdditions, deletions: totalDeletions)
+                        .font(AppFont.subheadline())
+                }
             }
 
             Spacer(minLength: 8)
@@ -172,37 +173,25 @@ struct FileChangeSummaryBox: View {
                     HapticFeedback.shared.triggerImpactFeedback(style: .light)
                     activeDiffPresentation = .allEntries
                 } label: {
-                    RemodexIcon.image(systemName: "arrow.up.right")
-                        .font(AppFont.system(size: 11, weight: .semibold))
-                        .foregroundStyle(.secondary)
-                        .frame(width: 24, height: 24)
-                        .contentShape(Circle())
+                    Text("Review")
+                        .font(AppFont.body(weight: .medium))
+                        .foregroundStyle(.primary)
+                        .padding(.horizontal, 13)
+                        .padding(.vertical, 7)
+                        .background(Color(.systemBackground).opacity(colorScheme == .dark ? 0.08 : 0.75), in: Capsule())
+                        .overlay {
+                            Capsule()
+                                .stroke(cardOutlineColor, lineWidth: 1)
+                        }
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Open diff")
-            }
-
-            if canCollapse {
-                Button {
-                    withAnimation(.easeInOut(duration: 0.18)) {
-                        isExpanded.toggle()
-                    }
-                } label: {
-                    RemodexIcon.image(systemName: "chevron.down")
-                        .font(AppFont.system(size: 11, weight: .semibold))
-                        .foregroundStyle(.secondary)
-                        .rotationEffect(.degrees(isExpanded ? 0 : -90))
-                        .frame(width: 24, height: 24)
-                        .contentShape(Circle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(isExpanded ? "Collapse file changes" : "Expand file changes")
+                .accessibilityLabel("Review file changes")
             }
         }
         .padding(.leading, 12)
-        .padding(.trailing, 8)
-        .padding(.top, 6)
-        .padding(.bottom, isExpanded && !entries.isEmpty ? 6 : 8)
+        .padding(.trailing, 14)
+        .padding(.top, 12)
+        .padding(.bottom, 12)
     }
 
     private var totalAdditions: Int {
@@ -221,5 +210,34 @@ struct FileChangeSummaryBox: View {
 
     private var softDividerColor: Color {
         Color(.separator).opacity(0.6)
+    }
+
+    private var summaryTitle: String {
+        guard !entries.isEmpty else {
+            return "File changes"
+        }
+
+        return "\(summaryActionTitle) \(entries.count) \(entries.count == 1 ? "file" : "files")"
+    }
+
+    private var summaryActionTitle: String {
+        let actionTitles = Set(entries.compactMap { $0.action?.rawValue })
+        return actionTitles.count == 1 ? (actionTitles.first ?? "Edited") : "Edited"
+    }
+
+    private var cardBackgroundColor: Color {
+        colorScheme == .dark
+            ? Color(red: 0.12, green: 0.12, blue: 0.13)
+            : Color(.systemBackground)
+    }
+
+    private var cardOutlineColor: Color {
+        Color(.separator).opacity(colorScheme == .dark ? 0.52 : 0.44)
+    }
+
+    private var iconBackgroundColor: Color {
+        colorScheme == .dark
+            ? Color.white.opacity(0.04)
+            : Color(.secondarySystemBackground).opacity(0.65)
     }
 }

--- a/CodexMobile/CodexMobile/Views/Turn/Messages/FileChangeStatusCapsule.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Messages/FileChangeStatusCapsule.swift
@@ -1,0 +1,240 @@
+// FILE: FileChangeStatusCapsule.swift
+// Purpose: Renders compact right-aligned Liquid Glass capsules for file-change activity.
+// Layer: View Component
+// Exports: FileChangeStatusSnapshot, FileChangeStatusCapsule
+// Depends on: SwiftUI, TurnDiffSheet, AdaptiveGlassModifier, AppFont, HapticFeedback
+
+import SwiftUI
+
+struct FileChangeStatusSnapshot: Equatable {
+    let fileCount: Int
+    let additions: Int
+    let deletions: Int
+    let entries: [TurnFileChangeSummaryEntry]
+    let detailBodyText: String
+    let messageID: String
+
+    var title: String {
+        fileCount == 1 ? "1 file changed" : "\(fileCount) files changed"
+    }
+
+    var compactTitle: String {
+        fileCount == 1 ? "1 change" : "\(fileCount) changes"
+    }
+
+    var hasChanges: Bool {
+        fileCount > 0
+    }
+
+    static func activeTurnSnapshot(
+        from messages: [CodexMessage],
+        activeTurnID: String?,
+        isThreadRunning: Bool
+    ) -> FileChangeStatusSnapshot? {
+        guard isThreadRunning,
+              let activeTurnID = activeTurnID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !activeTurnID.isEmpty else {
+            return nil
+        }
+
+        let activeFileChangeMessages = messages.filter { message in
+            message.role == .system
+                && message.kind == .fileChange
+                && message.turnId == activeTurnID
+        }
+        guard !activeFileChangeMessages.isEmpty else {
+            return nil
+        }
+
+        guard let presentation = FileChangeBlockPresentationBuilder.build(from: activeFileChangeMessages)
+            ?? fallbackPresentation(from: activeFileChangeMessages) else {
+            return nil
+        }
+
+        let additions = presentation.entries.reduce(0) { $0 + $1.additions }
+        let deletions = presentation.entries.reduce(0) { $0 + $1.deletions }
+        let contentFingerprint = TurnTextCacheKey.stableFingerprint(for: presentation.bodyText)
+        let entriesFingerprint = TurnTextCacheKey.entriesFingerprint(presentation.entries)
+        let snapshot = FileChangeStatusSnapshot(
+            fileCount: presentation.entries.count,
+            additions: additions,
+            deletions: deletions,
+            entries: presentation.entries,
+            detailBodyText: presentation.bodyText,
+            messageID: "active-file-change-\(activeTurnID)-\(entriesFingerprint)-\(contentFingerprint)"
+        )
+        return snapshot.hasChanges ? snapshot : nil
+    }
+
+    private static func fallbackPresentation(from messages: [CodexMessage]) -> FileChangeBlockPresentation? {
+        var entries: [TurnFileChangeSummaryEntry] = []
+        var bodyTexts: [String] = []
+
+        for message in messages {
+            guard message.text.utf8.count <= 128_000,
+                  let summary = TurnFileChangeSummaryParser.parse(from: message.text) else {
+                continue
+            }
+
+            entries.append(contentsOf: summary.entries)
+            bodyTexts.append(message.text)
+        }
+
+        let consolidatedEntries = consolidateFallbackEntries(entries)
+        guard !consolidatedEntries.isEmpty else {
+            return nil
+        }
+
+        return FileChangeBlockPresentation(
+            entries: consolidatedEntries,
+            bodyText: bodyTexts.joined(separator: "\n\n---\n\n")
+        )
+    }
+
+    private static func consolidateFallbackEntries(
+        _ entries: [TurnFileChangeSummaryEntry]
+    ) -> [TurnFileChangeSummaryEntry] {
+        var consolidated: [TurnFileChangeSummaryEntry] = []
+        consolidated.reserveCapacity(entries.count)
+
+        for entry in entries {
+            guard let existingIndex = consolidated.firstIndex(where: {
+                FileChangePathIdentity.representsSameFile($0.path, entry.path)
+            }) else {
+                consolidated.append(entry)
+                continue
+            }
+
+            let existing = consolidated[existingIndex]
+            consolidated[existingIndex] = TurnFileChangeSummaryEntry(
+                path: FileChangePathIdentity.preferredDisplayPath(existing.path, entry.path),
+                additions: existing.additions + entry.additions,
+                deletions: existing.deletions + entry.deletions,
+                action: existing.action ?? entry.action
+            )
+        }
+
+        return consolidated
+    }
+}
+
+struct FileChangeStatusCapsule: View {
+    let title: String
+    var additions: Int? = nil
+    var deletions: Int? = nil
+    private var snapshot: FileChangeStatusSnapshot?
+    @State private var isShowingDiffSheet = false
+
+    init(snapshot: FileChangeStatusSnapshot) {
+        self.title = snapshot.compactTitle
+        self.additions = snapshot.additions
+        self.deletions = snapshot.deletions
+        self.snapshot = snapshot
+    }
+
+    init(title: String, additions: Int? = nil, deletions: Int? = nil) {
+        self.title = title
+        self.additions = additions
+        self.deletions = deletions
+        self.snapshot = nil
+    }
+
+    var body: some View {
+        Group {
+            if let snapshot {
+                Button {
+                    HapticFeedback.shared.triggerImpactFeedback(style: .light)
+                    isShowingDiffSheet = true
+                } label: {
+                    capsuleContent
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Open file changes diff")
+                .sheet(isPresented: $isShowingDiffSheet) {
+                    TurnDiffSheet(
+                        title: "Changes",
+                        entries: snapshot.entries,
+                        bodyText: snapshot.detailBodyText,
+                        messageID: snapshot.messageID
+                    )
+                }
+            } else {
+                capsuleContent
+            }
+        }
+    }
+
+    private var capsuleContent: some View {
+        HStack(spacing: 8) {
+            Image("changes")
+                .renderingMode(.template)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 16, height: 16)
+                .foregroundStyle(.secondary)
+
+            Text(title)
+                .font(AppFont.subheadline(weight: .medium))
+                .foregroundStyle(.primary.opacity(0.78))
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .minimumScaleFactor(0.82)
+
+            if let additions, let deletions, additions > 0 || deletions > 0 {
+                FileChangeStatusDiffCountsLabel(additions: additions, deletions: deletions)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .layoutPriority(1)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .adaptiveGlass(.regular, in: Capsule())
+        .overlay {
+            Capsule()
+                .stroke(Color.white.opacity(0.22), lineWidth: 0.5)
+        }
+        .contentShape(Capsule())
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct FileChangeStatusDiffCountsLabel: View {
+    let additions: Int
+    let deletions: Int
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Text("+\(Self.compactCount(additions))")
+                .foregroundStyle(Color.green)
+            Text("-\(Self.compactCount(deletions))")
+                .foregroundStyle(Color.red)
+        }
+        .font(AppFont.subheadline(weight: .semibold))
+        .lineLimit(1)
+    }
+
+    private static func compactCount(_ value: Int) -> String {
+        let absoluteValue = abs(value)
+        guard absoluteValue >= 1_000 else {
+            return "\(value)"
+        }
+
+        let formatter = NumberFormatter()
+        formatter.locale = .current
+        formatter.maximumFractionDigits = absoluteValue >= 10_000 ? 0 : 1
+        formatter.minimumFractionDigits = 0
+
+        let scaledValue = Double(value) / 1_000
+        let formatted = formatter.string(from: NSNumber(value: scaledValue)) ?? String(format: "%.1f", scaledValue)
+        return "\(formatted)K"
+    }
+}
+
+#if DEBUG
+#Preview("File Change Status Capsule") {
+    VStack(spacing: 14) {
+        FileChangeStatusCapsule(title: "30 files changed", additions: 2700, deletions: 72)
+    }
+    .padding()
+}
+#endif

--- a/CodexMobile/CodexMobile/Views/Turn/Messages/TurnMarkdownTextRendering.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Messages/TurnMarkdownTextRendering.swift
@@ -211,14 +211,33 @@ struct StreamingAssistantMarkdownTextView: View {
             }
 
             if !segments.activeMarkdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                MarkdownTextView(
-                    text: segments.activeMarkdown,
-                    profile: .assistantProse,
-                    enablesSelection: enablesSelection,
-                    constrainsToAvailableWidth: constrainsToAvailableWidth,
-                    usesCaches: false
-                )
+                if StreamingMarkdownRenderPolicy.usesPlainActiveRenderer(for: segments.activeMarkdown) {
+                    streamingPlainText(segments.activeMarkdown)
+                } else {
+                    MarkdownTextView(
+                        text: segments.activeMarkdown,
+                        profile: .assistantProse,
+                        enablesSelection: enablesSelection,
+                        constrainsToAvailableWidth: constrainsToAvailableWidth,
+                        usesCaches: false
+                    )
+                }
             }
+        }
+    }
+
+    @ViewBuilder
+    private func streamingPlainText(_ text: String) -> some View {
+        let plainText = Text(text)
+            .font(AppFont.body())
+            .foregroundStyle(.primary)
+            .frame(maxWidth: constrainsToAvailableWidth ? .infinity : nil, alignment: .leading)
+            .fixedSize(horizontal: false, vertical: true)
+
+        if enablesSelection {
+            plainText.textSelection(.enabled)
+        } else {
+            plainText
         }
     }
 
@@ -317,13 +336,22 @@ private enum StreamingMarkdownRevealPolicy {
     // MessageRow already coalesces assistant text, so this view only needs a light reveal.
     static let frameIntervalNanoseconds: UInt64 = 45_000_000
     private static let largeInitialRevealCharacterCount = 512
+    private static let maximumAnimatedByteCount = 8_000
+    private static let maximumAnimatedBacklogByteCount = 2_000
     private static let minimumAdvanceCharacterCount = 14
     private static let maximumAdvanceCharacterCount = 96
     private static let largeBacklogAdvanceCharacterCount = 256
     private static let hugeBacklogAdvanceCharacterCount = 512
 
     static func shouldSnap(displayedText: String, targetText: String) -> Bool {
-        !targetText.hasPrefix(displayedText)
+        if !targetText.hasPrefix(displayedText) {
+            return true
+        }
+        if targetText.utf8.count > maximumAnimatedByteCount {
+            return true
+        }
+        let backlogByteCount = max(0, targetText.utf8.count - displayedText.utf8.count)
+        return backlogByteCount > maximumAnimatedBacklogByteCount
     }
 
     static func shouldAnimateInitialReveal(_ text: String) -> Bool {
@@ -341,6 +369,14 @@ private enum StreamingMarkdownRevealPolicy {
             minimumAdvanceCharacterCount,
             min(remaining / 2, maximumAdvanceCharacterCount)
         )
+    }
+}
+
+private enum StreamingMarkdownRenderPolicy {
+    private static let plainActiveRendererByteCount = 4_000
+
+    static func usesPlainActiveRenderer(for text: String) -> Bool {
+        text.utf8.count > plainActiveRendererByteCount
     }
 }
 

--- a/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineCacheKeys.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineCacheKeys.swift
@@ -12,6 +12,8 @@ enum TurnTimelineCacheKeyBuilder {
         timelineChangeToken: Int,
         visibleTailCount: Int,
         messages: ArraySlice<CodexMessage>,
+        activeTurnID: String? = nil,
+        isThreadRunning: Bool = false,
         completedTurnIDs: Set<String>
     ) -> TurnTimelineRenderItemsCacheSignature {
         var hasher = Hasher()
@@ -20,6 +22,8 @@ enum TurnTimelineCacheKeyBuilder {
             threadID: threadID,
             timelineChangeToken: timelineChangeToken,
             visibleTailCount: visibleTailCount,
+            activeTurnID: activeTurnID,
+            isThreadRunning: isThreadRunning,
             messageCount: messages.count,
             firstMessageID: messages.first?.id,
             lastMessageID: messages.last?.id,

--- a/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineRenderProjection.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineRenderProjection.swift
@@ -73,7 +73,12 @@ enum TurnTimelineRenderProjection {
     private static let smallWhitespaceScanByteLimit = 512
 
     // Groups tool runs and completed-turn preamble rows so the visible timeline stays compact.
-    static func project(messages: [CodexMessage], completedTurnIDs: Set<String> = []) -> [TurnTimelineRenderItem] {
+    static func project(
+        messages: [CodexMessage],
+        completedTurnIDs: Set<String> = [],
+        activeTurnID: String? = nil,
+        isThreadRunning: Bool = false
+    ) -> [TurnTimelineRenderItem] {
         var items: [TurnTimelineRenderItem] = []
         var bufferedToolMessages: [CodexMessage] = []
         let fileChangePlan = fileChangeCollapsePlan(in: messages)
@@ -81,8 +86,10 @@ enum TurnTimelineRenderProjection {
             in: messages,
             completedTurnIDs: completedTurnIDs
         )
+        let duplicateAssistantHiddenIndices = duplicateCommentaryAssistantIndices(in: messages)
         let hiddenIndices = Set(finalCollapsePlan.values.flatMap(\.indices))
             .union(fileChangePlan.hiddenIndices)
+            .union(duplicateAssistantHiddenIndices)
         let groupByInsertionIndex = finalCollapsePlan.values.reduce(into: [Int: PreviousMessagesCollapse]()) { result, collapse in
             result[collapse.insertionIndex] = collapse
         }
@@ -115,7 +122,11 @@ enum TurnTimelineRenderProjection {
             }
 
             let renderedMessage = previousReplacementByIndex[index] ?? fileChangePlan.replacementByIndex[index] ?? message
-            if shouldSkipVisualRow(renderedMessage) {
+            if shouldSkipVisualRow(
+                renderedMessage,
+                activeTurnID: activeTurnID,
+                isThreadRunning: isThreadRunning
+            ) {
                 continue
             }
             guard isToolBurstCandidate(message) else {
@@ -168,6 +179,37 @@ enum TurnTimelineRenderProjection {
     private struct FileChangeCollapsePlan {
         let hiddenIndices: Set<Int>
         let replacementByIndex: [Int: CodexMessage]
+    }
+
+    // Hides already-persisted duplicate commentary emitted by both desktop live state and rollout replay.
+    private static func duplicateCommentaryAssistantIndices(in messages: [CodexMessage]) -> Set<Int> {
+        var seenKeys: Set<String> = []
+        var hiddenIndices = Set<Int>()
+
+        for index in messages.indices {
+            let message = messages[index]
+            guard message.role == .assistant,
+                  isCommentaryAssistantPhase(message.assistantPhase),
+                  let turnID = normalizedIdentifier(message.turnId),
+                  message.text.utf8.count <= largeArtifactTextByteLimit else {
+                continue
+            }
+
+            let text = normalizedVisibleAssistantText(message.text)
+            guard text.count >= 24 else {
+                continue
+            }
+
+            let key = [
+                turnID,
+                text,
+            ].joined(separator: "\u{1F}")
+            if !seenKeys.insert(key).inserted {
+                hiddenIndices.insert(index)
+            }
+        }
+
+        return hiddenIndices
     }
 
     // Shows one end-of-turn file table even when the bridge streams multiple file-change snapshots.
@@ -671,10 +713,21 @@ enum TurnTimelineRenderProjection {
     }
 
     // Drops placeholder-only rows before SwiftUI can reserve timeline spacing for them.
-    private static func shouldSkipVisualRow(_ message: CodexMessage) -> Bool {
+    private static func shouldSkipVisualRow(
+        _ message: CodexMessage,
+        activeTurnID: String? = nil,
+        isThreadRunning: Bool = false
+    ) -> Bool {
         if message.role == .assistant,
            message.isStreaming,
            isEmptyStreamingPlaceholderText(message.text) {
+            return true
+        }
+
+        if isThreadRunning,
+           message.role == .system,
+           message.kind == .fileChange,
+           normalizedIdentifier(message.turnId) == normalizedIdentifier(activeTurnID) {
             return true
         }
 

--- a/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineScrollSupport.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineScrollSupport.swift
@@ -37,6 +37,8 @@ struct TurnTimelineRenderItemsCacheSignature: Equatable {
     let threadID: String
     let timelineChangeToken: Int
     let visibleTailCount: Int
+    let activeTurnID: String?
+    let isThreadRunning: Bool
     let messageCount: Int
     let firstMessageID: String?
     let lastMessageID: String?
@@ -53,6 +55,8 @@ final class TurnTimelineRenderItemsCache {
         for signature: TurnTimelineRenderItemsCacheSignature,
         messages: ArraySlice<CodexMessage>,
         completedTurnIDs: Set<String>,
+        activeTurnID: String? = nil,
+        isThreadRunning: Bool = false,
         projector: (([CodexMessage], Set<String>) -> [TurnTimelineRenderItem])? = nil
     ) -> [TurnTimelineRenderItem] {
         if signature == cachedSignature {
@@ -63,7 +67,9 @@ final class TurnTimelineRenderItemsCache {
         let projectedItems = projector.map { $0(sourceMessages, completedTurnIDs) }
             ?? TurnTimelineRenderProjection.project(
                 messages: sourceMessages,
-                completedTurnIDs: completedTurnIDs
+                completedTurnIDs: completedTurnIDs,
+                activeTurnID: activeTurnID,
+                isThreadRunning: isThreadRunning
             )
         cachedSignature = signature
         cachedItems = projectedItems

--- a/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineView.swift
@@ -261,6 +261,8 @@ struct TurnTimelineView<EmptyState: View, Composer: View>: View {
             timelineChangeToken: timelineChangeToken,
             visibleTailCount: visibleTailCount,
             messages: messages,
+            activeTurnID: activeTurnID,
+            isThreadRunning: isThreadRunning,
             completedTurnIDs: completedTurnIDs
         )
     }
@@ -435,7 +437,9 @@ struct TurnTimelineView<EmptyState: View, Composer: View>: View {
             if signature != nextState.renderItemsSignature {
                 nextState.visibleRenderItems = TurnTimelineRenderProjection.project(
                     messages: visible,
-                    completedTurnIDs: completedTurnIDs
+                    completedTurnIDs: completedTurnIDs,
+                    activeTurnID: activeTurnID,
+                    isThreadRunning: isThreadRunning
                 )
                 nextState.renderItemsSignature = signature
                 didChange = true
@@ -550,12 +554,22 @@ struct TurnTimelineView<EmptyState: View, Composer: View>: View {
         )
     }
 
-    // Keep the thinking label pinned above the composer for the whole run, even while
-    // assistant prose and late tool rows stream into the scroll stack above it.
+    // Keep the thinking label pinned until assistant prose is actually visible.
+    // Tool/thinking placeholder rows alone should not hide it, otherwise the run
+    // looks idle during the Mac mirroring gap before the first assistant token.
     private var shouldShowStickyPendingAssistantIndicator: Bool {
         TurnTimelinePendingAssistantState.shouldShowIndicator(
             isRunStartingOrRunning: isRunStartingOrRunning
-        )
+        ) && !hasVisibleStreamingAssistantText
+    }
+
+    private var hasVisibleStreamingAssistantText: Bool {
+        visibleMessages.contains { message in
+            guard message.role == .assistant, message.isStreaming else {
+                return false
+            }
+            return message.text.contains { !$0.isWhitespace }
+        }
     }
 
     private func timelineRowsBottomPadding(showsStickyPendingAssistantIndicator: Bool) -> CGFloat {

--- a/CodexMobile/CodexMobileTests/CodexServiceIncomingRunIndicatorTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceIncomingRunIndicatorTests.swift
@@ -189,6 +189,42 @@ final class CodexServiceIncomingRunIndicatorTests: XCTestCase {
         XCTAssertFalse(service.protectedRunningFallbackThreadIDs.contains(threadID))
     }
 
+    func testDuplicateCommentaryDeltaWithDifferentItemIDDoesNotAppendSecondBubble() {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let turnID = "turn-\(UUID().uuidString)"
+        let text = "Checking whether the bridge or UI duplicated this commentary."
+
+        service.handleNotification(
+            method: "item/agentMessage/delta",
+            params: .object([
+                "threadId": .string(threadID),
+                "turnId": .string(turnID),
+                "itemId": .string("desktop-commentary"),
+                "phase": .string("commentary"),
+                "delta": .string(text),
+            ])
+        )
+        service.flushAllPendingStreamingDeltas()
+
+        service.handleNotification(
+            method: "item/agentMessage/delta",
+            params: .object([
+                "threadId": .string(threadID),
+                "turnId": .string(turnID),
+                "itemId": .string("rollout-commentary"),
+                "phase": .string("commentary"),
+                "delta": .string(text),
+            ])
+        )
+        service.flushAllPendingStreamingDeltas()
+
+        let assistantMessages = service.messages(for: threadID).filter { $0.role == .assistant }
+        XCTAssertEqual(assistantMessages.count, 1)
+        XCTAssertEqual(assistantMessages.first?.assistantPhase, "commentary")
+        XCTAssertEqual(assistantMessages.first?.text, text)
+    }
+
     func testDesktopMirrorActivityHeartbeatRestoresRunningAfterStaleClear() {
         let service = makeService()
         let threadID = "thread-\(UUID().uuidString)"
@@ -207,6 +243,257 @@ final class CodexServiceIncomingRunIndicatorTests: XCTestCase {
         XCTAssertEqual(service.activeTurnID(for: threadID), turnID)
         XCTAssertEqual(service.threadRunBadgeState(for: threadID), .running)
         XCTAssertTrue(service.desktopMirroredRunningThreadIDs.contains(threadID))
+    }
+
+    func testRolloutBootstrapReplayKeepsLiveMirrorResponsiveDuringCatchup() async {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let turnID = "turn-\(UUID().uuidString)"
+
+        service.handleNotification(
+            method: "remodex/rollout/bootstrapReplay",
+            params: .object([
+                "threadId": .string(threadID),
+                "replayId": .string("replay-\(UUID().uuidString)"),
+                "batchIndex": .integer(0),
+                "batchCount": .integer(1),
+                "notifications": .array([
+                    .object([
+                        "method": .string("turn/started"),
+                        "params": .object([
+                            "threadId": .string(threadID),
+                            "turnId": .string(turnID),
+                            "remodexDesktopMirror": .bool(true),
+                            "remodexRolloutLiveMirror": .bool(true),
+                        ]),
+                    ]),
+                ]),
+            ])
+        )
+
+        service.handleNotification(
+            method: "turn/completed",
+            params: .object([
+                "threadId": .string(threadID),
+                "turnId": .string(turnID),
+                "remodexDesktopMirror": .bool(true),
+                "remodexRolloutLiveMirror": .bool(true),
+            ])
+        )
+
+        await flushAsyncSideEffects()
+
+        XCTAssertNil(service.activeTurnID(for: threadID))
+        XCTAssertFalse(service.threadHasActiveOrRunningTurn(threadID))
+    }
+
+    func testRolloutBootstrapReplayCoalescesTimelineWorkUntilBatchEnd() async {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let turnID = "turn-\(UUID().uuidString)"
+        let itemID = "item-\(UUID().uuidString)"
+        service.activeThreadId = threadID
+        _ = service.timelineState(for: threadID)
+
+        service.handleNotification(
+            method: "remodex/rollout/bootstrapReplay",
+            params: .object([
+                "threadId": .string(threadID),
+                "replayId": .string("replay-\(UUID().uuidString)"),
+                "batchIndex": .integer(0),
+                "batchCount": .integer(1),
+                "notifications": .array([
+                    .object([
+                        "method": .string("codex/event/user_message"),
+                        "params": .object([
+                            "threadId": .string(threadID),
+                            "turnId": .string(turnID),
+                            "message": .string("Prompt from desktop"),
+                            "remodexDesktopMirror": .bool(true),
+                            "remodexRolloutLiveMirror": .bool(true),
+                        ]),
+                    ]),
+                    .object([
+                        "method": .string("item/completed"),
+                        "params": .object([
+                            "threadId": .string(threadID),
+                            "turnId": .string(turnID),
+                            "itemId": .string(itemID),
+                            "item": .object([
+                                "id": .string(itemID),
+                                "type": .string("message"),
+                                "role": .string("assistant"),
+                                "text": .string("Final from desktop"),
+                            ]),
+                            "remodexDesktopMirror": .bool(true),
+                            "remodexRolloutLiveMirror": .bool(true),
+                        ]),
+                    ]),
+                ]),
+            ])
+        )
+
+        await flushAsyncSideEffects()
+
+        XCTAssertEqual(service.messages(for: threadID).map(\.text), ["Prompt from desktop", "Final from desktop"])
+        XCTAssertEqual(service.currentOutput, "Final from desktop")
+        XCTAssertEqual(
+            service.timelineState(for: threadID).renderSnapshot.messages.map(\.text),
+            ["Prompt from desktop", "Final from desktop"]
+        )
+        XCTAssertEqual(service.rolloutBootstrapReplayCoalescingDepth, 0)
+        XCTAssertFalse(service.rolloutBootstrapReplayNeedsMessagePersist)
+        XCTAssertTrue(service.rolloutBootstrapReplayDeferredTimelineThreadIDs.isEmpty)
+        XCTAssertTrue(service.rolloutBootstrapReplayDeferredSyncThreadIDs.isEmpty)
+        XCTAssertTrue(service.rolloutBootstrapReplayDeferredHistoryReconcileThreadIDs.isEmpty)
+    }
+
+    func testRolloutBootstrapReplayDefersSyncWorkUntilFinalBatch() async {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let turnID = "turn-\(UUID().uuidString)"
+        let replayID = "replay-\(UUID().uuidString)"
+        service.isConnected = true
+        service.isInitialized = true
+
+        service.handleNotification(
+            method: "remodex/rollout/bootstrapReplay",
+            params: .object([
+                "threadId": .string(threadID),
+                "replayId": .string(replayID),
+                "batchIndex": .integer(0),
+                "batchCount": .integer(2),
+                "notifications": .array([
+                    .object([
+                        "method": .string("turn/completed"),
+                        "params": .object([
+                            "threadId": .string(threadID),
+                            "turnId": .string(turnID),
+                            "remodexDesktopMirror": .bool(true),
+                            "remodexRolloutLiveMirror": .bool(true),
+                        ]),
+                    ]),
+                ]),
+            ])
+        )
+
+        await flushAsyncSideEffects()
+
+        XCTAssertTrue(service.rolloutBootstrapReplayDeferredSyncThreadIDs.contains(threadID))
+        XCTAssertTrue(service.rolloutBootstrapReplayDeferredHistoryReconcileThreadIDs.contains(threadID))
+
+        service.handleNotification(
+            method: "remodex/rollout/bootstrapReplay",
+            params: .object([
+                "threadId": .string(threadID),
+                "replayId": .string(replayID),
+                "batchIndex": .integer(1),
+                "batchCount": .integer(2),
+                "notifications": .array([
+                    .object([
+                        "method": .string("turn/activity"),
+                        "params": .object([
+                            "threadId": .string(threadID),
+                            "turnId": .string(turnID),
+                            "remodexDesktopMirror": .bool(true),
+                            "remodexRolloutLiveMirror": .bool(true),
+                        ]),
+                    ]),
+                ]),
+            ])
+        )
+
+        await flushAsyncSideEffects()
+
+        XCTAssertTrue(service.rolloutBootstrapReplayDeferredSyncThreadIDs.isEmpty)
+        XCTAssertTrue(service.rolloutBootstrapReplayDeferredHistoryReconcileThreadIDs.isEmpty)
+    }
+
+    func testRolloutBootstrapReplayAllowsLiveMirrorBeforeFinalBatch() async {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let replayID = "replay-\(UUID().uuidString)"
+
+        service.handleNotification(
+            method: "remodex/rollout/bootstrapReplay",
+            params: .object([
+                "threadId": .string(threadID),
+                "replayId": .string(replayID),
+                "batchIndex": .integer(0),
+                "batchCount": .integer(2),
+                "notifications": .array([
+                    .object([
+                        "method": .string("codex/event/user_message"),
+                        "params": .object([
+                            "threadId": .string(threadID),
+                            "turnId": .string("turn-history-0"),
+                            "message": .string("history zero"),
+                            "remodexDesktopMirror": .bool(true),
+                            "remodexRolloutLiveMirror": .bool(true),
+                        ]),
+                    ]),
+                ]),
+            ])
+        )
+
+        service.handleNotification(
+            method: "codex/event/user_message",
+            params: .object([
+                "threadId": .string(threadID),
+                "turnId": .string("turn-live"),
+                "message": .string("live after history"),
+                "remodexDesktopMirror": .bool(true),
+                "remodexRolloutLiveMirror": .bool(true),
+            ])
+        )
+
+        XCTAssertEqual(
+            service.messages(for: threadID).map(\.text),
+            ["history zero", "live after history"]
+        )
+
+        service.handleNotification(
+            method: "remodex/rollout/bootstrapReplay",
+            params: .object([
+                "threadId": .string(threadID),
+                "replayId": .string(replayID),
+                "batchIndex": .integer(1),
+                "batchCount": .integer(2),
+                "notifications": .array([
+                    .object([
+                        "method": .string("codex/event/user_message"),
+                        "params": .object([
+                            "threadId": .string(threadID),
+                            "turnId": .string("turn-history-1"),
+                            "message": .string("history one"),
+                            "remodexDesktopMirror": .bool(true),
+                            "remodexRolloutLiveMirror": .bool(true),
+                        ]),
+                    ]),
+                ]),
+            ])
+        )
+
+        await flushAsyncSideEffects()
+
+        XCTAssertEqual(
+            service.messages(for: threadID).map(\.text),
+            ["history zero", "live after history", "history one"]
+        )
+    }
+
+    func testCancelPerThreadRefreshWorkClearsRolloutBootstrapReplayWork() {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let replayKey = "\(threadID)|replay-1|0"
+
+        service.appliedRolloutBootstrapReplayBatchKeys.insert(replayKey)
+        service.appliedRolloutBootstrapReplayBatchKeyOrder.append(replayKey)
+
+        service.cancelPerThreadRefreshWork(for: threadID)
+
+        XCTAssertFalse(service.appliedRolloutBootstrapReplayBatchKeys.contains(replayKey))
+        XCTAssertFalse(service.appliedRolloutBootstrapReplayBatchKeyOrder.contains(replayKey))
     }
 
     func testTurnStartedAcceptsTopLevelIDAsTurnID() {

--- a/CodexMobile/CodexMobileTests/CodexThreadProjectRoutingTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexThreadProjectRoutingTests.swift
@@ -323,6 +323,72 @@ final class CodexThreadProjectRoutingTests: XCTestCase {
         XCTAssertNil(service.thread(for: "quick-chat")?.gitWorkingDirectory)
     }
 
+    func testEmbeddedResumeHistoryRestoresCompletedTurnCollapseState() async throws {
+        let service = makeService()
+        let threadID = "thread-history-\(UUID().uuidString)"
+        let turnID = "turn-history-\(UUID().uuidString)"
+
+        service.requestTransportOverride = { method, _ in
+            XCTAssertEqual(method, "thread/resume")
+            return RPCMessage(
+                id: .string(UUID().uuidString),
+                result: .object([
+                    "thread": .object([
+                        "id": .string(threadID),
+                        "title": .string("Old mirrored chat"),
+                        "turns": .array([
+                            .object([
+                                "id": .string(turnID),
+                                "status": .string("completed"),
+                                "items": .array([
+                                    .object([
+                                        "id": .string("user-1"),
+                                        "type": .string("user_message"),
+                                        "text": .string("Fix mirrored chat"),
+                                    ]),
+                                    .object([
+                                        "id": .string("commentary-1"),
+                                        "type": .string("agentMessage"),
+                                        "phase": .string("commentary"),
+                                        "text": .string("Checking history"),
+                                    ]),
+                                    .object([
+                                        "id": .string("final-1"),
+                                        "type": .string("message"),
+                                        "role": .string("assistant"),
+                                        "phase": .string("final_answer"),
+                                        "content": .array([
+                                            .object([
+                                                "type": .string("output_text"),
+                                                "text": .string("Fixed."),
+                                            ]),
+                                        ]),
+                                    ]),
+                                ]),
+                            ]),
+                        ]),
+                    ]),
+                ]),
+                includeJSONRPC: false
+            )
+        }
+
+        _ = try await service.ensureThreadResumed(threadId: threadID, force: true)
+
+        let snapshot = service.timelineState(for: threadID).renderSnapshot
+        let renderItems = TurnTimelineRenderProjection.project(
+            messages: snapshot.messages,
+            completedTurnIDs: snapshot.completedTurnIDs
+        )
+
+        XCTAssertEqual(service.turnTerminalState(for: turnID), .completed)
+        XCTAssertTrue(snapshot.completedTurnIDs.contains(turnID))
+        XCTAssertTrue(renderItems.contains {
+            if case .previousMessages = $0 { return true }
+            return false
+        })
+    }
+
     func testProjectlessThreadTurnStartDoesNotInjectCwd() async throws {
         let service = makeService()
         service.upsertThread(CodexThread(id: "quick-chat", title: "Quick Chat", cwd: nil))

--- a/CodexMobile/CodexMobileTests/CodexTurnInputPayloadSkillTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexTurnInputPayloadSkillTests.swift
@@ -185,6 +185,24 @@ final class CodexTurnInputPayloadSkillTests: XCTestCase {
         XCTAssertTrue(service.shouldRetryTurnStartWithoutSkillItems(error))
     }
 
+    func testImageURLFallbackAcceptsExplicitImageURLError() {
+        let service = makeService()
+        let error = CodexServiceError.rpcError(
+            RPCError(code: -32602, message: "missing field image_url")
+        )
+
+        XCTAssertTrue(service.shouldRetryTurnStartWithImageURLField(error))
+    }
+
+    func testImageURLFallbackAcceptsRejectedURLFieldError() {
+        let service = makeService()
+        let error = CodexServiceError.rpcError(
+            RPCError(code: -32602, message: "unexpected field url")
+        )
+
+        XCTAssertTrue(service.shouldRetryTurnStartWithImageURLField(error))
+    }
+
     func testStartTurnRejectsEmptyStructuredMentions() async {
         let service = makeService()
         service.isConnected = true

--- a/CodexMobile/CodexMobileTests/ContentViewModelReconnectTests.swift
+++ b/CodexMobile/CodexMobileTests/ContentViewModelReconnectTests.swift
@@ -50,6 +50,35 @@ final class ContentViewModelReconnectTests: XCTestCase {
         )
     }
 
+    func testPairingCodeResolveURLCandidatesTryRelayMountedRouteBeforeRootRoute() {
+        let candidates = CodexPairingCodeResolveURLBuilder.candidates(
+            from: "wss://relay.example.com/relay?stale=1"
+        )
+
+        XCTAssertEqual(
+            candidates.map(\.absoluteString),
+            [
+                "https://relay.example.com/relay/v1/pairing/code/resolve",
+                "https://relay.example.com/v1/pairing/code/resolve",
+            ]
+        )
+    }
+
+    func testPairingCodeResolveURLCandidatesKeepProxyPrefixFallbacks() {
+        let candidates = CodexPairingCodeResolveURLBuilder.candidates(
+            from: "wss://relay.example.com/remodex/relay?stale=1#old"
+        )
+
+        XCTAssertEqual(
+            candidates.map(\.absoluteString),
+            [
+                "https://relay.example.com/remodex/relay/v1/pairing/code/resolve",
+                "https://relay.example.com/remodex/v1/pairing/code/resolve",
+                "https://relay.example.com/v1/pairing/code/resolve",
+            ]
+        )
+    }
+
     func testPreferredReconnectURLFallsBackToSavedSessionWhenTrustedResolveReportsOffline() async {
         let service = makeService()
         let viewModel = ContentViewModel()

--- a/CodexMobile/CodexMobileTests/TurnTimelineReducerTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnTimelineReducerTests.swift
@@ -599,6 +599,129 @@ final class TurnTimelineReducerTests: XCTestCase {
         XCTAssertEqual(final.id, "final-a")
     }
 
+    func testTimelineProjectionKeepsLiveTurnMessagesVisibleUntilCompletion() {
+        let now = Date()
+        let messages = [
+            makeMessage(
+                id: "user",
+                threadID: "thread",
+                role: .user,
+                text: "Optimize mirroring",
+                createdAt: now,
+                turnID: "turn-live",
+                orderIndex: 1
+            ),
+            makeMessage(
+                id: "commentary-a",
+                threadID: "thread",
+                role: .assistant,
+                assistantPhase: "commentary",
+                text: "Checking the live stream.",
+                createdAt: now.addingTimeInterval(1),
+                turnID: "turn-live",
+                itemID: "commentary-a",
+                orderIndex: 2
+            ),
+            makeMessage(
+                id: "tool",
+                threadID: "thread",
+                role: .system,
+                kind: .toolActivity,
+                text: "Inspecting session history",
+                createdAt: now.addingTimeInterval(2),
+                turnID: "turn-live",
+                itemID: "tool",
+                orderIndex: 3
+            ),
+            makeMessage(
+                id: "commentary-b",
+                threadID: "thread",
+                role: .assistant,
+                assistantPhase: "commentary",
+                text: "Found the duplicate source.",
+                createdAt: now.addingTimeInterval(3),
+                turnID: "turn-live",
+                itemID: "commentary-b",
+                isStreaming: true,
+                orderIndex: 4
+            ),
+        ]
+
+        let items = TurnTimelineRenderProjection.project(
+            messages: messages,
+            activeTurnID: "turn-live",
+            isThreadRunning: true
+        )
+
+        XCTAssertEqual(items.map(\.id), ["user", "commentary-a", "tool", "commentary-b"])
+        XCTAssertFalse(items.contains {
+            if case .previousMessages = $0 { return true }
+            return false
+        })
+    }
+
+    func testTimelineProjectionHidesDuplicateCommentaryAssistantRows() {
+        let now = Date()
+        let commentary = "La cosa non è un semplice scroll: sto controllando bridge e UI."
+        let messages = [
+            makeMessage(
+                id: "commentary-a",
+                threadID: "thread",
+                role: .assistant,
+                assistantPhase: "commentary",
+                text: commentary,
+                createdAt: now,
+                turnID: "turn-live",
+                itemID: "desktop-commentary",
+                orderIndex: 1
+            ),
+            makeMessage(
+                id: "commentary-b",
+                threadID: "thread",
+                role: .assistant,
+                assistantPhase: "commentary",
+                text: commentary,
+                createdAt: now.addingTimeInterval(1),
+                turnID: "turn-live",
+                itemID: "rollout-commentary",
+                orderIndex: 2
+            ),
+        ]
+
+        let items = TurnTimelineRenderProjection.project(messages: messages)
+
+        XCTAssertEqual(items.map(\.id), ["commentary-a"])
+    }
+
+    func testTimelineProjectionKeepsTurnlessRepeatedCommentaryRowsVisible() {
+        let now = Date()
+        let commentary = "Checking whether the bridge or UI duplicated this commentary."
+        let messages = [
+            makeMessage(
+                id: "commentary-a",
+                threadID: "thread",
+                role: .assistant,
+                assistantPhase: "commentary",
+                text: commentary,
+                createdAt: now,
+                orderIndex: 1
+            ),
+            makeMessage(
+                id: "commentary-b",
+                threadID: "thread",
+                role: .assistant,
+                assistantPhase: "commentary",
+                text: commentary,
+                createdAt: now.addingTimeInterval(1),
+                orderIndex: 2
+            ),
+        ]
+
+        let items = TurnTimelineRenderProjection.project(messages: messages)
+
+        XCTAssertEqual(items.map(\.id), ["commentary-a", "commentary-b"])
+    }
+
     func testTimelineProjectionSkipsFinalReplaysAndMergedImageArtifactsInPreviousMessages() {
         let now = Date()
         let imagePath = "/Users/example/.codex/generated_images/thread/generated-icon.png"
@@ -1063,6 +1186,86 @@ final class TurnTimelineReducerTests: XCTestCase {
         XCTAssertEqual(summary?.entries.map(\.path), ["Sources/App.swift", "Sources/Composer.swift"])
         XCTAssertEqual(summary?.entries.map(\.additions), [2, 3])
         XCTAssertEqual(summary?.entries.map(\.deletions), [1, 0])
+    }
+
+    func testTimelineProjectionHidesActiveTurnFileChangesUntilTurnCompletes() {
+        let now = Date()
+        let messages = [
+            makeMessage(
+                id: "assistant",
+                threadID: "thread",
+                role: .assistant,
+                text: "Working on it.",
+                createdAt: now,
+                turnID: "turn-1",
+                orderIndex: 1
+            ),
+            makeMessage(
+                id: "file-change",
+                threadID: "thread",
+                role: .system,
+                kind: .fileChange,
+                text: """
+                Status: completed
+
+                Path: Sources/App.swift
+                Kind: update
+                Totals: +1 -0
+                """,
+                createdAt: now.addingTimeInterval(1),
+                turnID: "turn-1",
+                orderIndex: 2
+            ),
+        ]
+
+        let runningItems = TurnTimelineRenderProjection.project(
+            messages: messages,
+            activeTurnID: "turn-1",
+            isThreadRunning: true
+        )
+        let completedItems = TurnTimelineRenderProjection.project(
+            messages: messages,
+            activeTurnID: nil,
+            isThreadRunning: false
+        )
+
+        XCTAssertEqual(runningItems.map(\.id), ["assistant"])
+        XCTAssertEqual(completedItems.map(\.id), ["assistant", "file-change"])
+    }
+
+    func testActiveFileChangeStatusSnapshotCarriesDiffSheetPayload() {
+        let now = Date()
+        let messages = [
+            makeMessage(
+                id: "file-change",
+                threadID: "thread",
+                role: .system,
+                kind: .fileChange,
+                text: """
+                Status: completed
+
+                Path: Sources/App.swift
+                Kind: update
+                Totals: +2 -1
+                """,
+                createdAt: now,
+                turnID: "turn-1",
+                orderIndex: 1
+            ),
+        ]
+
+        let snapshot = FileChangeStatusSnapshot.activeTurnSnapshot(
+            from: messages,
+            activeTurnID: "turn-1",
+            isThreadRunning: true
+        )
+
+        XCTAssertEqual(snapshot?.fileCount, 1)
+        XCTAssertEqual(snapshot?.additions, 2)
+        XCTAssertEqual(snapshot?.deletions, 1)
+        XCTAssertEqual(snapshot?.entries.map(\.path), ["Sources/App.swift"])
+        XCTAssertTrue(snapshot?.detailBodyText.contains("Sources/App.swift") == true)
+        XCTAssertTrue(snapshot?.messageID.contains("active-file-change-turn-1") == true)
     }
 
     func testTimelineProjectionMergesAdjacentSameFileChangeRows() {

--- a/CodexMobile/RemodexWidget/RemodexControlCenterWidget.swift
+++ b/CodexMobile/RemodexWidget/RemodexControlCenterWidget.swift
@@ -17,8 +17,7 @@ struct RemodexLaunchControl: ControlWidget {
         StaticControlConfiguration(kind: Self.kind) {
             ControlWidgetButton(action: RemodexLaunchIntent()) {
                 // Control Center only accepts symbol images, so this routes
-                // through the dedicated Remodex symbolset instead of the
-                // regular vector image used by Lock Screen widgets.
+                // through the control-sized Remodex symbolset.
                 Label("Remodex", image: "remodex_control_symbol")
             }
         }

--- a/CodexMobile/RemodexWidget/RemodexLockScreenWidget.swift
+++ b/CodexMobile/RemodexWidget/RemodexLockScreenWidget.swift
@@ -1,6 +1,6 @@
 // FILE: RemodexLockScreenWidget.swift
 // Purpose: Lock Screen / Always-On accessory widget that surfaces the Remodex
-//          outline logo. Tapping the widget launches Remodex on the host
+//          filled logo. Tapping the widget launches Remodex on the host
 //          device. Three accessory families are supported so the user can pick
 //          the layout that fits their Lock Screen.
 // Layer: Widget Extension
@@ -51,7 +51,7 @@ struct RemodexLockScreenWidgetView: View {
     private var circularBody: some View {
         // Keep the circular accessory as a bare glyph; the Lock Screen slot
         // already supplies the surrounding widget chrome.
-        Image("remodex-outline")
+        Image("remodex_symbol_medium")
             .resizable()
             .renderingMode(.template)
             .scaledToFit()
@@ -61,7 +61,7 @@ struct RemodexLockScreenWidgetView: View {
 
     private var rectangularBody: some View {
         HStack(spacing: 8) {
-            Image("remodex-outline")
+            Image("remodex_symbol_medium")
                 .resizable()
                 .renderingMode(.template)
                 .scaledToFit()
@@ -86,7 +86,7 @@ struct RemodexLockScreenWidgetView: View {
     private var inlineBody: some View {
         // Inline accessories collapse to a single line next to the clock; the
         // image is auto-tinted by the system.
-        Label("Remodex", image: "remodex-outline")
+        Label("Remodex", image: "remodex_symbol_medium")
     }
 }
 

--- a/phodex-bridge/bin/remodex.js
+++ b/phodex-bridge/bin/remodex.js
@@ -158,7 +158,7 @@ async function main({
         ok: true,
         currentVersion: version,
         plistPath: result?.plistPath,
-        pairingSession: result?.pairingSession,
+        pairingSession: sanitizePairingSessionForOutput(result?.pairingSession),
       });
       return;
     }

--- a/phodex-bridge/src/desktop-ipc-action-follower.js
+++ b/phodex-bridge/src/desktop-ipc-action-follower.js
@@ -605,6 +605,7 @@ function projectDesktopAssistantDeltaNotifications(
         turnId: message.turnId,
         itemId: message.itemId,
         delta,
+        ...(message.phase ? { phase: message.phase } : {}),
       },
     });
   }
@@ -629,6 +630,7 @@ function collectAssistantMessages(conversationState) {
 
       const itemId = readString(item?.id) || readString(item?.itemId) || readString(item?.item_id);
       const text = assistantMessageText(item);
+      const phase = assistantMessagePhase(item);
       if (!turnId || !itemId) {
         continue;
       }
@@ -637,6 +639,7 @@ function collectAssistantMessages(conversationState) {
         key: `${turnId}:${itemId}`,
         turnId,
         itemId,
+        phase,
         text,
       });
     }
@@ -650,6 +653,26 @@ function isAssistantMessageItem(item) {
     return true;
   }
   return type === "message" && normalizeToken(item?.role) === "assistant";
+}
+
+function assistantMessagePhase(item) {
+  return normalizeAssistantPhase(
+    readString(item?.phase)
+      || readString(item?.assistantPhase)
+      || readString(item?.assistant_phase)
+      || readString(item?.metadata?.phase)
+  );
+}
+
+function normalizeAssistantPhase(value) {
+  const normalized = normalizeToken(value);
+  if (!normalized) {
+    return "";
+  }
+  if (normalized === "finalanswer") {
+    return "final_answer";
+  }
+  return normalized;
 }
 
 function assistantMessageText(item) {

--- a/phodex-bridge/src/rollout-live-mirror.js
+++ b/phodex-bridge/src/rollout-live-mirror.js
@@ -18,6 +18,10 @@ const DEFAULT_POLL_INTERVAL_MS = 700;
 const DEFAULT_LOOKUP_TIMEOUT_MS = 5_000;
 const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
 const DEFAULT_ACTIVITY_HEARTBEAT_MS = 5_000;
+const DEFAULT_BOOTSTRAP_REPLAY_BATCH_INTERVAL_MS = 0;
+const BOOTSTRAP_REPLAY_CHUNK_SIZE = 50;
+const BOOTSTRAP_REPLAY_CHUNK_MAX_BYTES = 128 * 1024;
+const BOOTSTRAP_REPLAY_CACHE_LIMIT = 32;
 const DESKTOP_RESUME_METHODS = new Set(["thread/read", "thread/resume"]);
 
 // Observes desktop-authored rollout files and replays the currently active run as
@@ -29,12 +33,16 @@ function createRolloutLiveMirrorController({
   now = () => Date.now(),
   setIntervalFn = setInterval,
   clearIntervalFn = clearInterval,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
   pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
   lookupTimeoutMs = DEFAULT_LOOKUP_TIMEOUT_MS,
   idleTimeoutMs = DEFAULT_IDLE_TIMEOUT_MS,
   activityHeartbeatMs = DEFAULT_ACTIVITY_HEARTBEAT_MS,
+  bootstrapReplayBatchIntervalMs = DEFAULT_BOOTSTRAP_REPLAY_BATCH_INTERVAL_MS,
 } = {}) {
   const mirrorsByThreadId = new Map();
+  const bootstrapReplayCache = new Map();
 
   function observeInbound(rawMessage) {
     const request = safeParseJSON(rawMessage);
@@ -63,10 +71,14 @@ function createRolloutLiveMirrorController({
       now,
       setIntervalFn,
       clearIntervalFn,
+      setTimeoutFn,
+      clearTimeoutFn,
       pollIntervalMs,
       lookupTimeoutMs,
       idleTimeoutMs,
       activityHeartbeatMs,
+      bootstrapReplayBatchIntervalMs,
+      bootstrapReplayCache,
       onStop() {
         if (mirrorsByThreadId.get(threadId) === mirror) {
           mirrorsByThreadId.delete(threadId);
@@ -99,14 +111,19 @@ function createThreadRolloutLiveMirror({
   now,
   setIntervalFn,
   clearIntervalFn,
+  setTimeoutFn,
+  clearTimeoutFn,
   pollIntervalMs,
   lookupTimeoutMs,
   idleTimeoutMs,
   activityHeartbeatMs,
+  bootstrapReplayBatchIntervalMs,
+  bootstrapReplayCache,
   onStop = () => {},
 }) {
   const startedAt = now();
   const state = createMirrorState(threadId);
+  const bootstrapReplayTimeouts = new Set();
 
   let isStopped = false;
   let rolloutPath = null;
@@ -151,6 +168,10 @@ function createThreadRolloutLiveMirror({
           state,
           fsModule,
           sendApplicationResponse,
+          bootstrapReplayCache,
+          setTimeoutFn,
+          bootstrapReplayBatchIntervalMs,
+          pendingTimeouts: bootstrapReplayTimeouts,
         });
         lastSize = fileSize;
         lastActivityAt = currentTime;
@@ -216,6 +237,10 @@ function createThreadRolloutLiveMirror({
 
     isStopped = true;
     clearIntervalFn(intervalId);
+    for (const timeout of bootstrapReplayTimeouts) {
+      clearTimeoutFn(timeout);
+    }
+    bootstrapReplayTimeouts.clear();
     onStop();
   }
 
@@ -231,6 +256,10 @@ function bootstrapFromExistingRollout({
   state,
   fsModule,
   sendApplicationResponse,
+  bootstrapReplayCache,
+  setTimeoutFn = setTimeout,
+  bootstrapReplayBatchIntervalMs = DEFAULT_BOOTSTRAP_REPLAY_BATCH_INTERVAL_MS,
+  pendingTimeouts,
 }) {
   const initialContents = readFileSlice(rolloutPath, 0, fileSize, fsModule);
   if (!initialContents) {
@@ -261,7 +290,7 @@ function bootstrapFromExistingRollout({
     const taskEventType = parsed?.type === "event_msg"
       ? readString(parsed?.payload?.type)
       : "";
-    if (taskEventType === "user_message") {
+    if (taskEventType === "user_message" && !insideActiveRun) {
       pendingUserPreludeLine = line;
     }
     if (taskEventType === "task_started") {
@@ -273,6 +302,7 @@ function bootstrapFromExistingRollout({
       if (pendingUserPreludeLine) {
         activeRunLines.push(pendingUserPreludeLine);
       }
+      pendingUserPreludeLine = null;
       activeRunLines.push(line);
       continue;
     }
@@ -282,7 +312,7 @@ function bootstrapFromExistingRollout({
     }
 
     activeRunLines.push(line);
-    if (taskEventType === "task_complete") {
+    if (isRolloutTerminalTaskEvent(taskEventType)) {
       insideActiveRun = false;
       activeTurnId = "";
       activeRunLines.length = 0;
@@ -296,7 +326,33 @@ function bootstrapFromExistingRollout({
   }
 
   state.isDesktopOrigin = true;
-  processRolloutLines(activeRunLines, state, sendApplicationResponse);
+  const replayId = bootstrapReplayId(state.threadId, rolloutPath, initialContents);
+  const cachedBatches = bootstrapReplayCache?.get(replayId);
+  const replayNotifications = cachedBatches ? null : [];
+  // Rebuild local mirror state from the already-written run while collecting
+  // every notification into bounded catch-up batches for the phone.
+  processRolloutLines(activeRunLines, state, (rawNotification) => {
+    if (cachedBatches) {
+      return;
+    }
+    const notification = safeParseJSON(rawNotification);
+    if (notification) {
+      replayNotifications.push(notification);
+    }
+  });
+  const batches = cachedBatches || chunkBootstrapReplayNotifications(replayNotifications);
+  rememberBootstrapReplayBatches(bootstrapReplayCache, replayId, batches);
+  emitBootstrapReplayBatches(state, replayId, batches, sendApplicationResponse, {
+    setTimeoutFn,
+    batchIntervalMs: bootstrapReplayBatchIntervalMs,
+    pendingTimeouts,
+  });
+}
+
+function isRolloutTerminalTaskEvent(eventType) {
+  return eventType === "task_complete"
+    || eventType === "turn_aborted"
+    || eventType === "task_aborted";
 }
 
 function processRolloutLines(lines, state, sendApplicationResponse) {
@@ -319,6 +375,106 @@ function processRolloutLines(lines, state, sendApplicationResponse) {
     for (const notification of notifications) {
       sendApplicationResponse(JSON.stringify(notification));
     }
+  }
+}
+
+function emitBootstrapReplayBatches(
+  state,
+  replayId,
+  batches,
+  sendApplicationResponse,
+  {
+    setTimeoutFn = setTimeout,
+    batchIntervalMs = DEFAULT_BOOTSTRAP_REPLAY_BATCH_INTERVAL_MS,
+    pendingTimeouts,
+  } = {}
+) {
+  if (!Array.isArray(batches) || batches.length === 0) {
+    return;
+  }
+
+  const sendBatch = (batch, batchIndex) => {
+    sendApplicationResponse(JSON.stringify(createNotification("remodex/rollout/bootstrapReplay", {
+      threadId: state.threadId,
+      replayId,
+      batchIndex,
+      batchCount: batches.length,
+      notifications: batch,
+    })));
+  };
+
+  for (let batchIndex = 0; batchIndex < batches.length; batchIndex += 1) {
+    const batch = batches[batchIndex];
+    if (batchIndex === 0) {
+      sendBatch(batch, batchIndex);
+      continue;
+    }
+
+    if (batchIntervalMs <= 0) {
+      sendBatch(batch, batchIndex);
+      continue;
+    }
+
+    const timeout = setTimeoutFn(() => {
+      pendingTimeouts?.delete(timeout);
+      sendBatch(batch, batchIndex);
+    }, batchIndex * batchIntervalMs);
+    pendingTimeouts?.add(timeout);
+  }
+}
+
+function chunkBootstrapReplayNotifications(notifications) {
+  const batches = [];
+  let batch = [];
+  let batchBytes = 0;
+
+  for (const notification of notifications) {
+    const notificationBytes = Buffer.byteLength(JSON.stringify(notification), "utf8");
+    const shouldStartNextBatch = batch.length > 0
+      && (
+        batch.length >= BOOTSTRAP_REPLAY_CHUNK_SIZE
+        || batchBytes + notificationBytes > BOOTSTRAP_REPLAY_CHUNK_MAX_BYTES
+      );
+    if (shouldStartNextBatch) {
+      batches.push(batch);
+      batch = [];
+      batchBytes = 0;
+    }
+
+    batch.push(notification);
+    batchBytes += notificationBytes;
+  }
+
+  if (batch.length > 0) {
+    batches.push(batch);
+  }
+  return batches;
+}
+
+function bootstrapReplayId(threadId, rolloutPath, contents) {
+  return crypto
+    .createHash("sha256")
+    .update(readString(threadId))
+    .update("\0")
+    .update(readString(rolloutPath))
+    .update("\0")
+    .update(String(contents || ""))
+    .digest("hex")
+    .slice(0, 24);
+}
+
+function rememberBootstrapReplayBatches(cache, replayId, batches) {
+  if (!cache || cache.has(replayId)) {
+    return;
+  }
+
+  cache.set(replayId, batches);
+  while (cache.size > BOOTSTRAP_REPLAY_CACHE_LIMIT) {
+    const oldestKey = cache.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    cache.delete(oldestKey);
   }
 }
 

--- a/phodex-bridge/test/desktop-ipc-action-follower.test.js
+++ b/phodex-bridge/test/desktop-ipc-action-follower.test.js
@@ -414,6 +414,76 @@ test("projects canonical desktop agentMessage items as live app-server deltas", 
   );
 });
 
+test("keeps commentary assistant phase on desktop live deltas", () => {
+  const nextState = {
+    turns: [{
+      id: "turn-commentary",
+      items: [{
+        id: "commentary-1",
+        type: "message",
+        role: "assistant",
+        phase: "commentary",
+        content: [{ type: "output_text", text: "Working through the files..." }],
+      }],
+    }],
+  };
+
+  assert.deepEqual(
+    projectDesktopAssistantDeltaNotifications("thread-commentary", { turns: [] }, nextState),
+    [{
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "thread-commentary",
+        turnId: "turn-commentary",
+        itemId: "commentary-1",
+        delta: "Working through the files...",
+        phase: "commentary",
+      },
+    }]
+  );
+});
+
+test("keeps final assistant phase on desktop live deltas", () => {
+  const previousState = {
+    turns: [{
+      id: "turn-final",
+      items: [{
+        id: "final-1",
+        type: "message",
+        role: "assistant",
+        phase: "final_answer",
+        content: [{ type: "output_text", text: "Done" }],
+      }],
+    }],
+  };
+  const nextState = {
+    turns: [{
+      id: "turn-final",
+      items: [{
+        id: "final-1",
+        type: "message",
+        role: "assistant",
+        phase: "final_answer",
+        content: [{ type: "output_text", text: "Done now" }],
+      }],
+    }],
+  };
+
+  assert.deepEqual(
+    projectDesktopAssistantDeltaNotifications("thread-final", previousState, nextState),
+    [{
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "thread-final",
+        turnId: "turn-final",
+        itemId: "final-1",
+        delta: " now",
+        phase: "final_answer",
+      },
+    }]
+  );
+});
+
 test("does not replay unchanged or rewritten assistant text as live deltas", () => {
   const previousState = {
     turns: [{

--- a/phodex-bridge/test/remodex-cli.test.js
+++ b/phodex-bridge/test/remodex-cli.test.js
@@ -208,7 +208,7 @@ test("remodex pair is an alias for the QR refresh flow", async () => {
   ]);
 });
 
-test("remodex pair --json exposes the refreshed pairing payload", async () => {
+test("remodex pair --json exposes pairing readiness without private payload fields", async () => {
   const writes = [];
   const originalWrite = process.stdout.write;
 
@@ -242,8 +242,12 @@ test("remodex pair --json exposes the refreshed pairing payload", async () => {
             plistPath: "/tmp/remodex.plist",
             pairingSession: {
               pairingPayload: {
+                relay: "ws://127.0.0.1:9000/relay",
                 sessionId: "session-json-pair",
+                macIdentityPublicKey: "pub-key-pair",
+                expiresAt: 1_900_000_000_000,
               },
+              pairingCode: "ABCDEFGHJK",
             },
           };
         },
@@ -260,7 +264,15 @@ test("remodex pair --json exposes the refreshed pairing payload", async () => {
   assert.equal(payload.ok, true);
   assert.equal(payload.currentVersion, version);
   assert.equal(payload.plistPath, "/tmp/remodex.plist");
-  assert.equal(payload.pairingSession?.pairingPayload?.sessionId, "session-json-pair");
+  assert.equal(payload.pairingSession?.pairingPayload?.relay, undefined);
+  assert.equal(payload.pairingSession?.pairingPayload?.sessionId, undefined);
+  assert.equal(payload.pairingSession?.pairingPayload?.macIdentityPublicKey, undefined);
+  assert.equal(payload.pairingSession?.pairingPayload?.hasRelay, true);
+  assert.equal(payload.pairingSession?.pairingPayload?.hasSessionId, true);
+  assert.equal(payload.pairingSession?.pairingPayload?.hasMacIdentityPublicKey, true);
+  assert.equal(payload.pairingSession?.pairingPayload?.expiresAt, 1_900_000_000_000);
+  assert.equal(writes.join("").includes("ws://127.0.0.1:9000/relay"), false);
+  assert.equal(writes.join("").includes("session-json-pair"), false);
 });
 
 test("runCli prints expected failures without a Node stack trace", async () => {

--- a/phodex-bridge/test/rollout-live-mirror.test.js
+++ b/phodex-bridge/test/rollout-live-mirror.test.js
@@ -16,7 +16,7 @@ const {
   isDesktopRolloutOrigin,
 } = require("../src/rollout-live-mirror");
 
-test("desktop-origin active runs replay thinking and exec command activity on resume", async (t) => {
+test("desktop-origin active runs bootstrap compactly and keep command state for new output", async (t) => {
   const { homeDir, rolloutPath } = createTemporaryRolloutHome({
     threadId: "thread-desktop",
     originator: "Codex Desktop",
@@ -27,7 +27,6 @@ test("desktop-origin active runs replay thinking and exec command activity on re
         cmd: "git status",
         workdir: "/repo",
       }),
-      functionCallOutput("call-1", "On branch main"),
     ],
   });
   const previousCodexHome = process.env.CODEX_HOME;
@@ -38,9 +37,11 @@ test("desktop-origin active runs replay thinking and exec command activity on re
   });
 
   const outbound = [];
+  const rawOutbound = [];
   const controller = createRolloutLiveMirrorController({
     sendApplicationResponse(message) {
-      outbound.push(JSON.parse(message));
+      rawOutbound.push(JSON.parse(message));
+      recordOutbound(outbound, message);
     },
     pollIntervalMs: 5,
     idleTimeoutMs: 50,
@@ -57,6 +58,26 @@ test("desktop-origin active runs replay thinking and exec command activity on re
   await wait(30);
 
   assert.equal(rolloutPath.includes("thread-desktop"), true);
+  assert.equal(rawOutbound[0].method, "remodex/rollout/bootstrapReplay");
+  assert.match(rawOutbound[0].params.replayId, /^[a-f0-9]{24}$/);
+  assert.equal(rawOutbound[0].params.notifications.length, 3);
+  assert.deepEqual(
+    outbound.map((message) => message.method),
+    [
+      "turn/started",
+      "item/reasoning/textDelta",
+      "codex/event/exec_command_begin",
+    ]
+  );
+  assert.equal(outbound[1].params.delta, "Thinking...");
+  assert.equal(outbound[0].params.remodexDesktopMirror, true);
+  assert.equal(outbound[2].params.command, "git status");
+
+  appendRolloutLines(rolloutPath, [
+    functionCallOutput("call-1", "On branch main"),
+  ]);
+  await wait(30);
+
   assert.deepEqual(
     outbound.map((message) => message.method),
     [
@@ -67,9 +88,7 @@ test("desktop-origin active runs replay thinking and exec command activity on re
       "codex/event/exec_command_end",
     ]
   );
-  assert.equal(outbound[1].params.delta, "Thinking...");
-  assert.equal(outbound[0].params.remodexDesktopMirror, true);
-  assert.equal(outbound[2].params.command, "git status");
+  assert.equal(outbound[3].params.command, "git status");
   assert.equal(outbound[3].params.chunk, "On branch main");
 });
 
@@ -92,7 +111,7 @@ test("desktop-origin active runs emit activity heartbeat while rollout is quiet"
   const outbound = [];
   const controller = createRolloutLiveMirrorController({
     sendApplicationResponse(message) {
-      outbound.push(JSON.parse(message));
+      recordOutbound(outbound, message);
     },
     pollIntervalMs: 5,
     idleTimeoutMs: 80,
@@ -117,7 +136,7 @@ test("desktop-origin active runs emit activity heartbeat while rollout is quiet"
   assert.equal(outbound.at(-1).params.remodexRolloutLiveMirror, true);
 });
 
-test("desktop-origin bootstrap replays the pending user message and final assistant text", async (t) => {
+test("desktop-origin bootstrap replays pending user and assistant text in one catch-up batch", async (t) => {
   const { homeDir } = createTemporaryRolloutHome({
     threadId: "thread-chat",
     originator: "Codex Desktop",
@@ -138,7 +157,7 @@ test("desktop-origin bootstrap replays the pending user message and final assist
   const outbound = [];
   const controller = createRolloutLiveMirrorController({
     sendApplicationResponse(message) {
-      outbound.push(JSON.parse(message));
+      recordOutbound(outbound, message);
     },
     pollIntervalMs: 5,
     idleTimeoutMs: 50,
@@ -175,6 +194,124 @@ test("desktop-origin bootstrap replays the pending user message and final assist
   );
 });
 
+test("desktop-origin bootstrap drops aborted run state before replaying the next turn", async (t) => {
+  const { homeDir } = createTemporaryRolloutHome({
+    threadId: "thread-aborted-bootstrap",
+    originator: "Codex Desktop",
+    source: "desktop",
+    lines: [
+      userMessage("old interrupted screenshot"),
+      taskStarted("turn-aborted"),
+      userMessage("old active follow-up"),
+      turnAborted("turn-aborted"),
+      taskStarted("turn-current"),
+      userMessage("current follow-up"),
+    ],
+  });
+  const previousCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = homeDir;
+  t.after(() => {
+    restoreCodexHome(previousCodexHome);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  const outbound = [];
+  const controller = createRolloutLiveMirrorController({
+    sendApplicationResponse(message) {
+      recordOutbound(outbound, message);
+    },
+    pollIntervalMs: 5,
+    idleTimeoutMs: 50,
+  });
+  t.after(() => controller.stopAll());
+
+  controller.observeInbound(JSON.stringify({
+    method: "thread/resume",
+    params: {
+      threadId: "thread-aborted-bootstrap",
+    },
+  }));
+
+  await wait(30);
+
+  assert.deepEqual(
+    outbound.map((message) => message.method),
+    [
+      "turn/started",
+      "item/reasoning/textDelta",
+      "codex/event/user_message",
+    ]
+  );
+  assert.equal(outbound[0].params.turnId, "turn-current");
+  assert.equal(outbound[2].params.turnId, "turn-current");
+  assert.equal(outbound[2].params.message, "current follow-up");
+  assert.equal(outbound.some((message) => message.params?.message === "old interrupted screenshot"), false);
+  assert.equal(outbound.some((message) => message.params?.message === "old active follow-up"), false);
+});
+
+test("desktop-origin bootstrap replay splits large catch-up sets into ordered batches", async (t) => {
+  const toolCalls = Array.from({ length: 105 }, (_, index) => (
+    functionCall(`call-${index}`, "exec_command", {
+      cmd: `echo ${index}`,
+      workdir: "/repo",
+    })
+  ));
+  const { homeDir } = createTemporaryRolloutHome({
+    threadId: "thread-large-bootstrap",
+    originator: "Codex Desktop",
+    source: "desktop",
+    lines: [
+      taskStarted("turn-large-bootstrap"),
+      ...toolCalls,
+    ],
+  });
+  const previousCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = homeDir;
+  t.after(() => {
+    restoreCodexHome(previousCodexHome);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  const rawOutbound = [];
+  const controller = createRolloutLiveMirrorController({
+    sendApplicationResponse(message) {
+      rawOutbound.push(JSON.parse(message));
+    },
+    pollIntervalMs: 5,
+    idleTimeoutMs: 50,
+  });
+  t.after(() => controller.stopAll());
+
+  controller.observeInbound(JSON.stringify({
+    method: "thread/resume",
+    params: {
+      threadId: "thread-large-bootstrap",
+    },
+  }));
+
+  await wait(30);
+
+  assert.equal(rawOutbound.length, 3);
+  assert.deepEqual(rawOutbound.map((message) => message.method), [
+    "remodex/rollout/bootstrapReplay",
+    "remodex/rollout/bootstrapReplay",
+    "remodex/rollout/bootstrapReplay",
+  ]);
+  assert.equal(rawOutbound[0].params.batchIndex, 0);
+  assert.equal(rawOutbound[1].params.batchIndex, 1);
+  assert.equal(rawOutbound[2].params.batchIndex, 2);
+  assert.equal(rawOutbound[0].params.replayId, rawOutbound[1].params.replayId);
+  assert.equal(rawOutbound[0].params.replayId, rawOutbound[2].params.replayId);
+  assert.equal(rawOutbound[0].params.batchCount, 3);
+  assert.equal(rawOutbound[1].params.batchCount, 3);
+  assert.equal(rawOutbound[2].params.batchCount, 3);
+  assert.equal(rawOutbound[0].params.notifications.length, 50);
+  assert.equal(rawOutbound[1].params.notifications.length, 50);
+  assert.equal(rawOutbound[2].params.notifications.length, 7);
+  assert.equal(rawOutbound[0].params.notifications[0].method, "turn/started");
+  assert.equal(rawOutbound[2].params.notifications.at(-1).params.command, "echo 104");
+});
+
 test("desktop-origin live tail attaches pre-task user messages to the next turn", async (t) => {
   const { homeDir, rolloutPath } = createTemporaryRolloutHome({
     threadId: "thread-live-prelude",
@@ -192,7 +329,7 @@ test("desktop-origin live tail attaches pre-task user messages to the next turn"
   const outbound = [];
   const controller = createRolloutLiveMirrorController({
     sendApplicationResponse(message) {
-      outbound.push(JSON.parse(message));
+      recordOutbound(outbound, message);
     },
     pollIntervalMs: 5,
     idleTimeoutMs: 100,
@@ -235,13 +372,6 @@ test("desktop-origin update_plan calls mirror as structured activity plan update
     source: "desktop",
     lines: [
       taskStarted("turn-plan"),
-      functionCall("call-plan", "update_plan", {
-        explanation: "Break the work into safe slices.",
-        plan: [
-          { step: "Inspect plan rendering", status: "completed" },
-          { step: "Keep it visible", status: "in_progress" },
-        ],
-      }),
     ],
   });
   const previousCodexHome = process.env.CODEX_HOME;
@@ -254,7 +384,7 @@ test("desktop-origin update_plan calls mirror as structured activity plan update
   const outbound = [];
   const controller = createRolloutLiveMirrorController({
     sendApplicationResponse(message) {
-      outbound.push(JSON.parse(message));
+      recordOutbound(outbound, message);
     },
     pollIntervalMs: 5,
     idleTimeoutMs: 50,
@@ -268,6 +398,16 @@ test("desktop-origin update_plan calls mirror as structured activity plan update
     },
   }));
 
+  await wait(20);
+  appendRolloutLines(rolloutPathForHome(homeDir, "thread-plan"), [
+    functionCall("call-plan", "update_plan", {
+      explanation: "Break the work into safe slices.",
+      plan: [
+        { step: "Inspect plan rendering", status: "completed" },
+        { step: "Keep it visible", status: "in_progress" },
+      ],
+    }),
+  ]);
   await wait(30);
 
   assert.deepEqual(
@@ -311,7 +451,7 @@ test("desktop-origin completed plan items mirror as final plan rows", async (t) 
   const outbound = [];
   const controller = createRolloutLiveMirrorController({
     sendApplicationResponse(message) {
-      outbound.push(JSON.parse(message));
+      recordOutbound(outbound, message);
     },
     pollIntervalMs: 5,
     idleTimeoutMs: 50,
@@ -374,7 +514,7 @@ test("desktop-origin task_started without turn_id still mirrors live file change
   const outbound = [];
   const controller = createRolloutLiveMirrorController({
     sendApplicationResponse(message) {
-      outbound.push(JSON.parse(message));
+      recordOutbound(outbound, message);
     },
     pollIntervalMs: 5,
     idleTimeoutMs: 50,
@@ -426,7 +566,6 @@ test("desktop-origin active runs mirror generated image previews", async (t) => 
     source: "desktop",
     lines: [
       taskStarted("turn-image"),
-      imageGenerationCall("ig_123"),
     ],
   });
   const previousCodexHome = process.env.CODEX_HOME;
@@ -439,7 +578,7 @@ test("desktop-origin active runs mirror generated image previews", async (t) => 
   const outbound = [];
   const controller = createRolloutLiveMirrorController({
     sendApplicationResponse(message) {
-      outbound.push(JSON.parse(message));
+      recordOutbound(outbound, message);
     },
     pollIntervalMs: 5,
     idleTimeoutMs: 50,
@@ -453,6 +592,10 @@ test("desktop-origin active runs mirror generated image previews", async (t) => 
     },
   }));
 
+  await wait(20);
+  appendRolloutLines(rolloutPathForHome(homeDir, "thread-image"), [
+    imageGenerationCall("ig_123"),
+  ]);
   await wait(30);
 
   assert.deepEqual(
@@ -479,7 +622,6 @@ test("desktop-origin active runs mirror imageView items", async (t) => {
     source: "desktop",
     lines: [
       taskStarted("turn-image-view"),
-      imageViewItem("view_123", "/tmp/generated view.png"),
     ],
   });
   const previousCodexHome = process.env.CODEX_HOME;
@@ -492,7 +634,7 @@ test("desktop-origin active runs mirror imageView items", async (t) => {
   const outbound = [];
   const controller = createRolloutLiveMirrorController({
     sendApplicationResponse(message) {
-      outbound.push(JSON.parse(message));
+      recordOutbound(outbound, message);
     },
     pollIntervalMs: 5,
     idleTimeoutMs: 50,
@@ -506,6 +648,10 @@ test("desktop-origin active runs mirror imageView items", async (t) => {
     },
   }));
 
+  await wait(20);
+  appendRolloutLines(rolloutPathForHome(homeDir, "thread-image-view"), [
+    imageViewItem("view_123", "/tmp/generated view.png"),
+  ]);
   await wait(30);
 
   assert.deepEqual(
@@ -527,7 +673,6 @@ test("desktop-origin active runs mirror image_generation items", async (t) => {
     source: "desktop",
     lines: [
       taskStarted("turn-image-generation"),
-      imageGenerationItem("ig_generation", "/tmp/generated item.png"),
     ],
   });
   const previousCodexHome = process.env.CODEX_HOME;
@@ -540,7 +685,7 @@ test("desktop-origin active runs mirror image_generation items", async (t) => {
   const outbound = [];
   const controller = createRolloutLiveMirrorController({
     sendApplicationResponse(message) {
-      outbound.push(JSON.parse(message));
+      recordOutbound(outbound, message);
     },
     pollIntervalMs: 5,
     idleTimeoutMs: 50,
@@ -554,6 +699,10 @@ test("desktop-origin active runs mirror image_generation items", async (t) => {
     },
   }));
 
+  await wait(20);
+  appendRolloutLines(rolloutPathForHome(homeDir, "thread-image-generation"), [
+    imageGenerationItem("ig_generation", "/tmp/generated item.png"),
+  ]);
   await wait(30);
 
   assert.deepEqual(
@@ -575,7 +724,6 @@ test("desktop-origin active runs mirror generated image end events without respo
     source: "desktop",
     lines: [
       taskStarted("turn-image-event"),
-      imageGenerationEnd("turn-image-event", "ig_event", "/tmp/generated event.png"),
     ],
   });
   const previousCodexHome = process.env.CODEX_HOME;
@@ -588,7 +736,7 @@ test("desktop-origin active runs mirror generated image end events without respo
   const outbound = [];
   const controller = createRolloutLiveMirrorController({
     sendApplicationResponse(message) {
-      outbound.push(JSON.parse(message));
+      recordOutbound(outbound, message);
     },
     pollIntervalMs: 5,
     idleTimeoutMs: 50,
@@ -602,6 +750,10 @@ test("desktop-origin active runs mirror generated image end events without respo
     },
   }));
 
+  await wait(20);
+  appendRolloutLines(rolloutPathForHome(homeDir, "thread-image-event"), [
+    imageGenerationEnd("turn-image-event", "ig_event", "/tmp/generated event.png"),
+  ]);
   await wait(30);
 
   assert.deepEqual(
@@ -641,7 +793,7 @@ test("phone-origin rollouts do not emit mirrored updates", async (t) => {
   const outbound = [];
   const controller = createRolloutLiveMirrorController({
     sendApplicationResponse(message) {
-      outbound.push(JSON.parse(message));
+      recordOutbound(outbound, message);
     },
     pollIntervalMs: 5,
     idleTimeoutMs: 50,
@@ -677,7 +829,7 @@ test("desktop-origin idle watchers stream new rollout growth after the phone reo
   const outbound = [];
   const controller = createRolloutLiveMirrorController({
     sendApplicationResponse(message) {
-      outbound.push(JSON.parse(message));
+      recordOutbound(outbound, message);
     },
     pollIntervalMs: 5,
     idleTimeoutMs: 100,
@@ -719,14 +871,12 @@ test("desktop-origin rollouts mirror custom apply_patch as file-change lifecycle
     "*** End Patch",
     "",
   ].join("\n");
-  const { homeDir } = createTemporaryRolloutHome({
+  const { homeDir, rolloutPath } = createTemporaryRolloutHome({
     threadId: "thread-patch",
     originator: "Codex Desktop",
     source: "desktop",
     lines: [
       taskStarted("turn-patch"),
-      customToolCall("call-patch", "apply_patch", patch),
-      patchApplyEnd("turn-patch", "call-patch"),
     ],
   });
   const previousCodexHome = process.env.CODEX_HOME;
@@ -739,7 +889,7 @@ test("desktop-origin rollouts mirror custom apply_patch as file-change lifecycle
   const outbound = [];
   const controller = createRolloutLiveMirrorController({
     sendApplicationResponse(message) {
-      outbound.push(JSON.parse(message));
+      recordOutbound(outbound, message);
     },
     pollIntervalMs: 5,
     idleTimeoutMs: 50,
@@ -753,6 +903,11 @@ test("desktop-origin rollouts mirror custom apply_patch as file-change lifecycle
     },
   }));
 
+  await wait(20);
+  appendRolloutLines(rolloutPath, [
+    customToolCall("call-patch", "apply_patch", patch),
+    patchApplyEnd("turn-patch", "call-patch"),
+  ]);
   await wait(30);
 
   assert.deepEqual(
@@ -817,7 +972,7 @@ test("desktop-origin rollouts emit turn-end file-change snapshot after final tex
   const outbound = [];
   const controller = createRolloutLiveMirrorController({
     sendApplicationResponse(message) {
-      outbound.push(JSON.parse(message));
+      recordOutbound(outbound, message);
     },
     pollIntervalMs: 5,
     idleTimeoutMs: 50,
@@ -881,8 +1036,31 @@ function createTemporaryRolloutHome({ threadId, originator, source, lines }) {
   return { homeDir, rolloutPath };
 }
 
+function rolloutPathForHome(homeDir, threadId) {
+  return path.join(
+    homeDir,
+    "sessions",
+    "2026",
+    "03",
+    "15",
+    `rollout-2026-03-15T19-47-36-${threadId}.jsonl`
+  );
+}
+
 function appendRolloutLines(rolloutPath, lines) {
   fs.appendFileSync(rolloutPath, `${lines.join("\n")}\n`);
+}
+
+function recordOutbound(outbound, message) {
+  const parsed = JSON.parse(message);
+  if (parsed.method !== "remodex/rollout/bootstrapReplay") {
+    outbound.push(parsed);
+    return;
+  }
+
+  for (const notification of parsed.params?.notifications || []) {
+    outbound.push(notification);
+  }
 }
 
 function taskStarted(turnId) {
@@ -996,6 +1174,18 @@ function taskComplete(turnId) {
     payload: {
       type: "task_complete",
       turn_id: turnId,
+    },
+  });
+}
+
+function turnAborted(turnId) {
+  return JSON.stringify({
+    timestamp: "2026-03-15T19:47:41.000Z",
+    type: "event_msg",
+    payload: {
+      type: "turn_aborted",
+      turn_id: turnId,
+      reason: "interrupted",
     },
   });
 }


### PR DESCRIPTION
## Summary
- Batch desktop replay/bootstrap mirroring so resumed threads do not flood iOS with thousands of individual events.
- Preserve item/phase identity through the bridge and iOS timeline so live deltas update the right row instead of duplicating old assistant text.
- Reduce active streaming cost by coalescing updates, rendering large in-flight assistant text more cheaply, and keeping file-change/tool/status UI compact while a turn is running.
- Refresh local-first settings/about/command reference UI and add focused regression coverage for replay, dedupe, routing, and reconnect behavior.

## What changed
- Added `remodex/rollout/bootstrapReplay` batch handling on both bridge and iOS, with ordered chunking and final-batch reconciliation.
- Reset aborted run state before replaying the next turn and kept pending user prelude messages scoped to the active run.
- Added assistant commentary/final phase propagation from desktop IPC and iOS duplicate-commentary adoption/hiding safeguards.
- Kept active file-change rows out of the main stream while a turn is running, replacing them with a compact status capsule/diff sheet entry point.
- Tuned streaming text rendering so large active markdown does not repeatedly rebuild the expensive rich renderer.
- Added settings command reference, pairing resolve URL fallback cleanup, and composer/input stability tweaks.

## Validation
- `git diff --check`
- `node --test ./test/rollout-live-mirror.test.js ./test/desktop-ipc-action-follower.test.js ./test/remodex-cli.test.js`
- `{ git diff --name-only -z -- '*.swift'; git ls-files --others -z --exclude-standard -- '*.swift'; } | xargs -0 xcrun swiftc -parse`

## Notes
- Full Xcode tests were not run, per the repo guardrail to avoid running them unless explicitly requested.
