### PR TITLE
Fix desktop IPC mirror tool activity

### DIFF
--- a/CodexMobile/CodexMobile/Services/CodexService+Incoming.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Incoming.swift
@@ -599,6 +599,7 @@ extension CodexService {
     private func handleTurnCompleted(_ paramsObject: IncomingParamsObject?) {
         let completedTurnID = extractTurnIDForTurnLifecycleEvent(from: paramsObject)
         let turnFailureMessage = parseTurnFailureMessage(from: paramsObject)
+        let isDesktopIpcMirrorCompletion = paramsObject?["remodexDesktopIpcMirror"]?.boolValue == true
 
         if let threadId = resolveThreadID(from: paramsObject, turnIdHint: completedTurnID) {
             if let completedTurnID {
@@ -609,9 +610,29 @@ extension CodexService {
                 from: paramsObject,
                 turnFailureMessage: turnFailureMessage
             )
+            if isDesktopIpcMirrorCompletion {
+                suppressCanonicalHistoryReconcileAfterDesktopIpcCompletion(for: threadId)
+                if hasActiveStreamingSystemActivity(threadId: threadId, turnId: resolvedTurnID) {
+                    return
+                }
+                // Desktop IPC completion is an idle/local projection signal. It can stop
+                // running chrome, but must not stamp the turn terminal: a premature
+                // terminal state makes live commentary collapse behind "previous messages"
+                // and makes later mirror activity look stale.
+                markTurnCompleted(
+                    threadId: threadId,
+                    turnId: resolvedTurnID,
+                    scheduleHistoryReconcile: false
+                )
+                return
+            }
             recordTurnTerminalState(threadId: threadId, turnId: resolvedTurnID, state: terminalState)
             noteTurnFinished(turnId: resolvedTurnID)
-            markTurnCompleted(threadId: threadId, turnId: resolvedTurnID)
+            markTurnCompleted(
+                threadId: threadId,
+                turnId: resolvedTurnID,
+                scheduleHistoryReconcile: true
+            )
             if terminalState == .completed {
                 Task { @MainActor [weak self] in
                     await self?.captureTurnEndWorkspaceCheckpointIfPossible(

--- a/CodexMobile/CodexMobile/Services/CodexService+Messages.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Messages.swift
@@ -459,7 +459,7 @@ extension CodexService {
     }
 
     // Clears running/fallback flags together when a thread finishes or disappears.
-    func clearRunningState(for threadId: String) {
+    func clearRunningState(for threadId: String, scheduleHistoryReconcile: Bool = true) {
         runningThreadIDs.remove(threadId)
         protectedRunningFallbackThreadIDs.remove(threadId)
         desktopMirroredRunningThreadIDs.remove(threadId)
@@ -468,7 +468,9 @@ extension CodexService {
         clearMirroredRunningCatchupNeeded(for: threadId)
         refreshBusyRepoRootsAndDependentTimelineStates()
         refreshThreadTimelineState(for: threadId)
-        scheduleCanonicalHistoryReconcileIfNeeded(for: threadId)
+        if scheduleHistoryReconcile {
+            scheduleCanonicalHistoryReconcileIfNeeded(for: threadId)
+        }
     }
 
     // Clears every running marker during disconnect/cleanup so stale repo-busy state cannot leak.
@@ -592,6 +594,16 @@ extension CodexService {
         threadsWithSatisfiedDeferredHistoryHydration.insert(threadId)
     }
 
+    // Desktop IPC completion is only a local mirror signal, not proof that a
+    // follow-up thread/read is authoritative enough to replace local chronology.
+    func suppressCanonicalHistoryReconcileAfterDesktopIpcCompletion(for threadId: String) {
+        threadsNeedingCanonicalHistoryReconcile.remove(threadId)
+        canonicalHistoryReconcileTaskByThreadID[threadId]?.cancel()
+        canonicalHistoryReconcileTaskByThreadID.removeValue(forKey: threadId)
+        canonicalHistoryReconcileRetryTaskByThreadID[threadId]?.cancel()
+        canonicalHistoryReconcileRetryTaskByThreadID.removeValue(forKey: threadId)
+    }
+
     // With turn pagination, the cursor-backed store replaces one-shot full-history reconciliation.
     func markThreadPaginatedHistorySatisfied(_ threadId: String) {
         threadsNeedingCanonicalHistoryReconcile.remove(threadId)
@@ -611,6 +623,40 @@ extension CodexService {
     // Returns turn ids that ended via interruption so copy actions can stay hidden.
     func stoppedTurnIDs(for threadId: String) -> Set<String> {
         stoppedTurnIDsByThread[threadId] ?? []
+    }
+
+    // Desktop IPC idle completion can arrive while tool rows are still the only active signal.
+    // Keep those rows streaming/running until their own item completion lands.
+    func hasActiveStreamingSystemActivity(threadId: String, turnId: String?) -> Bool {
+        let normalizedTurnId = normalizedIdentifier(turnId)
+        let belongsToTurn: (String?) -> Bool = { candidateTurnId in
+            guard let normalizedTurnId else { return true }
+            return self.normalizedIdentifier(candidateTurnId) == normalizedTurnId
+        }
+
+        if pendingSystemDeltasByKey.values.contains(where: { pending in
+            pending.threadId == threadId
+                && belongsToTurn(pending.turnId)
+                && Self.isActiveSystemActivityKind(pending.kind)
+        }) {
+            return true
+        }
+
+        return messagesByThread[threadId]?.contains(where: { message in
+            message.role == .system
+                && message.isStreaming
+                && belongsToTurn(message.turnId)
+                && Self.isActiveSystemActivityKind(message.kind)
+        }) ?? false
+    }
+
+    private static func isActiveSystemActivityKind(_ kind: CodexMessageKind) -> Bool {
+        switch kind {
+        case .toolActivity, .commandExecution, .fileChange, .subagentAction:
+            return true
+        case .thinking, .chat, .plan, .userInputPrompt:
+            return false
+        }
     }
 
     // Returns sidebar-only chat badge state. This intentionally stays separate from
@@ -4108,13 +4154,18 @@ extension CodexService {
         return true
     }
 
-    // Marks streaming assistant state complete once turn/completed arrives.
-    func markTurnCompleted(threadId: String, turnId: String?) {
+    // Flushes streaming rows and clears running flags for terminal or synthetic completion signals.
+    // Callers decide whether the signal is authoritative enough to trigger canonical history reconcile.
+    func markTurnCompleted(
+        threadId: String,
+        turnId: String?,
+        scheduleHistoryReconcile: Bool = true
+    ) {
         let resolvedTurnId = turnId ?? activeTurnIdByThread[threadId]
         flushPendingAssistantDeltas(for: threadId, turnId: resolvedTurnId)
         flushPendingSystemDeltasForTurn(threadId: threadId, turnId: resolvedTurnId)
 
-        clearRunningState(for: threadId)
+        clearRunningState(for: threadId, scheduleHistoryReconcile: scheduleHistoryReconcile)
         clearRunningThreadWatch(threadId)
         let shouldFinalizePlanSteps: Bool = {
             if let resolvedTurnId {

--- a/CodexMobile/CodexMobile/Services/CodexService+Messages.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Messages.swift
@@ -1355,14 +1355,23 @@ extension CodexService {
                 messagesByThread[threadId]?[existingIndex].createdAt = createdAt
                 didMutate = true
             }
+            if moveMirroredOpeningUserBeforeTurnOutputIfNeeded(
+                threadId: threadId,
+                turnId: turnId,
+                messageIndex: existingIndex
+            ) {
+                didMutate = true
+            }
             guard didMutate else {
                 return
             }
+            messagesByThread[threadId]?.sort(by: { $0.orderIndex < $1.orderIndex })
             persistMessages()
             updateCurrentOutput(for: threadId)
             return
         }
 
+        let orderIndex = reserveMirroredOpeningUserOrderIndex(threadId: threadId, turnId: turnId)
         appendMessage(
             CodexMessage(
                 threadId: threadId,
@@ -1371,9 +1380,87 @@ extension CodexService {
                 fileMentions: fileMentions,
                 createdAt: createdAt ?? Date(),
                 turnId: turnId,
-                deliveryState: .confirmed
+                deliveryState: .confirmed,
+                orderIndex: orderIndex
             )
         )
+    }
+
+    // Desktop rollout mirrors can deliver assistant output before the opening user event.
+    // Reserve the first same-turn slot so the phone timeline matches the Mac transcript.
+    private func reserveMirroredOpeningUserOrderIndex(threadId: String, turnId: String?) -> Int? {
+        guard let turnAnchor = mirroredOpeningUserAnchor(threadId: threadId, turnId: turnId) else {
+            return nil
+        }
+
+        guard let indices = messagesByThread[threadId]?.indices else {
+            return turnAnchor
+        }
+
+        for index in indices {
+            guard let currentOrder = messagesByThread[threadId]?[index].orderIndex,
+                  currentOrder >= turnAnchor else {
+                continue
+            }
+            messagesByThread[threadId]?[index].orderIndex = currentOrder + 1
+        }
+        CodexMessageOrderCounter.seed(from: messagesByThread)
+        return turnAnchor
+    }
+
+    // Repositions an already-created mirrored opener without moving real steer prompts.
+    private func moveMirroredOpeningUserBeforeTurnOutputIfNeeded(
+        threadId: String,
+        turnId: String?,
+        messageIndex: Int
+    ) -> Bool {
+        guard let threadMessages = messagesByThread[threadId],
+              threadMessages.indices.contains(messageIndex),
+              let turnAnchor = mirroredOpeningUserAnchor(
+                threadId: threadId,
+                turnId: turnId,
+                existingMessageID: threadMessages[messageIndex].id
+              ),
+              threadMessages[messageIndex].orderIndex > turnAnchor else {
+            return false
+        }
+
+        let previousOrder = threadMessages[messageIndex].orderIndex
+        for index in threadMessages.indices where index != messageIndex {
+            guard let currentOrder = messagesByThread[threadId]?[index].orderIndex,
+                  currentOrder >= turnAnchor,
+                  currentOrder < previousOrder else {
+                continue
+            }
+            messagesByThread[threadId]?[index].orderIndex = currentOrder + 1
+        }
+        messagesByThread[threadId]?[messageIndex].orderIndex = turnAnchor
+        return true
+    }
+
+    // Returns the first output slot only when this turn has no other user row.
+    // Multiple user rows mean an in-turn steer, where chronological order is intentional.
+    private func mirroredOpeningUserAnchor(
+        threadId: String,
+        turnId: String?,
+        existingMessageID: String? = nil
+    ) -> Int? {
+        guard let turnId, !turnId.isEmpty,
+              let threadMessages = messagesByThread[threadId] else {
+            return nil
+        }
+
+        var firstOutputOrder: Int?
+        for message in threadMessages where message.turnId == turnId {
+            if message.id == existingMessageID {
+                continue
+            }
+            if message.role == .user {
+                return nil
+            }
+            firstOutputOrder = min(firstOutputOrder ?? message.orderIndex, message.orderIndex)
+        }
+        return firstOutputOrder
     }
 
     // Appends a system message in the current thread timeline.
@@ -1443,7 +1530,6 @@ extension CodexService {
                 if threadMessages[targetIndex].itemId == nil {
                     threadMessages[targetIndex].itemId = itemId
                 }
-                let keepID = threadMessages[targetIndex].id
                 pruneDuplicateSystemRows(
                     in: &threadMessages,
                     keepIndex: targetIndex,

--- a/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
@@ -1747,6 +1747,7 @@ extension CodexService {
         mentionMentions: [CodexTurnMention] = [],
         fileMentions: [String] = [],
         shouldAppendUserMessage: Bool = true,
+        preAppendedUserMessageID: String? = nil,
         collaborationMode: CodexCollaborationModeKind? = nil
     ) async throws {
         let normalizedThreadID = normalizedInterruptIdentifier(threadId) ?? threadId
@@ -1758,8 +1759,12 @@ extension CodexService {
             threadId: normalizedThreadID,
             collaborationMode: effectiveRequestedCollaborationMode
         )
-        let pendingMessageId = shouldAppendUserMessage
-            ? appendUserMessage(
+        let normalizedPreAppendedUserMessageID = normalizedInterruptIdentifier(preAppendedUserMessageID)
+        let pendingMessageId: String
+        if let normalizedPreAppendedUserMessageID {
+            pendingMessageId = normalizedPreAppendedUserMessageID
+        } else if shouldAppendUserMessage {
+            pendingMessageId = appendUserMessage(
                 threadId: normalizedThreadID,
                 text: displayTextForOutgoingTurn(
                     userInput: userInput,
@@ -1778,7 +1783,9 @@ extension CodexService {
                     return normalized.isEmpty ? nil : normalized
                 }
             )
-            : ""
+        } else {
+            pendingMessageId = ""
+        }
         var resolvedExpectedTurnID = normalizedInterruptIdentifier(expectedTurnId)
         if resolvedExpectedTurnID == nil {
             do {

--- a/CodexMobile/CodexMobile/Views/Turn/Core/TurnConversationContainerView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Core/TurnConversationContainerView.swift
@@ -49,37 +49,9 @@ struct TurnConversationContainerView: View {
     let onTapOutsideComposer: () -> Void
 
     @State private var isShowingPinnedPlanSheet = false
-    @State private var cachedMessageLayout = TimelineMessageLayout.empty
-    @State private var lastMessageLayoutThreadID: String?
-    @State private var lastMessageLayoutToken: Int = -1
-
-    // Body reads only cached layout; `rebuildMessageLayoutIfNeeded` commits updates off-thread.
-    private var messageLayout: TimelineMessageLayout {
-        cachedMessageLayout
-    }
-
-    // Detects the pending-send append that can arrive just after the timeline
-    // token observer ran, without comparing the full message array.
-    private var messageLayoutInputSignature: Int {
-        var hasher = Hasher()
-        hasher.combine(threadID)
-        hasher.combine(messages.count)
-        if let first = messages.first {
-            hasher.combine(first.id)
-            hasher.combine(first.orderIndex)
-        }
-        if let last = messages.last {
-            hasher.combine(last.id)
-            hasher.combine(last.role)
-            hasher.combine(last.kind)
-            hasher.combine(last.turnId)
-            hasher.combine(last.orderIndex)
-        }
-        return hasher.finalize()
-    }
 
     // Keeps accessory-only chats informative instead of showing a blank viewport.
-    private var timelineEmptyState: AnyView {
+    private func timelineEmptyState(for messageLayout: TimelineMessageLayout) -> AnyView {
         guard messageLayout.timelineMessages.isEmpty else {
             return emptyState
         }
@@ -107,6 +79,13 @@ struct TurnConversationContainerView: View {
 
     // ─── ENTRY POINT ─────────────────────────────────────────────
     var body: some View {
+        // Keep this split synchronous with `messages`: cached layout refreshes can
+        // be starved by rapid assistant streaming and hide a just-sent user row.
+        let messageLayout = Self.buildMessageLayout(
+            from: messages,
+            planSessionSource: planSessionSource
+        )
+
         ZStack(alignment: .top) {
             TurnTimelineView(
                 threadID: threadID,
@@ -145,9 +124,9 @@ struct TurnConversationContainerView: View {
                 onRetryEarlierMessages: onRetryEarlierMessages,
                 onTapOutsideComposer: onTapOutsideComposer
             ) {
-                timelineEmptyState
+                timelineEmptyState(for: messageLayout)
             } composer: {
-                composerWithPinnedPlanAccessory
+                composerWithPinnedPlanAccessory(for: messageLayout)
             }
 
             VStack(spacing: 0) {
@@ -157,19 +136,7 @@ struct TurnConversationContainerView: View {
                 }
             }
         }
-        .onAppear {
-            rebuildMessageLayoutIfNeeded(force: true)
-        }
-        .task(id: timelineChangeToken) {
-            rebuildMessageLayoutIfNeeded()
-        }
-        .onChange(of: threadID) { _, _ in
-            rebuildMessageLayoutIfNeeded(force: true)
-        }
-        .onChange(of: messageLayoutInputSignature) { _, _ in
-            rebuildMessageLayoutIfNeeded(force: true)
-        }
-        .onChange(of: cachedMessageLayout.pinnedTaskPlanMessage?.id) { _, newValue in
+        .onChange(of: messageLayout.pinnedTaskPlanMessage?.id) { _, newValue in
             if newValue == nil {
                 isShowingPinnedPlanSheet = false
             }
@@ -182,7 +149,7 @@ struct TurnConversationContainerView: View {
     }
 
     // Keeps the active plan discoverable without covering the message timeline.
-    private var composerWithPinnedPlanAccessory: some View {
+    private func composerWithPinnedPlanAccessory(for messageLayout: TimelineMessageLayout) -> some View {
         VStack(spacing: 8) {
             if let pinnedTaskPlanMessage = messageLayout.pinnedTaskPlanMessage {
                 PlanExecutionAccessory(message: pinnedTaskPlanMessage) {
@@ -208,22 +175,6 @@ struct TurnConversationContainerView: View {
         }
         .animation(.easeInOut(duration: 0.18), value: messageLayout.pinnedTaskPlanMessage?.id)
         .animation(.easeInOut(duration: 0.18), value: messageLayout.activeStructuredPromptMessage?.id)
-    }
-
-    // Rebuilds the plan/timeline split only when the thread or timeline token really changed.
-    private func rebuildMessageLayoutIfNeeded(force: Bool = false) {
-        guard force
-                || lastMessageLayoutThreadID != threadID
-                || lastMessageLayoutToken != timelineChangeToken else {
-            return
-        }
-
-        lastMessageLayoutThreadID = threadID
-        lastMessageLayoutToken = timelineChangeToken
-        cachedMessageLayout = Self.buildMessageLayout(
-            from: messages,
-            planSessionSource: planSessionSource
-        )
     }
 
     // Separates pinned plan content from renderable timeline rows in one pass.

--- a/CodexMobile/CodexMobile/Views/Turn/Core/TurnViewModel.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Core/TurnViewModel.swift
@@ -57,6 +57,8 @@ struct TurnComposerAttachmentIntakePlan {
 
 struct QueuedTurnDraft: Identifiable {
     let id: String
+    // Points at the optimistic timeline bubble shown while this draft waits behind a running turn.
+    let preAppendedMessageID: String?
     let text: String
     let attachments: [CodexImageAttachment]
     let skillMentions: [CodexTurnSkillMention]
@@ -74,6 +76,7 @@ struct QueuedTurnDraft: Identifiable {
 
     init(
         id: String,
+        preAppendedMessageID: String? = nil,
         text: String,
         attachments: [CodexImageAttachment],
         skillMentions: [CodexTurnSkillMention],
@@ -88,6 +91,7 @@ struct QueuedTurnDraft: Identifiable {
         createdAt: Date
     ) {
         self.id = id
+        self.preAppendedMessageID = preAppendedMessageID
         self.text = text
         self.attachments = attachments
         self.skillMentions = skillMentions
@@ -100,6 +104,26 @@ struct QueuedTurnDraft: Identifiable {
         self.rawAttachments = rawAttachments
         self.rawSubagentsSelectionArmed = rawSubagentsSelectionArmed
         self.createdAt = createdAt
+    }
+
+    // Carries the optimistic row id without rebuilding queue payloads at call sites.
+    func withPreAppendedMessageID(_ messageID: String?) -> QueuedTurnDraft {
+        QueuedTurnDraft(
+            id: id,
+            preAppendedMessageID: messageID,
+            text: text,
+            attachments: attachments,
+            skillMentions: skillMentions,
+            mentionMentions: mentionMentions,
+            collaborationMode: collaborationMode,
+            rawInput: rawInput,
+            rawFileMentions: rawFileMentions,
+            rawSkillMentions: rawSkillMentions,
+            rawPluginMentions: rawPluginMentions,
+            rawAttachments: rawAttachments,
+            rawSubagentsSelectionArmed: rawSubagentsSelectionArmed,
+            createdAt: createdAt
+        )
     }
 }
 
@@ -521,10 +545,19 @@ final class TurnViewModel {
         queuedDrafts(codex: codex, threadID: threadID)
     }
 
-    func removeQueuedDraft(id: String, codex: CodexService, threadID: String) {
+    func removeQueuedDraft(
+        id: String,
+        codex: CodexService,
+        threadID: String,
+        removeOptimisticMessage: Bool = true
+    ) {
         var drafts = queuedDrafts(codex: codex, threadID: threadID)
+        let removedDraft = drafts.first { $0.id == id }
         drafts.removeAll { $0.id == id }
         setQueuedDrafts(drafts, codex: codex, threadID: threadID)
+        if removeOptimisticMessage {
+            removeQueuedDraftOptimisticMessageIfNeeded(removedDraft, codex: codex, threadID: threadID)
+        }
     }
 
     // Moves one queued row back into the composer so the user can edit/resend it manually.
@@ -540,6 +573,7 @@ final class TurnViewModel {
 
         let draft = drafts.remove(at: draftIndex)
         setQueuedDrafts(drafts, codex: codex, threadID: threadID)
+        removeQueuedDraftOptimisticMessageIfNeeded(draft, codex: codex, threadID: threadID)
         restoreComposerState(from: draft)
         clearComposerAutocomplete()
         shouldAnchorToAssistantResponse = false
@@ -1358,11 +1392,16 @@ final class TurnViewModel {
             return
         }
 
-        let queuedDraft = pendingSend.rawReviewSelection == nil
+        let initialQueuedDraft = pendingSend.rawReviewSelection == nil
             ? makeQueuedDraft(from: pendingSend)
             : nil
         let threadBusy = isThreadBusy(codex: codex, threadID: threadID)
         let queuePaused = isQueuePaused(codex: codex, threadID: threadID)
+        // Busy-state refresh may wait on the runtime. Publish the queued bubble
+        // before any await so follow-ups appear above the first assistant block.
+        let queuedDraft = threadBusy
+            ? initialQueuedDraft.map { preAppendQueuedDraftMessageIfNeeded($0, codex: codex, threadID: threadID) }
+            : initialQueuedDraft
 
         subscriptions?.consumeFreeSendAttemptIfNeeded()
         isSending = true
@@ -1384,6 +1423,9 @@ final class TurnViewModel {
                 return
             }
 
+            let preAppendedMessage = queuedDraft?.preAppendedMessageID.map {
+                CodexPreAppendedTurnMessage(messageID: $0, automaticTitleSeed: nil)
+            }
             if queuePaused, let queuedDraft {
                 appendQueuedDraft(queuedDraft, codex: codex, threadID: threadID)
                 clearLocalDraft(codex: codex, threadID: threadID, persistToDisk: true)
@@ -1392,7 +1434,12 @@ final class TurnViewModel {
                 return
             }
 
-            await performTurnSend(pendingSend, codex: codex, threadID: threadID)
+            await performTurnSend(
+                pendingSend,
+                codex: codex,
+                threadID: threadID,
+                preAppendedMessage: preAppendedMessage
+            )
         }
     }
 
@@ -1685,6 +1732,8 @@ final class TurnViewModel {
                     skillMentions: nextDraft.skillMentions,
                     mentionMentions: nextDraft.mentionMentions,
                     fileMentions: confirmedFileMentionPaths(from: nextDraft.rawFileMentions),
+                    shouldAppendUserMessage: nextDraft.preAppendedMessageID == nil,
+                    preAppendedUserMessageID: nextDraft.preAppendedMessageID,
                     collaborationMode: nextDraft.collaborationMode
                 )
                 codex.lastErrorMessage = nil
@@ -1739,9 +1788,11 @@ final class TurnViewModel {
                         skillMentions: draft.skillMentions,
                         mentionMentions: draft.mentionMentions,
                         fileMentions: confirmedFileMentionPaths(from: draft.rawFileMentions),
+                        shouldAppendUserMessage: draft.preAppendedMessageID == nil,
+                        preAppendedUserMessageID: draft.preAppendedMessageID,
                         collaborationMode: draft.collaborationMode
                     )
-                    removeQueuedDraft(id: id, codex: codex, threadID: threadID)
+                    removeQueuedDraft(id: id, codex: codex, threadID: threadID, removeOptimisticMessage: false)
                     return
                 }
 
@@ -1757,17 +1808,14 @@ final class TurnViewModel {
                     skillMentions: draft.skillMentions,
                     mentionMentions: draft.mentionMentions,
                     fileMentions: confirmedFileMentionPaths(from: draft.rawFileMentions),
-                    shouldAppendUserMessage: true,
+                    shouldAppendUserMessage: draft.preAppendedMessageID == nil,
+                    preAppendedUserMessageID: draft.preAppendedMessageID,
                     collaborationMode: draft.collaborationMode
                 )
-                removeQueuedDraft(id: id, codex: codex, threadID: threadID)
+                removeQueuedDraft(id: id, codex: codex, threadID: threadID, removeOptimisticMessage: false)
             } catch {
                 shouldAnchorToAssistantResponse = false
-                codex.removeLatestFailedUserMessage(
-                    threadId: threadID,
-                    matchingText: draft.text,
-                    matchingAttachments: draft.attachments
-                )
+                clearQueuedDraftOptimisticMessage(id: id, draft: draft, codex: codex, threadID: threadID)
                 codex.lastErrorMessage = codex.userFacingTurnErrorMessageForFooter(from: error)
             }
         }
@@ -2545,7 +2593,11 @@ final class TurnViewModel {
 
         isPlanModeArmed = false
         shouldAnchorToAssistantResponse = true
-        appendQueuedDraft(queuedDraft, codex: codex, threadID: threadID)
+        appendQueuedDraft(
+            preAppendQueuedDraftMessageIfNeeded(queuedDraft, codex: codex, threadID: threadID),
+            codex: codex,
+            threadID: threadID
+        )
         clearLocalDraft(codex: codex, threadID: threadID, persistToDisk: true)
     }
 
@@ -2553,10 +2605,16 @@ final class TurnViewModel {
     private func performTurnSend(
         _ pendingSend: PendingTurnSend,
         codex: CodexService,
-        threadID: String
+        threadID: String,
+        preAppendedMessage: CodexPreAppendedTurnMessage? = nil
     ) async {
         do {
-            try await dispatchPendingSend(pendingSend, codex: codex, threadID: threadID)
+            try await dispatchPendingSend(
+                pendingSend,
+                codex: codex,
+                threadID: threadID,
+                preAppendedMessage: preAppendedMessage
+            )
             clearLocalDraft(codex: codex, threadID: threadID, persistToDisk: true)
         } catch {
             restorePendingSendOnFailure(
@@ -2651,9 +2709,85 @@ final class TurnViewModel {
         setQueuedDrafts(drafts, codex: codex, threadID: threadID)
     }
 
+    // Shows queued follow-ups in the transcript immediately, then reuses the same row
+    // when the queue flushes so the bubble does not duplicate at assistant completion.
+    private func preAppendQueuedDraftMessageIfNeeded(
+        _ draft: QueuedTurnDraft,
+        codex: CodexService,
+        threadID: String
+    ) -> QueuedTurnDraft {
+        guard draft.preAppendedMessageID == nil else {
+            return draft
+        }
+
+        let messageID = codex.appendUserMessage(
+            threadId: threadID,
+            text: draft.text,
+            attachments: draft.attachments,
+            fileMentions: confirmedFileMentionPaths(from: draft.rawFileMentions),
+            skillMentions: draft.skillMentions.compactMap {
+                let rawName = $0.name ?? $0.id
+                let normalized = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+                return normalized.isEmpty ? nil : normalized
+            },
+            pluginMentions: draft.mentionMentions.compactMap {
+                let normalized = $0.name.trimmingCharacters(in: .whitespacesAndNewlines)
+                return normalized.isEmpty ? nil : normalized
+            }
+        )
+
+        return messageID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? draft
+            : draft.withPreAppendedMessageID(messageID)
+    }
+
+    private func removeQueuedDraftOptimisticMessageIfNeeded(
+        _ draft: QueuedTurnDraft?,
+        codex: CodexService,
+        threadID: String
+    ) {
+        guard let messageID = draft?.preAppendedMessageID else {
+            return
+        }
+        _ = codex.removeUserMessage(threadId: threadID, messageId: messageID)
+    }
+
+    private func clearQueuedDraftOptimisticMessage(
+        id: String,
+        draft: QueuedTurnDraft,
+        codex: CodexService,
+        threadID: String
+    ) {
+        if let messageID = draft.preAppendedMessageID {
+            _ = codex.removeUserMessage(threadId: threadID, messageId: messageID)
+            replaceQueuedDraft(id: id, with: draft.withPreAppendedMessageID(nil), codex: codex, threadID: threadID)
+            return
+        }
+
+        codex.removeLatestFailedUserMessage(
+            threadId: threadID,
+            matchingText: draft.text,
+            matchingAttachments: draft.attachments
+        )
+    }
+
     private func prependQueuedDraft(_ draft: QueuedTurnDraft, codex: CodexService, threadID: String) {
         var drafts = queuedDrafts(codex: codex, threadID: threadID)
         drafts.insert(draft, at: 0)
+        setQueuedDrafts(drafts, codex: codex, threadID: threadID)
+    }
+
+    private func replaceQueuedDraft(
+        id: String,
+        with replacement: QueuedTurnDraft,
+        codex: CodexService,
+        threadID: String
+    ) {
+        var drafts = queuedDrafts(codex: codex, threadID: threadID)
+        guard let index = drafts.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        drafts[index] = replacement
         setQueuedDrafts(drafts, codex: codex, threadID: threadID)
     }
 

--- a/CodexMobile/CodexMobile/Views/Turn/Messages/TurnMarkdownTextRendering.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Messages/TurnMarkdownTextRendering.swift
@@ -144,6 +144,7 @@ struct StreamingAssistantMarkdownTextView: View {
     @State private var displayedSegments: StreamingMarkdownBlockSegments
     @State private var targetText: String
     @State private var revealTask: Task<Void, Never>?
+    @State private var textAdoptionTask: Task<Void, Never>?
 
     init(
         text: String,
@@ -183,7 +184,7 @@ struct StreamingAssistantMarkdownTextView: View {
                 .isEmpty
                 && !nextText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 && !shouldAnimateInitialReveal(for: nextText)
-            adoptText(
+            scheduleTextAdoption(
                 nextText,
                 animated: animatesReveal && !reduceMotion && !shouldSnapFirstVisibleChunk
             )
@@ -194,6 +195,8 @@ struct StreamingAssistantMarkdownTextView: View {
             }
         }
         .onDisappear {
+            textAdoptionTask?.cancel()
+            textAdoptionTask = nil
             cancelReveal()
         }
     }
@@ -224,6 +227,19 @@ struct StreamingAssistantMarkdownTextView: View {
 
     // Smoothly reveals appended text instead of dropping in throttled bursts.
     // Snaps for non-append updates and tiny first chunks that do not disturb layout.
+    private func scheduleTextAdoption(_ nextText: String, animated: Bool) {
+        textAdoptionTask?.cancel()
+        // Streaming text can change repeatedly in one SwiftUI frame. Coalescing the
+        // local @State writes keeps reveal state current without tripping onChange's
+        // per-frame mutation guard.
+        textAdoptionTask = Task { @MainActor in
+            await Task.yield()
+            guard !Task.isCancelled else { return }
+            adoptText(nextText, animated: animated)
+            textAdoptionTask = nil
+        }
+    }
+
     private func adoptText(_ nextText: String, animated: Bool) {
         targetText = nextText
 

--- a/CodexMobile/CodexMobile/Views/Turn/Messages/TurnMessageComponents.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Messages/TurnMessageComponents.swift
@@ -342,6 +342,7 @@ struct MessageRow: View, Equatable {
     @State private var throttledAssistantDisplayText: String?
     @State private var pendingAssistantDisplayText: String?
     @State private var assistantDisplayUpdateTask: Task<Void, Never>?
+    @State private var assistantDisplaySyncTask: Task<Void, Never>?
     @State private var textExpansionLevel = 0
     @State private var previewImage: PreviewImagePayload?
 
@@ -465,7 +466,7 @@ struct MessageRow: View, Equatable {
             synchronizeAssistantDisplayText(immediate: true)
         }
         .onChange(of: message.text) { _, _ in
-            synchronizeAssistantDisplayText(immediate: shouldSynchronizeAssistantDisplayImmediately())
+            scheduleAssistantDisplayTextSync(immediate: shouldSynchronizeAssistantDisplayImmediately())
         }
         .onChange(of: message.isStreaming) { _, isStreaming in
             synchronizeAssistantDisplayText(immediate: !isStreaming)
@@ -474,6 +475,8 @@ struct MessageRow: View, Equatable {
             synchronizeAssistantDisplayText(immediate: true)
         }
         .onDisappear {
+            assistantDisplaySyncTask?.cancel()
+            assistantDisplaySyncTask = nil
             assistantDisplayUpdateTask?.cancel()
             assistantDisplayUpdateTask = nil
         }
@@ -780,8 +783,23 @@ struct MessageRow: View, Equatable {
 
     // Throttles only the assistant row's visible text during streaming so markdown/layout
     // work stays local to that cell instead of firing on every token delta.
+    private func scheduleAssistantDisplayTextSync(immediate: Bool) {
+        assistantDisplaySyncTask?.cancel()
+        // Streaming can deliver several String changes in one SwiftUI frame. Deferring
+        // this state write avoids the "onChange(of: String) updated multiple times"
+        // runtime warning while still applying the newest text on the next turn.
+        assistantDisplaySyncTask = Task { @MainActor in
+            await Task.yield()
+            guard !Task.isCancelled else { return }
+            synchronizeAssistantDisplayText(immediate: immediate)
+            assistantDisplaySyncTask = nil
+        }
+    }
+
     private func synchronizeAssistantDisplayText(immediate: Bool) {
         guard message.role == .assistant else {
+            assistantDisplaySyncTask?.cancel()
+            assistantDisplaySyncTask = nil
             throttledAssistantDisplayText = nil
             pendingAssistantDisplayText = nil
             assistantDisplayUpdateTask?.cancel()

--- a/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineReducer.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineReducer.swift
@@ -120,6 +120,17 @@ enum TurnTimelineReducer {
     // Detects steer-like flows where a later user prompt is appended inside the same turn.
     // In those cases the original event order is authoritative for rendering.
     private static func hasInterleavedUserFlow(_ turnMessages: [CodexMessage]) -> Bool {
+        let userCount = turnMessages.reduce(into: 0) { count, message in
+            if message.role == .user {
+                count += 1
+            }
+        }
+        guard userCount > 1 else {
+            // Desktop mirrors can deliver the only opening prompt after assistant output.
+            // A single user row is still the turn opener, not a steer.
+            return false
+        }
+
         let ordered = turnMessages.sorted { $0.orderIndex < $1.orderIndex }
         var seenNonUser = false
 

--- a/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineRenderProjection.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineRenderProjection.swift
@@ -338,6 +338,7 @@ enum TurnTimelineRenderProjection {
         var preferredFinalIndexByTurn: [String: Int] = [:]
         var phasedFinalIndexByTurn: [String: Int] = [:]
         var fallbackFinalIndexByTurn: [String: Int] = [:]
+        var turnsWithExplicitAssistantPhase = Set<String>()
 
         for index in messages.indices {
             let message = messages[index]
@@ -350,6 +351,9 @@ enum TurnTimelineRenderProjection {
             }
 
             fallbackFinalIndexByTurn[turnID] = index
+            if message.assistantPhase != nil {
+                turnsWithExplicitAssistantPhase.insert(turnID)
+            }
             if isFinalAnswerAssistantPhase(message.assistantPhase) {
                 phasedFinalIndexByTurn[turnID] = index
             }
@@ -358,9 +362,19 @@ enum TurnTimelineRenderProjection {
             }
         }
 
-        return phasedFinalIndexByTurn
-            .merging(preferredFinalIndexByTurn) { phased, _ in phased }
-            .merging(fallbackFinalIndexByTurn) { preferred, _ in preferred }
+        var resolved = phasedFinalIndexByTurn
+        for (turnID, index) in preferredFinalIndexByTurn where resolved[turnID] == nil {
+            // If the stream carries explicit assistant phases, only a final_answer
+            // phase is allowed to own the previous-message disclosure. Commentary
+            // updates are live progress, not a final answer to collapse around.
+            guard !turnsWithExplicitAssistantPhase.contains(turnID) else { continue }
+            resolved[turnID] = index
+        }
+        for (turnID, index) in fallbackFinalIndexByTurn where resolved[turnID] == nil {
+            guard !turnsWithExplicitAssistantPhase.contains(turnID) else { continue }
+            resolved[turnID] = index
+        }
+        return resolved
     }
 
     private struct PreviousMessageSelection {

--- a/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineView.swift
@@ -12,6 +12,7 @@ private struct TurnTimelineRenderCacheState: Equatable {
     var blockInfoByMessageID: [String: AssistantBlockAccessoryState] = [:]
     var newestStreamingMessageID: String?
     var renderItemsSignature: TurnTimelineRenderItemsCacheSignature?
+    var renderItemsShapeSignature: Int?
     var visibleRenderItems: [TurnTimelineRenderItem] = []
     var blockInfoInputKey: Int?
 }
@@ -120,9 +121,47 @@ struct TurnTimelineView<EmptyState: View, Composer: View>: View {
         return messages[startIndex...]
     }
 
-    // Never project inside `body`; stale cache is refreshed by lifecycle handlers.
+    // Renders appended/removed rows immediately if SwiftUI reaches body before the
+    // lifecycle cache refresh. Assistant text-only deltas still use the cached rows.
     private var visibleRenderItems: [TurnTimelineRenderItem] {
-        renderCacheState.visibleRenderItems
+        let visibleSlice = visibleMessages
+        guard renderItemsShapeSignature(for: visibleSlice) != renderCacheState.renderItemsShapeSignature else {
+            return renderCacheState.visibleRenderItems
+        }
+
+        return TurnTimelineRenderProjection.project(
+            messages: Array(visibleSlice),
+            completedTurnIDs: completedTurnIDs,
+            activeTurnID: activeTurnID,
+            isThreadRunning: isThreadRunning
+        )
+    }
+
+    private func renderItemsShapeSignature(for messages: ArraySlice<CodexMessage>) -> Int {
+        var hasher = Hasher()
+        hasher.combine(threadID)
+        hasher.combine(visibleTailCount)
+        hasher.combine(messages.count)
+        hasher.combine(activeTurnID)
+        hasher.combine(isThreadRunning)
+        hasher.combine(completedTurnIDs)
+
+        if let message = messages.first {
+            hasher.combine(message.id)
+            hasher.combine(message.orderIndex)
+        }
+
+        if let message = messages.last {
+            hasher.combine(message.id)
+            hasher.combine(message.role)
+            hasher.combine(message.kind)
+            hasher.combine(message.turnId)
+            hasher.combine(message.deliveryState)
+            hasher.combine(message.isStreaming)
+            hasher.combine(message.orderIndex)
+        }
+
+        return hasher.finalize()
     }
 
     private var hasEarlierMessages: Bool {
@@ -429,6 +468,7 @@ struct TurnTimelineView<EmptyState: View, Composer: View>: View {
         let visible = Array(visibleSlice)
         var nextState = renderCacheState
         var didChange = false
+        let shapeSignature = renderItemsShapeSignature(for: visibleSlice)
 
         // Block-info placement depends on collapsed render items, so keep the
         // projection fresh before deriving accessory state.
@@ -442,6 +482,7 @@ struct TurnTimelineView<EmptyState: View, Composer: View>: View {
                     isThreadRunning: isThreadRunning
                 )
                 nextState.renderItemsSignature = signature
+                nextState.renderItemsShapeSignature = shapeSignature
                 didChange = true
             }
         }

--- a/CodexMobile/CodexMobileTests/CodexServiceIncomingCommandExecutionTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceIncomingCommandExecutionTests.swift
@@ -1381,6 +1381,37 @@ final class CodexServiceIncomingCommandExecutionTests: XCTestCase {
         XCTAssertEqual(userRows[0].skillMentions, ["check-code"])
     }
 
+    func testMirroredOpeningUserMessageAnchorsBeforeExistingTurnOutput() {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let turnID = "turn-\(UUID().uuidString)"
+
+        service.appendMessage(
+            CodexMessage(
+                id: "assistant-first",
+                threadId: threadID,
+                role: .assistant,
+                text: "Already streaming from desktop",
+                turnId: turnID,
+                itemId: "assistant-item",
+                isStreaming: true,
+                orderIndex: 10
+            )
+        )
+
+        service.appendConfirmedMirroredUserMessage(
+            threadId: threadID,
+            turnId: turnID,
+            text: "let's hope now it will"
+        )
+
+        let messages = service.messages(for: threadID)
+
+        XCTAssertEqual(messages.map(\.role), [.user, .assistant])
+        XCTAssertLessThan(messages[0].orderIndex, messages[1].orderIndex)
+        XCTAssertEqual(messages[0].text, "let's hope now it will")
+    }
+
     func testThreadReadDecodesTurnIdAliasAndRejectsEpochHistoryTimestamp() {
         let service = makeService()
         let threadID = "thread-\(UUID().uuidString)"

--- a/CodexMobile/CodexMobileTests/CodexServiceIncomingRunIndicatorTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceIncomingRunIndicatorTests.swift
@@ -209,6 +209,88 @@ final class CodexServiceIncomingRunIndicatorTests: XCTestCase {
         XCTAssertTrue(service.desktopMirroredRunningThreadIDs.contains(threadID))
     }
 
+    func testDesktopIpcCompletionClearsRunningWithoutStampingTerminalTurn() {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let turnID = "turn-\(UUID().uuidString)"
+
+        service.handleNotification(
+            method: "turn/started",
+            params: .object([
+                "threadId": .string(threadID),
+                "turnId": .string(turnID),
+                "remodexDesktopMirror": .bool(true),
+                "remodexDesktopIpcMirror": .bool(true),
+            ])
+        )
+        service.handleNotification(
+            method: "turn/completed",
+            params: .object([
+                "threadId": .string(threadID),
+                "turnId": .string(turnID),
+                "remodexDesktopMirror": .bool(true),
+                "remodexDesktopIpcMirror": .bool(true),
+            ])
+        )
+
+        XCTAssertFalse(service.threadHasActiveOrRunningTurn(threadID))
+        XCTAssertNil(service.turnTerminalState(for: turnID))
+
+        service.handleNotification(
+            method: "turn/activity",
+            params: .object([
+                "threadId": .string(threadID),
+                "turnId": .string(turnID),
+                "remodexDesktopMirror": .bool(true),
+                "remodexDesktopIpcMirror": .bool(true),
+            ])
+        )
+
+        XCTAssertEqual(service.threadRunBadgeState(for: threadID), .running)
+    }
+
+    func testDesktopIpcCompletionKeepsRunningWhileToolActivityStreams() {
+        let service = makeService()
+        let threadID = "thread-\(UUID().uuidString)"
+        let turnID = "turn-\(UUID().uuidString)"
+        let itemID = "tool-\(UUID().uuidString)"
+
+        service.handleNotification(
+            method: "turn/started",
+            params: .object([
+                "threadId": .string(threadID),
+                "turnId": .string(turnID),
+                "remodexDesktopMirror": .bool(true),
+                "remodexDesktopIpcMirror": .bool(true),
+            ])
+        )
+        service.appendStreamingSystemItemDelta(
+            threadId: threadID,
+            turnId: turnID,
+            itemId: itemID,
+            kind: .toolActivity,
+            delta: "Reading files"
+        )
+        service.flushPendingSystemDeltas(threadId: threadID, itemId: itemID)
+
+        service.handleNotification(
+            method: "turn/completed",
+            params: .object([
+                "threadId": .string(threadID),
+                "turnId": .string(turnID),
+                "remodexDesktopMirror": .bool(true),
+                "remodexDesktopIpcMirror": .bool(true),
+            ])
+        )
+
+        XCTAssertEqual(service.activeTurnID(for: threadID), turnID)
+        XCTAssertEqual(service.threadRunBadgeState(for: threadID), .running)
+        XCTAssertTrue(service.messages(for: threadID).contains { message in
+            message.itemId == itemID && message.isStreaming
+        })
+        XCTAssertNil(service.turnTerminalState(for: turnID))
+    }
+
     func testTurnStartedAcceptsTopLevelIDAsTurnID() {
         let service = makeService()
         let threadID = "thread-\(UUID().uuidString)"

--- a/CodexMobile/CodexMobileTests/TurnTimelineReducerTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnTimelineReducerTests.swift
@@ -1326,6 +1326,49 @@ final class TurnTimelineReducerTests: XCTestCase {
         XCTAssertEqual(messageIDs, ["status", "final"])
     }
 
+    func testTimelineRenderProjectionDoesNotCollapseCommentaryOnlyTurn() {
+        let now = Date()
+        let messages = [
+            makeMessage(
+                id: "user",
+                threadID: "thread",
+                role: .user,
+                text: "Check this",
+                createdAt: now,
+                turnID: "turn-1",
+                orderIndex: 1
+            ),
+            makeMessage(
+                id: "commentary-1",
+                threadID: "thread",
+                role: .assistant,
+                assistantPhase: "commentary",
+                text: "I am checking the files.",
+                createdAt: now.addingTimeInterval(1),
+                turnID: "turn-1",
+                orderIndex: 2
+            ),
+            makeMessage(
+                id: "commentary-2",
+                threadID: "thread",
+                role: .assistant,
+                assistantPhase: "commentary",
+                text: "The dirty set is small.",
+                createdAt: now.addingTimeInterval(2),
+                turnID: "turn-1",
+                orderIndex: 3
+            ),
+        ]
+
+        let items = TurnTimelineRenderProjection.project(
+            messages: messages,
+            completedTurnIDs: ["turn-1"],
+            isThreadRunning: true
+        )
+
+        XCTAssertEqual(items.map(\.id), ["user", "commentary-1", "commentary-2"])
+    }
+
     func testRemoveDuplicateAssistantMessagesByTurnAndText() {
         let now = Date()
         let messages = [

--- a/CodexMobile/CodexMobileTests/TurnTimelineReducerTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnTimelineReducerTests.swift
@@ -2619,6 +2619,55 @@ final class TurnTimelineReducerTests: XCTestCase {
         ])
     }
 
+    func testEnforceIntraTurnOrderFloatsLateSingleMirroredUserToTurnStart() {
+        let now = Date()
+        var order = 0
+        func nextOrder() -> Int { order += 1; return order }
+
+        let messages = [
+            makeMessage(
+                id: "thinking-1",
+                threadID: "thread",
+                role: .system,
+                kind: .thinking,
+                text: "Reasoning started",
+                createdAt: now,
+                turnID: "turn-1",
+                itemID: "thinking-1",
+                orderIndex: nextOrder()
+            ),
+            makeMessage(
+                id: "assistant-1",
+                threadID: "thread",
+                role: .assistant,
+                kind: .chat,
+                text: "Assistant output already arrived",
+                createdAt: now.addingTimeInterval(1),
+                turnID: "turn-1",
+                itemID: "assistant-1",
+                orderIndex: nextOrder()
+            ),
+            makeMessage(
+                id: "user-1",
+                threadID: "thread",
+                role: .user,
+                kind: .chat,
+                text: "let's hope now it will",
+                createdAt: now.addingTimeInterval(-1),
+                turnID: "turn-1",
+                orderIndex: nextOrder()
+            ),
+        ]
+
+        let reordered = TurnTimelineReducer.enforceIntraTurnOrder(in: messages)
+
+        XCTAssertEqual(reordered.map(\.id), [
+            "user-1",
+            "thinking-1",
+            "assistant-1",
+        ])
+    }
+
     func testEnforceIntraTurnOrderKeepsFileChangeAfterFinalAssistantWhenStatusTextPrecedesIt() {
         let now = Date()
         var order = 0

--- a/phodex-bridge/src/desktop-ipc-action-follower.js
+++ b/phodex-bridge/src/desktop-ipc-action-follower.js
@@ -7,6 +7,7 @@
 const net = require("net");
 const os = require("os");
 const path = require("path");
+const { buildApplyPatchFileChangeItem } = require("./apply-patch-changes");
 
 const FRAME_HEADER_BYTES = 4;
 const MAX_FRAME_BYTES = 256 * 1024 * 1024;
@@ -60,6 +61,7 @@ function createDesktopIpcActionFollower({
   });
   const rawStatesByThreadId = new Map();
   const assistantMessageTextsByThreadId = new Map();
+  const mirroredActivityKeysByThreadId = new Map();
   const mirroredUserMessageKeysByThreadId = new Map();
   const activeDesktopTurnsByThreadId = new Map();
   const pendingRoutesByRequestId = new Map();
@@ -93,6 +95,7 @@ function createDesktopIpcActionFollower({
   function stopAll() {
     rawStatesByThreadId.clear();
     assistantMessageTextsByThreadId.clear();
+    mirroredActivityKeysByThreadId.clear();
     mirroredUserMessageKeysByThreadId.clear();
     clearAllDesktopTurnCompletionTimers();
     pendingRoutesByRequestId.clear();
@@ -143,13 +146,14 @@ function createDesktopIpcActionFollower({
     }
 
     rawStatesByThreadId.set(threadId, nextState);
-    syncProjectedAssistantDeltas(threadId, previousState, nextState);
+    syncProjectedLiveState(threadId, previousState, nextState);
     syncProjectedActions(threadId, projectPendingDesktopActions(threadId, nextState));
   }
 
   function onDisconnect() {
     rawStatesByThreadId.clear();
     assistantMessageTextsByThreadId.clear();
+    mirroredActivityKeysByThreadId.clear();
     mirroredUserMessageKeysByThreadId.clear();
     clearAllDesktopTurnCompletionTimers();
     pendingRoutesByRequestId.clear();
@@ -288,8 +292,13 @@ function createDesktopIpcActionFollower({
     }
 
     rawStatesByThreadId.set(threadId, nextState);
-    syncProjectedAssistantDeltas(threadId, baselineState, nextState);
+    syncProjectedLiveState(threadId, baselineState, nextState);
     syncProjectedActions(threadId, projectPendingDesktopActions(threadId, nextState));
+  }
+
+  function syncProjectedLiveState(threadId, previousState, nextState) {
+    syncProjectedAssistantDeltas(threadId, previousState, nextState);
+    syncProjectedDesktopActivities(threadId, nextState);
   }
 
   function syncProjectedAssistantDeltas(threadId, previousState, nextState) {
@@ -337,11 +346,53 @@ function createDesktopIpcActionFollower({
     syncProjectedDesktopTurnCompletions(threadId, nextState);
   }
 
+  function syncProjectedDesktopActivities(threadId, nextState) {
+    refreshTrackedDesktopTurnState(threadId, nextState);
+    const activityKeys = mirroredActivityKeysForThread(threadId);
+    const notifications = projectDesktopActivityNotifications(threadId, nextState, activityKeys);
+    if (notifications.length === 0) {
+      syncProjectedDesktopTurnCompletions(threadId, nextState);
+      return;
+    }
+
+    const activeActivityTurnIds = new Set(
+      notifications
+        .map((notification) => readString(notification?.params?.turnId) || readString(notification?.params?.turn_id))
+        .filter(Boolean)
+    );
+    const userNotifications = projectDesktopUserMessageNotifications(
+      threadId,
+      nextState,
+      mirroredUserMessageKeysForThread(threadId),
+      activeActivityTurnIds
+    );
+
+    // Tool-call snapshots are independent from assistant text deltas. Emit them
+    // through the same app-server event names rollout mirroring uses so iOS keeps
+    // showing active tool rows while the Mac-owned run is still executing.
+    for (const notification of [...userNotifications, ...notifications]) {
+      sendApplicationResponse(JSON.stringify(notification));
+    }
+    for (const turnId of activeActivityTurnIds) {
+      noteDesktopIpcTurnActivity(threadId, turnId, nextState);
+    }
+    syncProjectedDesktopTurnCompletions(threadId, nextState);
+  }
+
   function mirroredUserMessageKeysForThread(threadId) {
     let keys = mirroredUserMessageKeysByThreadId.get(threadId);
     if (!keys) {
       keys = new Set();
       mirroredUserMessageKeysByThreadId.set(threadId, keys);
+    }
+    return keys;
+  }
+
+  function mirroredActivityKeysForThread(threadId) {
+    let keys = mirroredActivityKeysByThreadId.get(threadId);
+    if (!keys) {
+      keys = new Set();
+      mirroredActivityKeysByThreadId.set(threadId, keys);
     }
     return keys;
   }
@@ -375,7 +426,8 @@ function createDesktopIpcActionFollower({
         return;
       }
 
-      if (hasOpenDesktopRequestForTurn(currentEntry.latestState, turnId)) {
+      if (hasOpenDesktopRequestForTurn(currentEntry.latestState, turnId)
+        || hasActiveDesktopActivityForTurn(currentEntry.latestState, turnId)) {
         scheduleDesktopIpcTurnIdleCompletion(threadId, turnId, currentEntry);
         return;
       }
@@ -782,6 +834,144 @@ function projectDesktopUserMessageNotifications(
   return notifications;
 }
 
+function projectDesktopActivityNotifications(threadId, conversationState, mirroredKeys = new Set()) {
+  const turns = Array.isArray(conversationState?.turns) ? conversationState.turns : [];
+  const notifications = [];
+
+  for (const turn of turns) {
+    const turnId = readString(turn?.id) || readString(turn?.turnId) || readString(turn?.turn_id);
+    if (!turnId || (
+      !hasActiveDesktopActivityForTurn(conversationState, turnId)
+      && !isDesktopTurnLive(turn, conversationState)
+      && !hasMirroredActivityOutputPending(turn, mirroredKeys)
+    )) {
+      continue;
+    }
+
+    const items = Array.isArray(turn?.items) ? turn.items : [];
+    const callsById = new Map();
+    for (const item of items) {
+      if (isDesktopActivityCallItem(item)) {
+        const callId = desktopActivityCallId(item);
+        if (callId) {
+          callsById.set(callId, item);
+        }
+      }
+    }
+
+    for (const item of items) {
+      if (isDesktopActivityCallItem(item)) {
+        notifications.push(...projectDesktopActivityBeginNotifications(threadId, turnId, item, mirroredKeys));
+      } else if (isDesktopActivityOutputItem(item)) {
+        const callId = desktopActivityCallId(item);
+        notifications.push(...projectDesktopActivityOutputNotifications(
+          threadId,
+          turnId,
+          item,
+          callsById.get(callId),
+          mirroredKeys
+        ));
+      }
+    }
+  }
+
+  return notifications;
+}
+
+function projectDesktopActivityBeginNotifications(threadId, turnId, item, mirroredKeys) {
+  const callId = desktopActivityCallId(item);
+  const toolName = readString(item?.name) || readString(item?.toolName) || readString(item?.tool_name);
+  if (!callId || !toolName || !markMirroredActivityKey(mirroredKeys, turnId, callId, "begin")) {
+    return [];
+  }
+
+  if (isCommandToolName(toolName)) {
+    const argumentsObject = parseToolArguments(item?.arguments);
+    return [createDesktopIpcNotification("codex/event/exec_command_begin", {
+      threadId,
+      turnId,
+      call_id: callId,
+      command: resolveToolCommand(toolName, argumentsObject),
+      cwd: resolveToolWorkingDirectory(argumentsObject, item),
+      status: "running",
+    })];
+  }
+
+  if (toolName === "apply_patch") {
+    const isCompletedPatch = Boolean(terminalStatusFromObject(item));
+    const fileChange = buildApplyPatchFileChangeItem({
+      callId,
+      patch: readString(item?.input) || readString(item?.arguments),
+      status: readString(item?.status) || (isCompletedPatch ? "completed" : "inProgress"),
+      idFallback: buildSyntheticActivityItemId("file-change", threadId, turnId, callId),
+      cwd: readString(item?.cwd) || readString(item?.workdir),
+    });
+    if (fileChange) {
+      return [createDesktopIpcNotification(
+        isCompletedPatch ? "codex/event/patch_apply_end" : "codex/event/patch_apply_begin",
+        {
+          threadId,
+          turnId,
+          id: turnId,
+          call_id: callId,
+          itemId: fileChange.id,
+          status: fileChange.status,
+          ...(isCompletedPatch ? { success: true } : {}),
+          changes: fileChange.changes,
+        }
+      )];
+    }
+  }
+
+  return [createDesktopIpcNotification("codex/event/background_event", {
+    threadId,
+    turnId,
+    call_id: callId,
+    message: genericToolActivityMessage(toolName),
+  })];
+}
+
+function projectDesktopActivityOutputNotifications(threadId, turnId, item, callItem, mirroredKeys) {
+  const callId = desktopActivityCallId(item);
+  const toolName = readString(callItem?.name) || readString(callItem?.toolName) || readString(callItem?.tool_name);
+  if (!callId || !toolName || !mirroredKeys.has(activityMirrorKey(turnId, callId, "begin"))) {
+    return [];
+  }
+  if (!markMirroredActivityKey(mirroredKeys, turnId, callId, "output")) {
+    return [];
+  }
+
+  if (!isCommandToolName(toolName)) {
+    return [];
+  }
+
+  const argumentsObject = parseToolArguments(callItem?.arguments);
+  const command = resolveToolCommand(toolName, argumentsObject);
+  const cwd = resolveToolWorkingDirectory(argumentsObject, callItem);
+  const output = readString(item?.output) || readString(item?.text) || readString(item?.content);
+  const notifications = [];
+  if (output) {
+    notifications.push(createDesktopIpcNotification("codex/event/exec_command_output_delta", {
+      threadId,
+      turnId,
+      call_id: callId,
+      command,
+      cwd,
+      chunk: output,
+    }));
+  }
+  notifications.push(createDesktopIpcNotification("codex/event/exec_command_end", {
+    threadId,
+    turnId,
+    call_id: callId,
+    command,
+    cwd,
+    status: "completed",
+    output: output || "",
+  }));
+  return notifications;
+}
+
 function projectDesktopTurnCompletedNotifications(
   threadId,
   conversationState,
@@ -796,6 +986,11 @@ function projectDesktopTurnCompletedNotifications(
   for (const turn of turns) {
     const turnId = readString(turn?.id) || readString(turn?.turnId) || readString(turn?.turn_id);
     if (!turnId || !trackedTurnIds.has(turnId)) {
+      continue;
+    }
+    // Terminal snapshots can race active tool rows. Keep tracking the turn until
+    // the activity itself closes, otherwise the phone may stay running forever.
+    if (hasActiveDesktopActivityForTurn(conversationState, turnId)) {
       continue;
     }
     if (!isDesktopTurnTerminal(turn, conversationState)) {
@@ -900,6 +1095,33 @@ function userMessageKey(turnId, itemId, text) {
     .slice(0, 16)}`;
 }
 
+function markMirroredActivityKey(mirroredKeys, turnId, callId, phase) {
+  const key = activityMirrorKey(turnId, callId, phase);
+  if (mirroredKeys.has(key)) {
+    return false;
+  }
+  mirroredKeys.add(key);
+  return true;
+}
+
+function activityMirrorKey(turnId, callId, phase) {
+  return `${turnId}:${callId}:${phase}`;
+}
+
+function hasMirroredActivityOutputPending(turn, mirroredKeys) {
+  const turnId = readString(turn?.id) || readString(turn?.turnId) || readString(turn?.turn_id);
+  const items = Array.isArray(turn?.items) ? turn.items : [];
+  return items.some((item) => {
+    if (!isDesktopActivityOutputItem(item)) {
+      return false;
+    }
+    const callId = desktopActivityCallId(item);
+    return callId
+      && mirroredKeys.has(activityMirrorKey(turnId, callId, "begin"))
+      && !mirroredKeys.has(activityMirrorKey(turnId, callId, "output"));
+  });
+}
+
 function isDesktopTurnTerminal(turn, conversationState) {
   if (desktopTerminalStatus(turn, conversationState)) {
     return true;
@@ -910,6 +1132,17 @@ function isDesktopTurnTerminal(turn, conversationState) {
       hasExplicitFalseFlag(conversationState, ["running", "isRunning", "streaming", "isStreaming"])
       && !hasOpenDesktopRequestForTurn(conversationState, readString(turn?.id) || readString(turn?.turnId) || readString(turn?.turn_id))
     );
+}
+
+function isDesktopTurnLive(turn, conversationState) {
+  return hasExplicitTrueFlag(turn, ["running", "isRunning", "streaming", "isStreaming"])
+    || hasExplicitTrueFlag(conversationState, ["running", "isRunning", "streaming", "isStreaming"])
+    || ACTIVE_STATUS_TOKENS.has(normalizeToken(readString(turn?.status)))
+    || ACTIVE_STATUS_TOKENS.has(normalizeToken(readString(turn?.state)))
+    || ACTIVE_STATUS_TOKENS.has(normalizeToken(readString(turn?.phase)))
+    || ACTIVE_STATUS_TOKENS.has(normalizeToken(readString(conversationState?.status)))
+    || ACTIVE_STATUS_TOKENS.has(normalizeToken(readString(conversationState?.state)))
+    || ACTIVE_STATUS_TOKENS.has(normalizeToken(readString(conversationState?.phase)));
 }
 
 function desktopTerminalStatus(turn, conversationState) {
@@ -995,6 +1228,24 @@ function hasExplicitFalseFlag(value, keys) {
   return keys.some((key) => Object.prototype.hasOwnProperty.call(value, key) && value[key] === false);
 }
 
+function hasExplicitTrueFlag(value, keys) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  return keys.some((key) => Object.prototype.hasOwnProperty.call(value, key) && value[key] === true);
+}
+
+const ACTIVE_STATUS_TOKENS = new Set([
+  "running",
+  "streaming",
+  "inprogress",
+  "inflight",
+  "started",
+  "pending",
+  "active",
+]);
+
 function hasOpenDesktopRequestForTurn(conversationState, turnId) {
   if (!turnId) {
     return false;
@@ -1015,6 +1266,103 @@ function hasOpenDesktopRequestForTurn(conversationState, turnId) {
       || readString(request.turn_id);
     return requestTurnId === turnId;
   });
+}
+
+function hasActiveDesktopActivityForTurn(conversationState, turnId) {
+  const turn = desktopTurnById(conversationState, turnId);
+  const items = Array.isArray(turn?.items) ? turn.items : [];
+  const completedActivityIds = completedDesktopActivityIds(items);
+  return items.some((item) => isActiveDesktopActivityItem(item, completedActivityIds));
+}
+
+function desktopTurnById(conversationState, turnId) {
+  if (!turnId) {
+    return null;
+  }
+
+  const turns = Array.isArray(conversationState?.turns) ? conversationState.turns : [];
+  return turns.find((turn) => {
+    const candidateTurnId = readString(turn?.id) || readString(turn?.turnId) || readString(turn?.turn_id);
+    return candidateTurnId === turnId;
+  }) || null;
+}
+
+function isActiveDesktopActivityItem(item, completedActivityIds = new Set()) {
+  if (!item || typeof item !== "object" || Array.isArray(item)) {
+    return false;
+  }
+  if (!isDesktopActivityItem(item) || isDesktopActivityOutputItem(item) || terminalStatusFromObject(item)) {
+    return false;
+  }
+  if (hasExplicitTrueFlag(item, ["running", "isRunning", "streaming", "isStreaming"])
+    || ACTIVE_STATUS_TOKENS.has(normalizeToken(readString(item.status)))
+    || ACTIVE_STATUS_TOKENS.has(normalizeToken(readString(item.state)))
+    || ACTIVE_STATUS_TOKENS.has(normalizeToken(readString(item.phase)))
+    || ACTIVE_STATUS_TOKENS.has(normalizeToken(readString(item.lifecycle)))) {
+    return true;
+  }
+
+  // Codex Desktop often represents a live tool as a bare function_call/custom_tool_call
+  // with only call_id, then appends a separate *_output item. Treat the call as active
+  // until that output appears, even when no explicit "running" status is present.
+  const activityId = desktopActivityCallId(item);
+  return isDesktopActivityCallItem(item) && activityId && !completedActivityIds.has(activityId);
+}
+
+function isDesktopActivityItem(item) {
+  const type = normalizeToken(item?.type);
+  return type.includes("tool")
+    || type.includes("command")
+    || type.includes("exec")
+    || type.includes("mcp")
+    || type.includes("function");
+}
+
+function isDesktopActivityCallItem(item) {
+  const type = normalizeToken(item?.type);
+  if (isDesktopActivityOutputItem(item)) {
+    return false;
+  }
+  return type.endsWith("call")
+    || type.includes("toolcall")
+    || type.includes("functioncall")
+    || type.includes("commandexecution")
+    || type.includes("localshellcall");
+}
+
+function isDesktopActivityOutputItem(item) {
+  const type = normalizeToken(item?.type);
+  return type.includes("output")
+    || type.includes("result")
+    || type.endsWith("end")
+    || type.includes("completed");
+}
+
+function completedDesktopActivityIds(items) {
+  const ids = new Set();
+  for (const item of items) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      continue;
+    }
+    if (!isDesktopActivityOutputItem(item) && !terminalStatusFromObject(item)) {
+      continue;
+    }
+    const id = desktopActivityCallId(item);
+    if (id) {
+      ids.add(id);
+    }
+  }
+  return ids;
+}
+
+function desktopActivityCallId(item) {
+  return readString(item?.call_id)
+    || readString(item?.callId)
+    || readString(item?.tool_call_id)
+    || readString(item?.toolCallId)
+    || readString(item?.requestId)
+    || readString(item?.request_id)
+    || readString(item?.id);
 }
 
 function isUserMessageItem(item) {
@@ -1213,6 +1561,68 @@ function requestIdKey(value) {
   return "";
 }
 
+function parseToolArguments(rawArguments) {
+  const parsed = safeParseJSON(rawArguments);
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+}
+
+function resolveToolCommand(toolName, argumentsObject) {
+  if (!isCommandToolName(toolName)) {
+    return toolName;
+  }
+
+  return readString(argumentsObject.cmd)
+    || readString(argumentsObject.command)
+    || readString(argumentsObject.raw_command)
+    || readString(argumentsObject.rawCommand)
+    || toolName;
+}
+
+function resolveToolWorkingDirectory(argumentsObject, item = {}) {
+  return readString(argumentsObject.workdir)
+    || readString(argumentsObject.cwd)
+    || readString(argumentsObject.working_directory)
+    || readString(item?.cwd)
+    || readString(item?.workdir)
+    || "";
+}
+
+function isCommandToolName(toolName) {
+  const normalized = readString(toolName).toLowerCase();
+  return normalized === "exec_command"
+    || normalized === "shell_command"
+    || normalized.endsWith(".exec_command")
+    || normalized.endsWith(".shell_command");
+}
+
+function genericToolActivityMessage(toolName) {
+  switch (readString(toolName).toLowerCase()) {
+  case "apply_patch":
+    return "Applying patch";
+  case "write_stdin":
+    return "Writing to terminal";
+  case "read_thread_terminal":
+    return "Reading terminal output";
+  default:
+    return `Running ${toolName}`;
+  }
+}
+
+function buildSyntheticActivityItemId(kind, threadId, turnId, callId) {
+  return `${kind}:${threadId}:${turnId}:${callId}`;
+}
+
+function createDesktopIpcNotification(method, params = {}) {
+  return {
+    method,
+    params: {
+      remodexDesktopMirror: true,
+      remodexDesktopIpcMirror: true,
+      ...params,
+    },
+  };
+}
+
 function readString(value) {
   return typeof value === "string" && value.trim() ? value.trim() : "";
 }
@@ -1239,7 +1649,9 @@ module.exports = {
   applyConversationStateChange,
   createDesktopIpcActionFollower,
   desktopFollowerPayloadForResponse,
+  hasActiveDesktopActivityForTurn,
   projectDesktopAssistantDeltaNotifications,
+  projectDesktopActivityNotifications,
   projectDesktopTurnCompletedNotifications,
   projectDesktopUserMessageNotifications,
   projectPendingDesktopActions,

--- a/phodex-bridge/src/desktop-ipc-action-follower.js
+++ b/phodex-bridge/src/desktop-ipc-action-follower.js
@@ -11,6 +11,7 @@ const path = require("path");
 const FRAME_HEADER_BYTES = 4;
 const MAX_FRAME_BYTES = 256 * 1024 * 1024;
 const REQUEST_TIMEOUT_MS = 10_000;
+const TURN_COMPLETION_IDLE_MS = 3_500;
 const DESKTOP_IPC_ACTION_SOURCE = "desktop-ipc-action-follower";
 const DESKTOP_RESUME_METHODS = new Set(["thread/read", "thread/resume"]);
 const ACTION_METHODS = new Set([
@@ -44,6 +45,9 @@ function createDesktopIpcActionFollower({
   netModule = net,
   now = () => Date.now(),
   requestTimeoutMs = REQUEST_TIMEOUT_MS,
+  turnCompletionIdleMs = TURN_COMPLETION_IDLE_MS,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
 } = {}) {
   const ipc = createDesktopIpcClient({
     socketPath,
@@ -56,6 +60,8 @@ function createDesktopIpcActionFollower({
   });
   const rawStatesByThreadId = new Map();
   const assistantMessageTextsByThreadId = new Map();
+  const mirroredUserMessageKeysByThreadId = new Map();
+  const activeDesktopTurnsByThreadId = new Map();
   const pendingRoutesByRequestId = new Map();
   const activeThreadIds = new Set();
   const recoveringThreadIds = new Set();
@@ -87,6 +93,8 @@ function createDesktopIpcActionFollower({
   function stopAll() {
     rawStatesByThreadId.clear();
     assistantMessageTextsByThreadId.clear();
+    mirroredUserMessageKeysByThreadId.clear();
+    clearAllDesktopTurnCompletionTimers();
     pendingRoutesByRequestId.clear();
     activeThreadIds.clear();
     recoveringThreadIds.clear();
@@ -142,6 +150,8 @@ function createDesktopIpcActionFollower({
   function onDisconnect() {
     rawStatesByThreadId.clear();
     assistantMessageTextsByThreadId.clear();
+    mirroredUserMessageKeysByThreadId.clear();
+    clearAllDesktopTurnCompletionTimers();
     pendingRoutesByRequestId.clear();
     recoveringThreadIds.clear();
     queuedChangesByThreadId.clear();
@@ -283,9 +293,11 @@ function createDesktopIpcActionFollower({
   }
 
   function syncProjectedAssistantDeltas(threadId, previousState, nextState) {
+    refreshTrackedDesktopTurnState(threadId, nextState);
     const previousTexts = assistantMessageTextsByThreadId.get(threadId);
     if (!previousTexts && !previousState) {
       assistantMessageTextsByThreadId.set(threadId, snapshotAssistantMessageTexts(nextState));
+      syncProjectedDesktopTurnCompletions(threadId, nextState);
       return;
     }
 
@@ -297,13 +309,136 @@ function createDesktopIpcActionFollower({
     );
     if (notifications.length === 0) {
       assistantMessageTextsByThreadId.set(threadId, snapshotAssistantMessageTexts(nextState));
+      syncProjectedDesktopTurnCompletions(threadId, nextState);
       return;
     }
 
-    for (const notification of notifications) {
+    const activeDeltaTurnIds = new Set(
+      notifications
+        .map((notification) => readString(notification?.params?.turnId) || readString(notification?.params?.turn_id))
+        .filter(Boolean)
+    );
+    const userNotifications = projectDesktopUserMessageNotifications(
+      threadId,
+      nextState,
+      mirroredUserMessageKeysForThread(threadId),
+      activeDeltaTurnIds
+    );
+
+    // Desktop IPC state can report assistant text growth before rollout replay catches
+    // up with the user prelude. Emit the opening prompt first to avoid mobile row jumps.
+    for (const notification of [...userNotifications, ...notifications]) {
       sendApplicationResponse(JSON.stringify(notification));
     }
+    for (const turnId of activeDeltaTurnIds) {
+      noteDesktopIpcTurnActivity(threadId, turnId, nextState);
+    }
     assistantMessageTextsByThreadId.set(threadId, snapshotAssistantMessageTexts(nextState));
+    syncProjectedDesktopTurnCompletions(threadId, nextState);
+  }
+
+  function mirroredUserMessageKeysForThread(threadId) {
+    let keys = mirroredUserMessageKeysByThreadId.get(threadId);
+    if (!keys) {
+      keys = new Set();
+      mirroredUserMessageKeysByThreadId.set(threadId, keys);
+    }
+    return keys;
+  }
+
+  function noteDesktopIpcTurnActivity(threadId, turnId, latestState) {
+    if (!turnId || turnCompletionIdleMs <= 0) {
+      return;
+    }
+
+    let turns = activeDesktopTurnsByThreadId.get(threadId);
+    if (!turns) {
+      turns = new Map();
+      activeDesktopTurnsByThreadId.set(threadId, turns);
+    }
+
+    const existing = turns.get(turnId);
+    if (existing?.timer) {
+      clearTimeoutFn(existing.timer);
+    }
+
+    const entry = { latestState, timer: null };
+    turns.set(turnId, entry);
+    scheduleDesktopIpcTurnIdleCompletion(threadId, turnId, entry);
+  }
+
+  function scheduleDesktopIpcTurnIdleCompletion(threadId, turnId, entry) {
+    entry.timer = setTimeoutFn(() => {
+      const currentTurns = activeDesktopTurnsByThreadId.get(threadId);
+      const currentEntry = currentTurns?.get(turnId);
+      if (!currentEntry) {
+        return;
+      }
+
+      if (hasOpenDesktopRequestForTurn(currentEntry.latestState, turnId)) {
+        scheduleDesktopIpcTurnIdleCompletion(threadId, turnId, currentEntry);
+        return;
+      }
+
+      completeDesktopIpcTurn(threadId, turnId);
+    }, turnCompletionIdleMs);
+    entry.timer.unref?.();
+  }
+
+  function refreshTrackedDesktopTurnState(threadId, latestState) {
+    const turns = activeDesktopTurnsByThreadId.get(threadId);
+    if (!turns) {
+      return;
+    }
+
+    for (const entry of turns.values()) {
+      entry.latestState = latestState;
+    }
+  }
+
+  function syncProjectedDesktopTurnCompletions(threadId, nextState) {
+    const turns = activeDesktopTurnsByThreadId.get(threadId);
+    if (!turns || turns.size === 0) {
+      return;
+    }
+
+    const completions = projectDesktopTurnCompletedNotifications(
+      threadId,
+      nextState,
+      new Set(turns.keys())
+    );
+    for (const notification of completions) {
+      completeDesktopIpcTurn(threadId, notification.params.turnId, notification.params.status || "completed");
+    }
+  }
+
+  function completeDesktopIpcTurn(threadId, turnId, status = "completed") {
+    const turns = activeDesktopTurnsByThreadId.get(threadId);
+    const entry = turns?.get(turnId);
+    if (!entry) {
+      return;
+    }
+
+    if (entry.timer) {
+      clearTimeoutFn(entry.timer);
+    }
+    turns.delete(turnId);
+    if (turns.size === 0) {
+      activeDesktopTurnsByThreadId.delete(threadId);
+    }
+
+    sendApplicationResponse(JSON.stringify(createDesktopIpcTurnCompletedNotification(threadId, turnId, status)));
+  }
+
+  function clearAllDesktopTurnCompletionTimers() {
+    for (const turns of activeDesktopTurnsByThreadId.values()) {
+      for (const entry of turns.values()) {
+        if (entry.timer) {
+          clearTimeoutFn(entry.timer);
+        }
+      }
+    }
+    activeDesktopTurnsByThreadId.clear();
   }
 
   return {
@@ -612,8 +747,118 @@ function projectDesktopAssistantDeltaNotifications(
   return notifications;
 }
 
+function projectDesktopUserMessageNotifications(
+  threadId,
+  conversationState,
+  mirroredKeys = new Set(),
+  turnIdFilter = null
+) {
+  const messages = collectUserMessages(conversationState);
+  const notifications = [];
+
+  for (const message of messages) {
+    if (turnIdFilter && turnIdFilter.size > 0 && !turnIdFilter.has(message.turnId)) {
+      continue;
+    }
+    if (mirroredKeys.has(message.key)) {
+      continue;
+    }
+
+    mirroredKeys.add(message.key);
+    notifications.push({
+      method: "codex/event/user_message",
+      params: {
+        threadId,
+        turnId: message.turnId,
+        message: message.text,
+        ...(message.itemId ? { id: message.itemId } : {}),
+        ...(message.timestamp ? { timestamp: message.timestamp } : {}),
+        remodexDesktopMirror: true,
+        remodexDesktopIpcMirror: true,
+      },
+    });
+  }
+
+  return notifications;
+}
+
+function projectDesktopTurnCompletedNotifications(
+  threadId,
+  conversationState,
+  trackedTurnIds = new Set()
+) {
+  if (!trackedTurnIds || trackedTurnIds.size === 0) {
+    return [];
+  }
+
+  const turns = Array.isArray(conversationState?.turns) ? conversationState.turns : [];
+  const notifications = [];
+  for (const turn of turns) {
+    const turnId = readString(turn?.id) || readString(turn?.turnId) || readString(turn?.turn_id);
+    if (!turnId || !trackedTurnIds.has(turnId)) {
+      continue;
+    }
+    if (!isDesktopTurnTerminal(turn, conversationState)) {
+      continue;
+    }
+
+    notifications.push(createDesktopIpcTurnCompletedNotification(
+      threadId,
+      turnId,
+      desktopTerminalStatus(turn, conversationState) || "completed"
+    ));
+  }
+  return notifications;
+}
+
+function createDesktopIpcTurnCompletedNotification(threadId, turnId, status = "completed") {
+  return {
+    method: "turn/completed",
+    params: {
+      threadId,
+      turnId,
+      id: turnId,
+      status,
+      remodexDesktopMirror: true,
+      remodexDesktopIpcMirror: true,
+    },
+  };
+}
+
 function snapshotAssistantMessageTexts(conversationState) {
   return new Map(collectAssistantMessages(conversationState).map((message) => [message.key, message.text]));
+}
+
+function collectUserMessages(conversationState) {
+  const turns = Array.isArray(conversationState?.turns) ? conversationState.turns : [];
+  const messages = [];
+  for (const turn of turns) {
+    const turnId = readString(turn?.id) || readString(turn?.turnId) || readString(turn?.turn_id);
+    const items = Array.isArray(turn?.items) ? turn.items : [];
+    for (const item of items) {
+      if (!isUserMessageItem(item)) {
+        continue;
+      }
+
+      const text = userMessageText(item);
+      if (!turnId || !text) {
+        continue;
+      }
+
+      const itemId = readString(item?.id) || readString(item?.itemId) || readString(item?.item_id);
+      messages.push({
+        key: userMessageKey(turnId, itemId, text),
+        turnId,
+        itemId,
+        text,
+        timestamp: readString(item?.createdAt)
+          || readString(item?.created_at)
+          || readString(item?.timestamp)
+          || readString(item?.time),
+      });
+    }
+  }
+  return messages;
 }
 
 function collectAssistantMessages(conversationState) {
@@ -644,12 +889,163 @@ function collectAssistantMessages(conversationState) {
   return messages;
 }
 
+function userMessageKey(turnId, itemId, text) {
+  if (itemId) {
+    return `${turnId}:${itemId}`;
+  }
+  return `${turnId}:text:${crypto
+    .createHash("sha256")
+    .update(text)
+    .digest("hex")
+    .slice(0, 16)}`;
+}
+
+function isDesktopTurnTerminal(turn, conversationState) {
+  if (desktopTerminalStatus(turn, conversationState)) {
+    return true;
+  }
+
+  return hasExplicitFalseFlag(turn, ["running", "isRunning", "streaming", "isStreaming"])
+    || (
+      hasExplicitFalseFlag(conversationState, ["running", "isRunning", "streaming", "isStreaming"])
+      && !hasOpenDesktopRequestForTurn(conversationState, readString(turn?.id) || readString(turn?.turnId) || readString(turn?.turn_id))
+    );
+}
+
+function desktopTerminalStatus(turn, conversationState) {
+  const terminal = terminalStatusFromObject(turn)
+    || terminalStatusFromObject(turn?.turn)
+    || terminalStatusFromObject(conversationState);
+  return terminal || "";
+}
+
+function terminalStatusFromObject(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return "";
+  }
+
+  const booleanStatus = terminalStatusFromBooleans(value);
+  if (booleanStatus) {
+    return booleanStatus;
+  }
+
+  const candidates = [
+    value.status,
+    value.state,
+    value.phase,
+    value.lifecycle,
+    value.lifecycleStatus,
+    value.lifecycle_status,
+    value.runStatus,
+    value.run_status,
+    value.turnStatus,
+    value.turn_status,
+  ];
+  for (const candidate of candidates) {
+    const token = normalizeToken(readString(candidate));
+    if (TERMINAL_STATUS_TOKENS.has(token)) {
+      return canonicalTerminalStatus(token);
+    }
+  }
+  return "";
+}
+
+function terminalStatusFromBooleans(value) {
+  if (value.completed === true || value.complete === true || value.done === true || value.finished === true) {
+    return "completed";
+  }
+  if (value.failed === true || value.error === true) {
+    return "failed";
+  }
+  if (value.cancelled === true || value.canceled === true || value.interrupted === true) {
+    return "canceled";
+  }
+  return "";
+}
+
+const TERMINAL_STATUS_TOKENS = new Set([
+  "completed",
+  "complete",
+  "finished",
+  "succeeded",
+  "success",
+  "failed",
+  "failure",
+  "error",
+  "cancelled",
+  "canceled",
+  "interrupted",
+]);
+
+function canonicalTerminalStatus(token) {
+  if (token === "failed" || token === "failure" || token === "error") {
+    return "failed";
+  }
+  if (token === "cancelled" || token === "canceled" || token === "interrupted") {
+    return "canceled";
+  }
+  return "completed";
+}
+
+function hasExplicitFalseFlag(value, keys) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  return keys.some((key) => Object.prototype.hasOwnProperty.call(value, key) && value[key] === false);
+}
+
+function hasOpenDesktopRequestForTurn(conversationState, turnId) {
+  if (!turnId) {
+    return false;
+  }
+
+  const requests = Array.isArray(conversationState?.requests) ? conversationState.requests : [];
+  return requests.some((request) => {
+    if (!request || request.completed === true) {
+      return false;
+    }
+
+    const params = request.params && typeof request.params === "object" && !Array.isArray(request.params)
+      ? request.params
+      : {};
+    const requestTurnId = readString(params.turnId)
+      || readString(params.turn_id)
+      || readString(request.turnId)
+      || readString(request.turn_id);
+    return requestTurnId === turnId;
+  });
+}
+
+function isUserMessageItem(item) {
+  const type = normalizeToken(item?.type);
+  if (type === "usermessage") {
+    return true;
+  }
+  return type === "message" && normalizeToken(item?.role) === "user";
+}
+
 function isAssistantMessageItem(item) {
   const type = normalizeToken(item?.type);
   if (type === "agentmessage" || type === "assistantmessage") {
     return true;
   }
   return type === "message" && normalizeToken(item?.role) === "assistant";
+}
+
+function userMessageText(item) {
+  const directText = readString(item?.text) || readString(item?.message);
+  if (directText) {
+    return directText;
+  }
+
+  const content = Array.isArray(item?.content) ? item.content : [];
+  return content
+    .map((entry) => entry && typeof entry === "object" ? entry : null)
+    .filter(Boolean)
+    .map((entry) => readString(entry.text) || readString(entry?.data?.text))
+    .filter(Boolean)
+    .join("");
 }
 
 function assistantMessageText(item) {
@@ -844,6 +1240,8 @@ module.exports = {
   createDesktopIpcActionFollower,
   desktopFollowerPayloadForResponse,
   projectDesktopAssistantDeltaNotifications,
+  projectDesktopTurnCompletedNotifications,
+  projectDesktopUserMessageNotifications,
   projectPendingDesktopActions,
   resolveDefaultIpcSocketPath,
   seedConversationStateFromThreadRead,

--- a/phodex-bridge/test/bridge-desktop-ipc-integration.test.js
+++ b/phodex-bridge/test/bridge-desktop-ipc-integration.test.js
@@ -467,6 +467,134 @@ test("bridge forwards live desktop assistant deltas to the phone", async (t) => 
   assert.ok(relayMessages.indexOf(deltaMessage) < relayMessages.indexOf(completedMessage));
 });
 
+test("bridge forwards live desktop IPC tool calls to the phone", async (t) => {
+  const { tempDir, socketPath: ipcSocketPath } = createIpcTestSocket("remodex-bridge-ipc-tools-");
+  const relayServer = new WebSocket.Server({ port: 0 });
+  const relayMessages = [];
+  let relaySocket = null;
+  let ipcServerSocket = null;
+  let bridge = null;
+
+  await new Promise((resolve) => relayServer.once("listening", resolve));
+  relayServer.on("connection", (socket) => {
+    relaySocket = socket;
+    socket.on("message", (data) => {
+      const parsed = safeParseJSON(data.toString("utf8"));
+      if (parsed) {
+        relayMessages.push(parsed);
+      }
+    });
+  });
+
+  const ipcServer = net.createServer((socket) => {
+    ipcServerSocket = socket;
+    attachFrameReader(socket, (frame) => {
+      if (frame.method === "initialize") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: "initialize",
+          handledByClientId: "desktop",
+          result: { clientId: "desktop-test" },
+        });
+      }
+    });
+  });
+  await new Promise((resolve) => ipcServer.listen(ipcSocketPath, resolve));
+
+  const { startBridge } = loadBridgeWithTestDoubles({
+    createCodexTransportImpl() {
+      return createFakeCodexTransport();
+    },
+  });
+
+  t.after(() => {
+    bridge?.stop();
+    relaySocket?.close();
+    relayServer.close();
+    ipcServer.close();
+    ipcServerSocket?.destroy();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  bridge = startBridge({
+    printPairingQr: false,
+    config: {
+      relayUrl: `ws://127.0.0.1:${relayServer.address().port}`,
+      pushServiceUrl: "",
+      pushPreviewMaxChars: 160,
+      refreshEnabled: false,
+      refreshDebounceMs: 1,
+      keepMacAwakeEnabled: false,
+      codexEndpoint: "",
+      refreshCommand: "",
+      codexBundleId: "",
+      codexAppPath: "",
+      desktopIpcSocketPath: ipcSocketPath,
+    },
+  });
+
+  await waitFor(() => relaySocket && relaySocket.readyState === WebSocket.OPEN);
+  relaySocket.send(JSON.stringify({
+    id: "resume-from-phone",
+    method: "thread/resume",
+    params: { threadId: "thread-ipc-tool" },
+  }));
+
+  await waitFor(() => ipcServerSocket, 2_000);
+  writeFrame(ipcServerSocket, {
+    type: "broadcast",
+    method: "thread-stream-state-changed",
+    sourceClientId: "desktop",
+    version: 1,
+    params: {
+      conversationId: "thread-ipc-tool",
+      change: {
+        type: "snapshot",
+        conversationState: {
+          turns: [{
+            id: "turn-ipc-tool",
+            status: "running",
+            items: [{
+              id: "user-ipc-tool",
+              type: "user_message",
+              text: "Run git status",
+            }, {
+              id: "call-ipc-tool",
+              type: "function_call",
+              call_id: "call-ipc-tool",
+              name: "exec_command",
+              arguments: JSON.stringify({ cmd: "git status", workdir: "/repo" }),
+            }],
+          }],
+        },
+      },
+    },
+  });
+
+  const userMessage = await waitForMessage(
+    relayMessages,
+    (message) => message.method === "codex/event/user_message"
+  );
+  const toolMessage = await waitForMessage(
+    relayMessages,
+    (message) => message.method === "codex/event/exec_command_begin"
+  );
+
+  assert.ok(relayMessages.indexOf(userMessage) < relayMessages.indexOf(toolMessage));
+  assert.deepEqual(toolMessage.params, {
+    threadId: "thread-ipc-tool",
+    turnId: "turn-ipc-tool",
+    call_id: "call-ipc-tool",
+    command: "git status",
+    cwd: "/repo",
+    status: "running",
+    remodexDesktopMirror: true,
+    remodexDesktopIpcMirror: true,
+  });
+});
+
 // Loads bridge.js with plaintext test transports while leaving the production module untouched.
 function loadBridgeWithTestDoubles({ createCodexTransportImpl }) {
   const bridgePath = require.resolve("../src/bridge");

--- a/phodex-bridge/test/bridge-desktop-ipc-integration.test.js
+++ b/phodex-bridge/test/bridge-desktop-ipc-integration.test.js
@@ -134,7 +134,6 @@ test("bridge forwards desktop IPC actions to the phone and routes replies back t
       },
     },
   });
-
   const actionMessage = await waitForMessage(relayMessages, (message) => message.id === "req-ipc");
   assert.equal(actionMessage.method, "item/tool/requestUserInput");
 
@@ -385,6 +384,10 @@ test("bridge forwards live desktop assistant deltas to the phone", async (t) => 
           turns: [{
             id: "turn-ipc-delta",
             items: [{
+              id: "user-ipc-delta",
+              type: "user_message",
+              text: "Please mirror me first",
+            }, {
               id: "assistant-ipc-delta",
               type: "assistant_message",
               text: "Hello",
@@ -405,8 +408,25 @@ test("bridge forwards live desktop assistant deltas to the phone", async (t) => 
         type: "patches",
         patches: [{
           op: "replace",
-          path: ["turns", 0, "items", 0, "text"],
+          path: ["turns", 0, "items", 1, "text"],
           value: "Hello world",
+        }],
+      },
+    },
+  });
+  writeFrame(ipcServerSocket, {
+    type: "broadcast",
+    method: "thread-stream-state-changed",
+    sourceClientId: "desktop",
+    version: 1,
+    params: {
+      conversationId: "thread-ipc-delta",
+      change: {
+        type: "patches",
+        patches: [{
+          op: "replace",
+          path: ["turns", 0, "status"],
+          value: "completed",
         }],
       },
     },
@@ -416,12 +436,35 @@ test("bridge forwards live desktop assistant deltas to the phone", async (t) => 
     relayMessages,
     (message) => message.method === "item/agentMessage/delta"
   );
+  const userMessage = relayMessages.find((message) => message.method === "codex/event/user_message");
+  assert.deepEqual(userMessage.params, {
+    threadId: "thread-ipc-delta",
+    turnId: "turn-ipc-delta",
+    message: "Please mirror me first",
+    id: "user-ipc-delta",
+    remodexDesktopMirror: true,
+    remodexDesktopIpcMirror: true,
+  });
+  assert.ok(relayMessages.indexOf(userMessage) < relayMessages.indexOf(deltaMessage));
   assert.deepEqual(deltaMessage.params, {
     threadId: "thread-ipc-delta",
     turnId: "turn-ipc-delta",
     itemId: "assistant-ipc-delta",
     delta: " world",
   });
+  const completedMessage = await waitForMessage(
+    relayMessages,
+    (message) => message.method === "turn/completed"
+  );
+  assert.deepEqual(completedMessage.params, {
+    threadId: "thread-ipc-delta",
+    turnId: "turn-ipc-delta",
+    id: "turn-ipc-delta",
+    status: "completed",
+    remodexDesktopMirror: true,
+    remodexDesktopIpcMirror: true,
+  });
+  assert.ok(relayMessages.indexOf(deltaMessage) < relayMessages.indexOf(completedMessage));
 });
 
 // Loads bridge.js with plaintext test transports while leaving the production module untouched.

--- a/phodex-bridge/test/desktop-ipc-action-follower.test.js
+++ b/phodex-bridge/test/desktop-ipc-action-follower.test.js
@@ -16,6 +16,8 @@ const {
   applyConversationStateChange,
   createDesktopIpcActionFollower,
   desktopFollowerPayloadForResponse,
+  hasActiveDesktopActivityForTurn,
+  projectDesktopActivityNotifications,
   projectDesktopAssistantDeltaNotifications,
   projectDesktopTurnCompletedNotifications,
   projectDesktopUserMessageNotifications,
@@ -529,11 +531,37 @@ test("projects desktop turn completion notifications from terminal state", () =>
         type: "assistant_message",
         text: "Still going",
       }],
+    }, {
+      id: "turn-terminal-active-tool",
+      status: "completed",
+      items: [{
+        id: "tool-running",
+        type: "tool_call",
+        status: "running",
+      }],
+    }, {
+      id: "turn-terminal-active-function-call",
+      status: "completed",
+      items: [{
+        id: "call-active",
+        type: "function_call",
+        call_id: "call-active",
+        name: "exec_command",
+      }],
     }],
   };
 
   assert.deepEqual(
-    projectDesktopTurnCompletedNotifications("thread-1", state, new Set(["turn-1", "turn-running"])),
+    projectDesktopTurnCompletedNotifications(
+      "thread-1",
+      state,
+      new Set([
+        "turn-1",
+        "turn-running",
+        "turn-terminal-active-tool",
+        "turn-terminal-active-function-call",
+      ])
+    ),
     [{
       method: "turn/completed",
       params: {
@@ -546,6 +574,154 @@ test("projects desktop turn completion notifications from terminal state", () =>
       },
     }]
   );
+});
+
+test("detects active desktop activity before idle turn completion", () => {
+  const state = {
+    turns: [{
+      id: "turn-running-tool",
+      items: [{
+        id: "tool-1",
+        type: "tool_call",
+        status: "running",
+      }],
+    }, {
+      id: "turn-running-function-call",
+      items: [{
+        id: "call-active",
+        type: "function_call",
+        call_id: "call-active",
+        name: "exec_command",
+      }],
+    }, {
+      id: "turn-finished-function-call",
+      items: [{
+        id: "call-finished",
+        type: "function_call",
+        call_id: "call-finished",
+        name: "exec_command",
+      }, {
+        type: "function_call_output",
+        call_id: "call-finished",
+        output: "done",
+      }],
+    }, {
+      id: "turn-completed-tool",
+      items: [{
+        id: "tool-2",
+        type: "command_execution",
+        status: "completed",
+      }],
+    }],
+  };
+
+  assert.equal(hasActiveDesktopActivityForTurn(state, "turn-running-tool"), true);
+  assert.equal(hasActiveDesktopActivityForTurn(state, "turn-running-function-call"), true);
+  assert.equal(hasActiveDesktopActivityForTurn(state, "turn-finished-function-call"), false);
+  assert.equal(hasActiveDesktopActivityForTurn(state, "turn-completed-tool"), false);
+});
+
+test("projects desktop IPC bare function calls as live tool rows", () => {
+  const mirroredKeys = new Set();
+  const stateWithCall = {
+    turns: [{
+      id: "turn-tool",
+      items: [{
+        id: "call-1",
+        type: "function_call",
+        call_id: "call-1",
+        name: "exec_command",
+        arguments: JSON.stringify({ cmd: "git status", workdir: "/repo" }),
+      }],
+    }],
+  };
+
+  assert.deepEqual(projectDesktopActivityNotifications("thread-1", stateWithCall, mirroredKeys), [{
+    method: "codex/event/exec_command_begin",
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-tool",
+      call_id: "call-1",
+      command: "git status",
+      cwd: "/repo",
+      status: "running",
+      remodexDesktopMirror: true,
+      remodexDesktopIpcMirror: true,
+    },
+  }]);
+  assert.deepEqual(projectDesktopActivityNotifications("thread-1", stateWithCall, mirroredKeys), []);
+
+  const stateWithOutput = {
+    turns: [{
+      id: "turn-tool",
+      items: [
+        ...stateWithCall.turns[0].items,
+        {
+          type: "function_call_output",
+          call_id: "call-1",
+          output: "clean\\n",
+        },
+      ],
+    }],
+  };
+
+  assert.deepEqual(projectDesktopActivityNotifications("thread-1", stateWithOutput, mirroredKeys), [{
+    method: "codex/event/exec_command_output_delta",
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-tool",
+      call_id: "call-1",
+      command: "git status",
+      cwd: "/repo",
+      chunk: "clean\\n",
+      remodexDesktopMirror: true,
+      remodexDesktopIpcMirror: true,
+    },
+  }, {
+    method: "codex/event/exec_command_end",
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-tool",
+      call_id: "call-1",
+      command: "git status",
+      cwd: "/repo",
+      status: "completed",
+      output: "clean\\n",
+      remodexDesktopMirror: true,
+      remodexDesktopIpcMirror: true,
+    },
+  }]);
+});
+
+test("projects completed-fast desktop custom tool calls as finished file changes", () => {
+  const notifications = projectDesktopActivityNotifications("thread-1", {
+    turns: [{
+      id: "turn-patch",
+      status: "running",
+      items: [{
+        id: "patch-1",
+        type: "custom_tool_call",
+        call_id: "patch-1",
+        name: "apply_patch",
+        status: "completed",
+        input: [
+          "*** Begin Patch",
+          "*** Add File: note.txt",
+          "+hello",
+          "*** End Patch",
+        ].join("\n"),
+      }],
+    }],
+  }, new Set());
+
+  assert.equal(notifications.length, 1);
+  assert.equal(notifications[0].method, "codex/event/patch_apply_end");
+  assert.equal(notifications[0].params.threadId, "thread-1");
+  assert.equal(notifications[0].params.turnId, "turn-patch");
+  assert.equal(notifications[0].params.call_id, "patch-1");
+  assert.equal(notifications[0].params.status, "completed");
+  assert.equal(notifications[0].params.success, true);
+  assert.equal(notifications[0].params.changes[0].path, "note.txt");
 });
 
 test("uses the Codex Desktop named pipe as the default Windows IPC path", (t) => {

--- a/phodex-bridge/test/desktop-ipc-action-follower.test.js
+++ b/phodex-bridge/test/desktop-ipc-action-follower.test.js
@@ -17,6 +17,8 @@ const {
   createDesktopIpcActionFollower,
   desktopFollowerPayloadForResponse,
   projectDesktopAssistantDeltaNotifications,
+  projectDesktopTurnCompletedNotifications,
+  projectDesktopUserMessageNotifications,
   projectPendingDesktopActions,
   resolveDefaultIpcSocketPath,
   seedConversationStateFromThreadRead,
@@ -453,6 +455,96 @@ test("does not replay unchanged or rewritten assistant text as live deltas", () 
   assert.deepEqual(
     projectDesktopAssistantDeltaNotifications("thread-1", previousState, nextState),
     []
+  );
+});
+
+test("projects desktop user prelude notifications once for active assistant turns", () => {
+  const mirroredKeys = new Set();
+  const state = {
+    turns: [{
+      id: "turn-1",
+      items: [{
+        id: "user-1",
+        type: "user_message",
+        text: "Fix the ordering",
+        createdAt: "2026-05-26T20:01:42.000Z",
+      }, {
+        id: "assistant-1",
+        type: "assistant_message",
+        text: "Working",
+      }],
+    }, {
+      id: "turn-old",
+      items: [{
+        id: "user-old",
+        type: "user_message",
+        text: "Old prompt",
+      }],
+    }],
+  };
+
+  const first = projectDesktopUserMessageNotifications(
+    "thread-1",
+    state,
+    mirroredKeys,
+    new Set(["turn-1"])
+  );
+  const second = projectDesktopUserMessageNotifications(
+    "thread-1",
+    state,
+    mirroredKeys,
+    new Set(["turn-1"])
+  );
+
+  assert.deepEqual(first, [{
+    method: "codex/event/user_message",
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      message: "Fix the ordering",
+      id: "user-1",
+      timestamp: "2026-05-26T20:01:42.000Z",
+      remodexDesktopMirror: true,
+      remodexDesktopIpcMirror: true,
+    },
+  }]);
+  assert.deepEqual(second, []);
+});
+
+test("projects desktop turn completion notifications from terminal state", () => {
+  const state = {
+    turns: [{
+      id: "turn-1",
+      status: "completed",
+      items: [{
+        id: "assistant-1",
+        type: "assistant_message",
+        text: "Done",
+      }],
+    }, {
+      id: "turn-running",
+      status: "running",
+      items: [{
+        id: "assistant-running",
+        type: "assistant_message",
+        text: "Still going",
+      }],
+    }],
+  };
+
+  assert.deepEqual(
+    projectDesktopTurnCompletedNotifications("thread-1", state, new Set(["turn-1", "turn-running"])),
+    [{
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        id: "turn-1",
+        status: "completed",
+        remodexDesktopMirror: true,
+        remodexDesktopIpcMirror: true,
+      },
+    }]
   );
 });
 
@@ -1045,6 +1137,7 @@ test("desktop IPC follower mirrors live assistant text growth from desktop state
       outbound.push(JSON.parse(message));
     },
     requestTimeoutMs: 500,
+    turnCompletionIdleMs: 10,
   });
   t.after(() => follower.stopAll());
 
@@ -1066,6 +1159,10 @@ test("desktop IPC follower mirrors live assistant text growth from desktop state
           turns: [{
             id: "turn-live-delta",
             items: [{
+              id: "user-live-delta",
+              type: "user_message",
+              text: "Make the message show first",
+            }, {
               id: "assistant-live-delta",
               type: "assistant_message",
               text: "Hello",
@@ -1086,7 +1183,7 @@ test("desktop IPC follower mirrors live assistant text growth from desktop state
         type: "patches",
         patches: [{
           op: "replace",
-          path: ["turns", 0, "items", 0, "text"],
+          path: ["turns", 0, "items", 1, "text"],
           value: "Hello world",
         }],
       },
@@ -1094,12 +1191,31 @@ test("desktop IPC follower mirrors live assistant text growth from desktop state
   });
 
   await waitFor(() => outbound.find((message) => message.method === "item/agentMessage/delta"));
+  assert.equal(outbound[0].method, "codex/event/user_message");
+  assert.deepEqual(outbound[0].params, {
+    threadId: "thread-live-delta",
+    turnId: "turn-live-delta",
+    message: "Make the message show first",
+    id: "user-live-delta",
+    remodexDesktopMirror: true,
+    remodexDesktopIpcMirror: true,
+  });
   const deltaMessage = outbound.find((message) => message.method === "item/agentMessage/delta");
   assert.deepEqual(deltaMessage.params, {
     threadId: "thread-live-delta",
     turnId: "turn-live-delta",
     itemId: "assistant-live-delta",
     delta: " world",
+  });
+  await waitFor(() => outbound.find((message) => message.method === "turn/completed"));
+  const completedMessage = outbound.find((message) => message.method === "turn/completed");
+  assert.deepEqual(completedMessage.params, {
+    threadId: "thread-live-delta",
+    turnId: "turn-live-delta",
+    id: "turn-live-delta",
+    status: "completed",
+    remodexDesktopMirror: true,
+    remodexDesktopIpcMirror: true,
   });
 });
 


### PR DESCRIPTION
## Summary
- keep Desktop IPC mirror runs from completing while tool activity is still active
- project Desktop IPC tool/function calls into the same phone-visible event shapes as rollout mirroring
- avoid canonical history reconciliation for synthetic Desktop IPC completions that can reorder local live rows

## Verification
- git diff --check
- node --test --test-concurrency=1 phodex-bridge/test/desktop-ipc-action-follower.test.js phodex-bridge/test/bridge-desktop-ipc-integration.test.js