### PR TITLE
Add desktop IPC live sync with safe snapshot hydration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ If you scan the pairing QR with a generic camera or QR reader before installing 
 │  app         │    WebSocket bridge    │ bridge        │    JSON-RPC              │ app-server  │
 └──────────────┘                        └───────────────┘                          └─────────────┘
                                                │                                         │
-                                               │  AppleScript route bounce                │ JSONL rollout
+                                               │  Local Codex IPC live state              │ JSONL rollout
                                                ▼                                         ▼
                                         ┌─────────────┐                           ┌─────────────┐
-                                        │  Codex.app  │ ◄─── reads from ──────── │  ~/.codex/  │
+                                        │  Codex.app  │ ◄─── persisted fallback ─│  ~/.codex/  │
                                         │  (desktop)  │      disk on navigate     │  sessions   │
                                         └─────────────┘                           └─────────────┘
 ```
@@ -68,7 +68,7 @@ If you scan the pairing QR with a generic camera or QR reader before installing 
 4. After the first handshake, the iPhone can resolve the Mac's live session through the configured relay and reconnect automatically
 5. Your phone sends instructions to Codex through the bridge and receives responses in real-time
 6. The bridge handles git operations and local session persistence on your Mac
-7. `Codex.app` can read the same thread history from disk, but it is not a true live mirror unless you enable the optional refresh workaround
+7. When the local Codex IPC bus is available, Remodex broadcasts live conversation state to Codex Desktop / VSCode; persisted JSONL history and the optional refresh workaround remain as fallbacks
 
 ## Repository Structure
 
@@ -330,6 +330,9 @@ remodex watch
 | `REMODEX_RELAY` | empty in source checkouts; optional in published packages | Session base URL used for QR bootstrap, trusted-session resolve, and phone/Mac session routing |
 | `REMODEX_PUSH_SERVICE_URL` | disabled by default | Optional HTTP base URL for managed push registration/completion |
 | `REMODEX_CODEX_ENDPOINT` | — | Connect to an existing Codex WebSocket instead of spawning a local `codex app-server` |
+| `REMODEX_DESKTOP_IPC_LIVE_SYNC` | `true` | Broadcast Remodex-owned active threads over the local Codex Desktop / VSCode IPC bus |
+| `REMODEX_DESKTOP_IPC_SOCKET` | auto-detected | Override the local Codex IPC socket or Windows named pipe path |
+| `REMODEX_DESKTOP_IPC_SNAPSHOT_DEBOUNCE_MS` | `75` | Debounce window (ms) for IPC `conversationState` snapshot / patch broadcasts |
 | `REMODEX_REFRESH_ENABLED` | `false` | Auto-refresh Codex.app when phone activity is detected (`true` enables it explicitly) |
 | `REMODEX_REFRESH_DEBOUNCE_MS` | `1200` | Debounce window (ms) for coalescing refresh events |
 | `REMODEX_REFRESH_COMMAND` | — | Custom shell command to run instead of the built-in AppleScript refresh |
@@ -339,6 +342,9 @@ remodex watch
 ```sh
 # Enable desktop refresh explicitly
 REMODEX_REFRESH_ENABLED=true remodex up
+
+# Disable local Desktop / VSCode IPC live sync
+REMODEX_DESKTOP_IPC_LIVE_SYNC=false remodex up
 
 # Connect to an existing Codex instance
 REMODEX_CODEX_ENDPOINT=ws://localhost:8080 remodex up
@@ -432,16 +438,18 @@ What is live today:
 
 - The iPhone conversation is live while the bridge session is connected.
 - The Mac-side Codex runtime is the real runtime doing the work.
+- Remodex-owned active threads are broadcast over the local Codex IPC bus as Desktop / VSCode-compatible `conversationState` updates. The first update is a full snapshot; later changes use Immer-style patches when they stay within size limits.
+- Codex Desktop or VSCode can follow those Remodex-owned threads and send continue, steer, interrupt, approval, and user-input actions back to the bridge through `thread-follower-*` IPC requests.
 
-What is not fully live today:
+Current boundaries:
 
-- `Codex.app` does not act like a second live subscriber to the active run by default.
-- The desktop app catches up from the persisted session files and can be nudged with the optional refresh workaround below.
-- True phone-to-desktop live sync in the `Codex.app` GUI is not supported today.
+- Remodex joins the local IPC bus when Codex Desktop or VSCode has created it. If no local IPC router is running, Remodex starts a compatible local router so Desktop / VSCode can connect later and receive the active thread snapshot.
+- IPC sync keeps a short debounce and falls back to a full snapshot when a patch would be too large or when a client reconnect requires a fresh baseline.
+- The IPC protocol is private to Codex clients, so future Codex Desktop / VSCode changes may require bridge updates.
 
-To make that limitation more practical, Remodex also includes a hand-off button in the iPhone app. It lets you explicitly continue the current chat on your Mac by opening the matching thread in `Codex.app` when you are ready to switch devices.
+Remodex also keeps the hand-off button in the iPhone app. It explicitly opens the matching thread in `Codex.app` when you want to switch devices or force Desktop to mount a thread.
 
-**Known limitation**: The Codex desktop app does not live-reload when an external `app-server` process writes new data to disk. Threads created or updated from your phone won't appear in the desktop app until it remounts that route. Remodex keeps desktop refresh off by default for now because the current deep-link bounce is still disruptive. You can still enable it manually if you want the old remount workaround.
+The old deep-link refresh workaround remains available, but it is off by default because it is more disruptive than IPC live sync.
 
 ```sh
 # Enable the old deep-link refresh workaround manually
@@ -488,10 +496,10 @@ Run `remodex reset-pairing`, then start the bridge again with `remodex up`. You 
 Yes — set `REMODEX_CODEX_ENDPOINT=ws://host:port` to skip spawning a local `codex app-server`.
 
 **Why don't my phone threads show up in the Codex desktop app immediately?**
-The desktop app reads session data from disk (`~/.codex/sessions`) but doesn't live-reload when an external process writes new data. Your phone still gets the live stream; it is the desktop GUI that lags unless you explicitly enable the refresh workaround with `REMODEX_REFRESH_ENABLED=true`.
+With `REMODEX_DESKTOP_IPC_LIVE_SYNC=true`, Remodex broadcasts active phone-owned threads over the local Codex IPC bus. If no IPC router is available yet, Remodex starts one locally so Desktop or VSCode can connect later; disk persistence and the older refresh workaround remain fallbacks.
 
 **Does Remodex support true live sync between phone and `Codex.app`?**
-No. The phone session is live, but the `Codex.app` GUI is not a true live mirror of the active run. To help with that, the iPhone app includes a `Hand off to Mac app` button so you can explicitly continue the same thread on your Mac.
+Yes, for active Remodex-owned threads when the local Codex IPC bus is available. The bridge acts as the thread owner, broadcasts Desktop / VSCode-compatible `conversationState`, and accepts follower requests back from those UIs.
 
 **Can I self-host the relay?**
 Yes. That is the intended forking path. The transport and push-service code are in [`relay/`](relay/); point `REMODEX_RELAY` at the instance you run.

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -56,6 +56,7 @@ const {
   createDesktopIpcActionFollower,
   seedConversationStateFromThreadRead,
 } = require("./desktop-ipc-action-follower");
+const { createDesktopIpcLiveOwner } = require("./desktop-ipc-live-owner");
 const { version: bridgePackageVersion = "" } = require("../package.json");
 const {
   MINIMUM_SUPPORTED_IOS_APP_VERSION,
@@ -258,6 +259,15 @@ function startBridge({
       socketPath: config.desktopIpcSocketPath || undefined,
     })
     : null;
+  const desktopIpcLiveOwner = !config.codexEndpoint
+    ? createDesktopIpcLiveOwner({
+      enabled: config.desktopIpcLiveSyncEnabled !== false,
+      sendCodexRequest,
+      sendRawCodexMessage: (rawMessage) => codex.send(rawMessage),
+      socketPath: config.desktopIpcSocketPath || undefined,
+      snapshotDebounceMs: config.desktopIpcSnapshotDebounceMs,
+    })
+    : null;
   let contextUsageWatcher = null;
   let watchedContextUsageKey = null;
 
@@ -347,6 +357,7 @@ function startBridge({
     stopContextUsageWatcher();
     rolloutLiveMirror?.stopAll();
     desktopIpcActionFollower?.stopAll();
+    desktopIpcLiveOwner?.stopAll();
   }
 
   function stopBridge() {
@@ -539,6 +550,7 @@ function startBridge({
     updatePendingAuthLoginFromCodexMessage(message);
     trackCodexHandshakeState(message);
     desktopRefresher.handleOutbound(message);
+    desktopIpcLiveOwner?.observeOutbound(message);
     pushNotificationTracker.handleOutbound(message);
     rememberThreadFromMessage("codex", message);
     secureTransport.queueOutboundApplicationMessage(
@@ -623,6 +635,7 @@ function startBridge({
     if (desktopIpcActionFollower?.observeInbound(rawMessage)) {
       return;
     }
+    desktopIpcLiveOwner?.observeInbound(rawMessage);
     if (handleBridgeManagedThreadTurnsListRequest(rawMessage, sendApplicationResponse)) {
       return;
     }

--- a/phodex-bridge/src/codex-desktop-refresher.js
+++ b/phodex-bridge/src/codex-desktop-refresher.js
@@ -553,11 +553,12 @@ function readBridgeConfig({
     env
   );
   const explicitRefreshEnabled = readOptionalBooleanEnv(["REMODEX_REFRESH_ENABLED"], env);
+  const explicitDesktopIpcLiveSyncEnabled = readOptionalBooleanEnv(["REMODEX_DESKTOP_IPC_LIVE_SYNC"], env);
   const explicitKeepMacAwakeEnabled = readOptionalBooleanEnv(["REMODEX_KEEP_MAC_AWAKE"], env);
   const persistedKeepMacAwakeEnabled = typeof daemonConfig.keepMacAwakeEnabled === "boolean"
     ? daemonConfig.keepMacAwakeEnabled
     : null;
-  // Desktop refresh is opt-in for now because Codex.app still lacks true live updates.
+  // The deep-link refresh workaround stays opt-in; local IPC live sync is the primary desktop path.
   const defaultRefreshEnabled = false;
   return {
     relayUrl,
@@ -582,6 +583,13 @@ function readBridgeConfig({
       : explicitKeepMacAwakeEnabled,
     codexEndpoint,
     desktopIpcSocketPath: readFirstDefinedEnv(["REMODEX_DESKTOP_IPC_SOCKET"], "", env),
+    desktopIpcLiveSyncEnabled: explicitDesktopIpcLiveSyncEnabled == null
+      ? true
+      : explicitDesktopIpcLiveSyncEnabled,
+    desktopIpcSnapshotDebounceMs: parseIntegerEnv(
+      readFirstDefinedEnv(["REMODEX_DESKTOP_IPC_SNAPSHOT_DEBOUNCE_MS"], "75", env),
+      75
+    ),
     refreshCommand,
     codexBundleId: readFirstDefinedEnv(["REMODEX_CODEX_BUNDLE_ID"], DEFAULT_BUNDLE_ID, env),
     codexAppPath: DEFAULT_APP_PATH,

--- a/phodex-bridge/src/desktop-ipc-action-follower.js
+++ b/phodex-bridge/src/desktop-ipc-action-follower.js
@@ -13,6 +13,12 @@ const MAX_FRAME_BYTES = 256 * 1024 * 1024;
 const REQUEST_TIMEOUT_MS = 10_000;
 const DESKTOP_IPC_ACTION_SOURCE = "desktop-ipc-action-follower";
 const DESKTOP_RESUME_METHODS = new Set(["thread/read", "thread/resume"]);
+const DESKTOP_FOLLOWER_REQUEST_METHODS = new Set([
+  "turn/start",
+  "turn/steer",
+  "turn/interrupt",
+  "thread/compact/start",
+]);
 const ACTION_METHODS = new Set([
   "item/commandExecution/requestApproval",
   "item/fileChange/requestApproval",
@@ -29,6 +35,10 @@ const REPLY_METHOD_BY_ACTION_METHOD = new Map([
 ]);
 const METHOD_VERSION_BY_NAME = new Map([
   ["initialize", 1],
+  ["thread-follower-start-turn", 1],
+  ["thread-follower-compact-thread", 1],
+  ["thread-follower-steer-turn", 1],
+  ["thread-follower-interrupt-turn", 1],
   ["thread-follower-command-approval-decision", 1],
   ["thread-follower-file-approval-decision", 1],
   ["thread-follower-submit-user-input", 1],
@@ -70,6 +80,14 @@ function createDesktopIpcActionFollower({
     }
 
     const method = readString(message?.method);
+    if (DESKTOP_FOLLOWER_REQUEST_METHODS.has(method)) {
+      const route = desktopFollowerRouteForRequest(message);
+      if (route) {
+        submitDesktopFollowerRequest(route, message);
+        return true;
+      }
+    }
+
     if (!DESKTOP_RESUME_METHODS.has(method)) {
       return false;
     }
@@ -222,6 +240,80 @@ function createDesktopIpcActionFollower({
           error: {
             code: -32000,
             message: "Could not send this action to Codex on the Mac.",
+          },
+        }));
+      });
+  }
+
+  function desktopFollowerRouteForRequest(message) {
+    const requestId = requestIdKey(message?.id);
+    if (!requestId) {
+      return null;
+    }
+    const method = readString(message?.method);
+    const params = message?.params && typeof message.params === "object" && !Array.isArray(message.params)
+      ? message.params
+      : {};
+    const threadId = readThreadId(params);
+    if (!threadId || !rawStatesByThreadId.has(threadId)) {
+      return null;
+    }
+
+    if (method === "turn/start") {
+      return {
+        method: "thread-follower-start-turn",
+        params: {
+          conversationId: threadId,
+          turnStartParams: params,
+        },
+      };
+    }
+    if (method === "turn/steer") {
+      return {
+        method: "thread-follower-steer-turn",
+        params: {
+          conversationId: threadId,
+          input: Array.isArray(params.input) ? params.input : [],
+          expectedTurnId: readString(params.expectedTurnId) || readString(params.expected_turn_id),
+        },
+      };
+    }
+    if (method === "turn/interrupt") {
+      return {
+        method: "thread-follower-interrupt-turn",
+        params: {
+          conversationId: threadId,
+          turnId: readString(params.turnId) || readString(params.turn_id),
+        },
+      };
+    }
+    if (method === "thread/compact/start") {
+      return {
+        method: "thread-follower-compact-thread",
+        params: {
+          conversationId: threadId,
+        },
+      };
+    }
+
+    return null;
+  }
+
+  function submitDesktopFollowerRequest(route, originalMessage) {
+    ipc.sendRequest(route.method, route.params)
+      .then((result) => {
+        sendApplicationResponse(JSON.stringify({
+          id: originalMessage.id,
+          result: result ?? null,
+        }));
+      })
+      .catch((error) => {
+        console.warn(`${logPrefix} desktop follower request failed: ${error.message}`);
+        sendApplicationResponse(JSON.stringify({
+          id: originalMessage.id,
+          error: {
+            code: -32000,
+            message: "Could not continue this Codex Desktop-owned thread from the phone.",
           },
         }));
       });

--- a/phodex-bridge/src/desktop-ipc-live-owner.js
+++ b/phodex-bridge/src/desktop-ipc-live-owner.js
@@ -1,0 +1,2039 @@
+// FILE: desktop-ipc-live-owner.js
+// Purpose: Exposes bridge-owned Codex app-server streams to Codex Desktop/VSCode over the local IPC bus.
+// Layer: CLI helper
+// Exports: createDesktopIpcLiveOwner, buildConversationStateFromThread, applyAppServerMessageToConversationState
+// Depends on: crypto, net, os, path
+
+const { randomUUID } = require("crypto");
+const fs = require("fs");
+const net = require("net");
+const os = require("os");
+const path = require("path");
+
+const FRAME_HEADER_BYTES = 4;
+const MAX_FRAME_BYTES = 256 * 1024 * 1024;
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+const DEFAULT_RECONNECT_MS = 1_500;
+const DEFAULT_SNAPSHOT_DEBOUNCE_MS = 75;
+const DEFAULT_MAX_PATCH_COUNT = 2_000;
+const DEFAULT_MAX_PATCH_BYTES = 512 * 1024;
+const DEFAULT_DISCOVERY_TIMEOUT_MS = 1_000;
+const THREAD_STREAM_STATE_CHANGED = "thread-stream-state-changed";
+const CLIENT_STATUS_CHANGED = "client-status-changed";
+const LOCAL_HOST_ID = "local";
+
+const METHOD_VERSION_BY_NAME = new Map([
+  ["initialize", 1],
+  [CLIENT_STATUS_CHANGED, 1],
+  [THREAD_STREAM_STATE_CHANGED, 6],
+  ["thread-follower-start-turn", 1],
+  ["thread-follower-compact-thread", 1],
+  ["thread-follower-steer-turn", 1],
+  ["thread-follower-interrupt-turn", 1],
+  ["thread-follower-set-model-and-reasoning", 1],
+  ["thread-follower-set-collaboration-mode", 1],
+  ["thread-follower-edit-last-user-turn", 1],
+  ["thread-follower-command-approval-decision", 1],
+  ["thread-follower-file-approval-decision", 1],
+  ["thread-follower-permissions-request-approval-response", 1],
+  ["thread-follower-submit-user-input", 1],
+  ["thread-follower-submit-mcp-server-elicitation-response", 1],
+  ["thread-follower-set-queued-follow-ups-state", 1],
+  ["thread-queued-followups-changed", 1],
+]);
+
+const SUPPORTED_FOLLOWER_REQUEST_METHODS = new Set([
+  "thread-follower-start-turn",
+  "thread-follower-compact-thread",
+  "thread-follower-steer-turn",
+  "thread-follower-interrupt-turn",
+  "thread-follower-set-model-and-reasoning",
+  "thread-follower-set-collaboration-mode",
+  "thread-follower-command-approval-decision",
+  "thread-follower-file-approval-decision",
+  "thread-follower-permissions-request-approval-response",
+  "thread-follower-submit-user-input",
+  "thread-follower-submit-mcp-server-elicitation-response",
+  "thread-follower-set-queued-follow-ups-state",
+]);
+
+const OWNER_INBOUND_METHODS = new Set([
+  "thread/start",
+  "turn/start",
+  "turn/steer",
+  "turn/interrupt",
+  "thread/compact/start",
+  "thread/archive",
+  "thread/unsubscribe",
+]);
+
+const THREAD_READ_METHODS = new Set(["thread/read", "thread/resume"]);
+
+const REQUEST_METHODS_WITH_THREAD = new Set([
+  "item/commandExecution/requestApproval",
+  "item/fileChange/requestApproval",
+  "item/fileRead/requestApproval",
+  "item/permissions/requestApproval",
+  "item/tool/requestUserInput",
+  "mcpServer/elicitation/request",
+  "item/tool/call",
+]);
+
+const ALLOWED_TURN_START_PARAM_KEYS = new Set([
+  "threadId",
+  "input",
+  "cwd",
+  "approvalPolicy",
+  "approvalsReviewer",
+  "sandboxPolicy",
+  "model",
+  "serviceTier",
+  "effort",
+  "summary",
+  "personality",
+  "outputSchema",
+  "collaborationMode",
+]);
+
+function createDesktopIpcLiveOwner({
+  enabled = true,
+  hostId = LOCAL_HOST_ID,
+  sendCodexRequest,
+  sendRawCodexMessage,
+  socketPath = resolveDefaultIpcSocketPath(),
+  snapshotDebounceMs = DEFAULT_SNAPSHOT_DEBOUNCE_MS,
+  maxPatchCount = DEFAULT_MAX_PATCH_COUNT,
+  maxPatchBytes = DEFAULT_MAX_PATCH_BYTES,
+  requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+  reconnectMs = DEFAULT_RECONNECT_MS,
+  netModule = net,
+  now = () => Date.now(),
+  logPrefix = "[remodex]",
+} = {}) {
+  if (!enabled || typeof sendCodexRequest !== "function" || typeof sendRawCodexMessage !== "function") {
+    return createDisabledDesktopIpcLiveOwner();
+  }
+
+  const conversations = new Map();
+  const ownedThreadIds = new Set();
+  const pendingThreadStartRequestIds = new Set();
+  const pendingThreadReadRequestIds = new Set();
+  const cachedThreadsByThreadId = new Map();
+  const lastBroadcastStatesByThreadId = new Map();
+  const dirtyThreadIds = new Set();
+  let snapshotTimer = null;
+
+  const ipc = createDesktopOwnerIpcClient({
+    socketPath,
+    netModule,
+    now,
+    requestTimeoutMs,
+    reconnectMs,
+    logPrefix,
+    onConnected() {
+      broadcastAllOwnedSnapshots();
+    },
+    onBroadcast(envelope) {
+      handlePeerBroadcast(envelope);
+    },
+    canHandleRequest(envelope) {
+      return canHandleFollowerRequest(envelope);
+    },
+    handleRequest(envelope) {
+      return handleFollowerRequest(envelope);
+    },
+  });
+
+  function observeInbound(rawMessage) {
+    const message = safeParseJSON(rawMessage);
+    const method = readString(message?.method);
+    if (THREAD_READ_METHODS.has(method)) {
+      if (message?.id != null) {
+        pendingThreadReadRequestIds.add(String(message.id));
+      }
+      return;
+    }
+
+    if (!method || !OWNER_INBOUND_METHODS.has(method)) {
+      return;
+    }
+
+    if (method === "thread/start") {
+      if (message?.id != null) {
+        pendingThreadStartRequestIds.add(String(message.id));
+      }
+      ipc.ensureConnected();
+      return;
+    }
+
+    const threadId = readThreadIdFromParams(message?.params);
+    if (!threadId) {
+      return;
+    }
+
+    if (method === "thread/archive" || method === "thread/unsubscribe") {
+      removeOwnedThread(threadId);
+      return;
+    }
+
+    markOwnedThread(threadId);
+    seedOwnedConversation(threadId, {
+      cwd: readString(message?.params?.cwd),
+    });
+    scheduleSnapshot(threadId);
+  }
+
+  function observeOutbound(rawMessage) {
+    const message = safeParseJSON(rawMessage);
+    if (!message || typeof message !== "object") {
+      return;
+    }
+
+    const responseId = message.id == null ? "" : String(message.id);
+    if (responseId && pendingThreadReadRequestIds.has(responseId)) {
+      pendingThreadReadRequestIds.delete(responseId);
+      const thread = readThreadFromResponse(message);
+      if (thread?.id) {
+        cachedThreadsByThreadId.set(thread.id, cloneJSON(thread));
+        if (ownedThreadIds.has(thread.id)) {
+          upsertConversationFromThread(thread);
+          scheduleSnapshot(thread.id);
+        }
+      }
+    }
+
+    if (responseId && pendingThreadStartRequestIds.has(responseId)) {
+      pendingThreadStartRequestIds.delete(responseId);
+      const thread = readThreadFromResponse(message);
+      if (thread?.id) {
+        markOwnedThread(thread.id);
+        upsertConversationFromThread(thread);
+        scheduleSnapshot(thread.id);
+      }
+    }
+
+    const update = applyAppServerMessageToConversationState({
+      conversations,
+      message,
+      hostId,
+      now,
+      shouldOwnThread(threadId) {
+        return ownedThreadIds.has(threadId);
+      },
+      markOwnedThread,
+    });
+
+    if (update?.threadId && update.changed) {
+      scheduleSnapshot(update.threadId);
+    }
+  }
+
+  function stopAll() {
+    if (snapshotTimer) {
+      clearTimeout(snapshotTimer);
+      snapshotTimer = null;
+    }
+    dirtyThreadIds.clear();
+    pendingThreadStartRequestIds.clear();
+    pendingThreadReadRequestIds.clear();
+    cachedThreadsByThreadId.clear();
+    lastBroadcastStatesByThreadId.clear();
+    ownedThreadIds.clear();
+    conversations.clear();
+    ipc.close();
+  }
+
+  function markOwnedThread(threadId) {
+    const normalizedThreadId = readString(threadId);
+    if (!normalizedThreadId) {
+      return;
+    }
+    ownedThreadIds.add(normalizedThreadId);
+    ipc.ensureConnected();
+  }
+
+  function removeOwnedThread(threadId) {
+    const normalizedThreadId = readString(threadId);
+    if (!normalizedThreadId) {
+      return;
+    }
+    ownedThreadIds.delete(normalizedThreadId);
+    conversations.delete(normalizedThreadId);
+    cachedThreadsByThreadId.delete(normalizedThreadId);
+    lastBroadcastStatesByThreadId.delete(normalizedThreadId);
+    dirtyThreadIds.delete(normalizedThreadId);
+  }
+
+  function upsertConversationFromThread(thread) {
+    const threadId = readString(thread?.id);
+    if (!threadId) {
+      return null;
+    }
+    const previous = conversations.get(threadId) || null;
+    const next = buildConversationStateFromThread(thread, {
+      previous,
+      hostId,
+      now,
+    });
+    conversations.set(threadId, next);
+    return next;
+  }
+
+  function ensureConversation(threadId, seed = {}) {
+    const normalizedThreadId = readString(threadId);
+    if (!normalizedThreadId) {
+      return null;
+    }
+    let conversation = conversations.get(normalizedThreadId);
+    if (!conversation) {
+      conversation = createEmptyConversationState(normalizedThreadId, {
+        hostId,
+        now,
+        cwd: seed.cwd,
+      });
+      conversations.set(normalizedThreadId, conversation);
+    }
+    return conversation;
+  }
+
+  function seedOwnedConversation(threadId, seed = {}) {
+    const normalizedThreadId = readString(threadId);
+    const cachedThread = normalizedThreadId ? cachedThreadsByThreadId.get(normalizedThreadId) : null;
+    if (cachedThread) {
+      return upsertConversationFromThread(cachedThread);
+    }
+    return ensureConversation(normalizedThreadId, seed);
+  }
+
+  function scheduleSnapshot(threadId) {
+    const normalizedThreadId = readString(threadId);
+    if (!normalizedThreadId || !ownedThreadIds.has(normalizedThreadId)) {
+      return;
+    }
+    dirtyThreadIds.add(normalizedThreadId);
+    ipc.ensureConnected();
+    if (snapshotTimer) {
+      return;
+    }
+    snapshotTimer = setTimeout(() => {
+      snapshotTimer = null;
+      flushSnapshots();
+    }, Math.max(0, snapshotDebounceMs));
+    snapshotTimer.unref?.();
+  }
+
+  function flushSnapshots() {
+    const pendingThreadIds = Array.from(dirtyThreadIds);
+    dirtyThreadIds.clear();
+    for (const threadId of pendingThreadIds) {
+      broadcastConversationState(threadId);
+    }
+  }
+
+  function broadcastAllOwnedSnapshots() {
+    for (const threadId of ownedThreadIds) {
+      broadcastConversationState(threadId, { forceSnapshot: true });
+    }
+  }
+
+  function broadcastConversationState(threadId, { forceSnapshot = false } = {}) {
+    const conversationState = conversations.get(threadId);
+    if (!conversationState || !ownedThreadIds.has(threadId)) {
+      return;
+    }
+    const currentState = cloneJSON(conversationState);
+    const previousState = lastBroadcastStatesByThreadId.get(threadId) || null;
+    if (!forceSnapshot && previousState) {
+      const patches = buildConversationStatePatches(previousState, currentState, {
+        maxPatchCount,
+        maxPatchBytes,
+      });
+      if (patches && patches.length === 0) {
+        return;
+      }
+      if (patches && ipc.sendBroadcast(THREAD_STREAM_STATE_CHANGED, {
+        hostId,
+        conversationId: threadId,
+        change: {
+          type: "patches",
+          patches,
+        },
+      })) {
+        lastBroadcastStatesByThreadId.set(threadId, currentState);
+        return;
+      }
+    }
+
+    if (ipc.sendBroadcast(THREAD_STREAM_STATE_CHANGED, {
+      hostId,
+      conversationId: threadId,
+      change: {
+        type: "snapshot",
+        conversationState: currentState,
+      },
+    })) {
+      lastBroadcastStatesByThreadId.set(threadId, currentState);
+    }
+  }
+
+  function handlePeerBroadcast(envelope) {
+    if (envelope?.method === CLIENT_STATUS_CHANGED) {
+      broadcastAllOwnedSnapshots();
+      return;
+    }
+    if (envelope?.method !== THREAD_STREAM_STATE_CHANGED) {
+      return;
+    }
+    const params = envelope.params || {};
+    const threadId = readString(params.conversationId) || readString(params.conversation_id);
+    if (!threadId || !ownedThreadIds.has(threadId)) {
+      return;
+    }
+    if (envelope.sourceClientId && envelope.sourceClientId === ipc.clientId) {
+      return;
+    }
+
+    // Another Codex frontend is actively owning this stream. Drop bridge ownership
+    // so two owners do not fight over the same Desktop conversation state.
+    ownedThreadIds.delete(threadId);
+    dirtyThreadIds.delete(threadId);
+    lastBroadcastStatesByThreadId.delete(threadId);
+  }
+
+  function canHandleFollowerRequest(envelope) {
+    const method = readString(envelope?.request?.method || envelope?.method);
+    const params = envelope?.request?.params || envelope?.params || {};
+    if (!SUPPORTED_FOLLOWER_REQUEST_METHODS.has(method)) {
+      return false;
+    }
+    const threadId = readConversationIdFromFollowerParams(params);
+    return Boolean(threadId && ownedThreadIds.has(threadId));
+  }
+
+  async function handleFollowerRequest(envelope) {
+    const method = readString(envelope?.method);
+    const params = envelope?.params && typeof envelope.params === "object" ? envelope.params : {};
+    const conversationId = readConversationIdFromFollowerParams(params);
+    if (!conversationId || !ownedThreadIds.has(conversationId)) {
+      throw new Error("conversation-not-owned");
+    }
+
+    switch (method) {
+      case "thread-follower-start-turn":
+        return await handleFollowerStartTurn(conversationId, params);
+      case "thread-follower-compact-thread":
+        return await sendCodexRequest("thread/compact/start", { threadId: conversationId });
+      case "thread-follower-steer-turn":
+        return await handleFollowerSteerTurn(conversationId, params);
+      case "thread-follower-interrupt-turn":
+        return await handleFollowerInterruptTurn(conversationId, params);
+      case "thread-follower-command-approval-decision":
+        return sendServerRequestResponse(params.requestId, { decision: params.decision });
+      case "thread-follower-file-approval-decision":
+        return sendServerRequestResponse(params.requestId, { decision: params.decision });
+      case "thread-follower-permissions-request-approval-response":
+        return sendServerRequestResponse(params.requestId, params.response);
+      case "thread-follower-submit-user-input":
+        return sendServerRequestResponse(params.requestId, params.response);
+      case "thread-follower-submit-mcp-server-elicitation-response":
+        return sendServerRequestResponse(params.requestId, params.response);
+      case "thread-follower-set-model-and-reasoning":
+        return applyFollowerModelAndReasoning(conversationId, params);
+      case "thread-follower-set-collaboration-mode":
+        return applyFollowerCollaborationMode(conversationId, params);
+      case "thread-follower-set-queued-follow-ups-state":
+        return { ok: true };
+      case "thread-follower-edit-last-user-turn":
+        throw new Error("thread-follower-edit-last-user-turn is not supported by Remodex yet.");
+      default:
+        throw new Error(`Unsupported follower request: ${method}`);
+    }
+  }
+
+  async function handleFollowerStartTurn(conversationId, params) {
+    const rawTurnStartParams = params.turnStartParams
+      || params.turn_start_params
+      || params.turnStart
+      || params;
+    const codexParams = sanitizeTurnStartParams({
+      ...rawTurnStartParams,
+      threadId: conversationId,
+    });
+    markOwnedThread(conversationId);
+    return await sendCodexRequest("turn/start", codexParams);
+  }
+
+  async function handleFollowerSteerTurn(conversationId, params) {
+    const rawSteerParams = params.turnSteerParams
+      || params.turn_steer_params
+      || params;
+    const expectedTurnId = readString(rawSteerParams.expectedTurnId)
+      || readString(rawSteerParams.expected_turn_id)
+      || activeTurnIdForConversation(conversationId);
+    if (!expectedTurnId) {
+      throw new Error("Missing expectedTurnId for follower steer request.");
+    }
+    return await sendCodexRequest("turn/steer", {
+      threadId: conversationId,
+      input: Array.isArray(rawSteerParams.input) ? rawSteerParams.input : [],
+      expectedTurnId,
+    });
+  }
+
+  async function handleFollowerInterruptTurn(conversationId, params) {
+    const turnId = readString(params.turnId)
+      || readString(params.turn_id)
+      || activeTurnIdForConversation(conversationId);
+    if (!turnId) {
+      throw new Error("Missing turnId for follower interrupt request.");
+    }
+    return await sendCodexRequest("turn/interrupt", {
+      threadId: conversationId,
+      turnId,
+    });
+  }
+
+  function sendServerRequestResponse(requestId, result) {
+    const normalizedRequestId = requestIdKey(requestId);
+    if (!normalizedRequestId) {
+      throw new Error("Missing requestId for follower server response.");
+    }
+    sendRawCodexMessage(JSON.stringify({
+      id: requestId,
+      result: result || {},
+    }));
+    return { ok: true };
+  }
+
+  function applyFollowerModelAndReasoning(conversationId, params) {
+    const conversation = conversations.get(conversationId);
+    if (conversation) {
+      if (Object.prototype.hasOwnProperty.call(params, "model")) {
+        conversation.latestModel = params.model || "";
+      }
+      if (Object.prototype.hasOwnProperty.call(params, "reasoningEffort")) {
+        conversation.latestReasoningEffort = params.reasoningEffort || null;
+      }
+      scheduleSnapshot(conversationId);
+    }
+    return { ok: true };
+  }
+
+  function applyFollowerCollaborationMode(conversationId, params) {
+    const conversation = conversations.get(conversationId);
+    if (conversation && params.collaborationMode) {
+      conversation.latestCollaborationMode = params.collaborationMode;
+      scheduleSnapshot(conversationId);
+    }
+    return { ok: true };
+  }
+
+  function activeTurnIdForConversation(conversationId) {
+    const turns = conversations.get(conversationId)?.turns || [];
+    for (let index = turns.length - 1; index >= 0; index -= 1) {
+      const turn = turns[index];
+      const status = normalizeToken(turn?.status);
+      const turnId = readString(turn?.turnId) || readString(turn?.id);
+      if (turnId && (!status || status === "inprogress" || status === "running" || status === "active")) {
+        return turnId;
+      }
+    }
+    const latestTurn = turns[turns.length - 1];
+    return readString(latestTurn?.turnId) || readString(latestTurn?.id);
+  }
+
+  return {
+    observeInbound,
+    observeOutbound,
+    stopAll,
+    _debugSnapshot(threadId) {
+      return cloneJSON(conversations.get(threadId) || null);
+    },
+  };
+}
+
+function createDisabledDesktopIpcLiveOwner() {
+  return {
+    observeInbound() {},
+    observeOutbound() {},
+    stopAll() {},
+  };
+}
+
+function applyAppServerMessageToConversationState({
+  conversations,
+  message,
+  hostId = LOCAL_HOST_ID,
+  now = () => Date.now(),
+  shouldOwnThread = () => false,
+  markOwnedThread = () => {},
+} = {}) {
+  const method = readString(message?.method);
+  if (!method) {
+    return null;
+  }
+
+  if (REQUEST_METHODS_WITH_THREAD.has(method) && message.id != null) {
+    const threadId = readThreadIdFromParams(message.params);
+    if (!threadId || !shouldOwnThread(threadId)) {
+      return null;
+    }
+    const conversation = ensureConversationInMap(conversations, threadId, { hostId, now });
+    upsertRequest(conversation, {
+      id: message.id,
+      method,
+      params: cloneJSON(message.params || {}),
+    });
+    conversation.hasUnreadTurn = true;
+    conversation.updatedAt = now();
+    return { threadId, changed: true };
+  }
+
+  switch (method) {
+    case "thread/started": {
+      const thread = message.params?.thread;
+      const threadId = readString(thread?.id);
+      if (!threadId) {
+        return null;
+      }
+      markOwnedThread(threadId);
+      const previous = conversations.get(threadId) || null;
+      conversations.set(threadId, buildConversationStateFromThread(thread, {
+        previous,
+        hostId,
+        now,
+      }));
+      return { threadId, changed: true };
+    }
+    case "thread/name/updated": {
+      const threadId = readThreadIdFromParams(message.params);
+      if (!threadId || !shouldOwnThread(threadId)) {
+        return null;
+      }
+      const conversation = ensureConversationInMap(conversations, threadId, { hostId, now });
+      conversation.title = readString(message.params?.threadName)
+        || readString(message.params?.thread_name)
+        || conversation.title;
+      conversation.updatedAt = now();
+      return { threadId, changed: true };
+    }
+    case "thread/status/changed": {
+      const threadId = readThreadIdFromParams(message.params);
+      if (!threadId || !shouldOwnThread(threadId)) {
+        return null;
+      }
+      const conversation = ensureConversationInMap(conversations, threadId, { hostId, now });
+      conversation.threadRuntimeStatus = cloneJSON(message.params?.status || null);
+      conversation.updatedAt = now();
+      return { threadId, changed: true };
+    }
+    case "thread/tokenUsage/updated": {
+      const threadId = readThreadIdFromParams(message.params);
+      if (!threadId || !shouldOwnThread(threadId)) {
+        return null;
+      }
+      const conversation = ensureConversationInMap(conversations, threadId, { hostId, now });
+      conversation.latestTokenUsageInfo = cloneJSON(
+        message.params?.tokenUsage || message.params?.usage || null
+      );
+      conversation.updatedAt = now();
+      return { threadId, changed: true };
+    }
+    case "turn/started":
+    case "turn/completed": {
+      const threadId = readThreadIdFromParams(message.params);
+      const turn = message.params?.turn;
+      if (!threadId || !shouldOwnThread(threadId) || !turn) {
+        return null;
+      }
+      const conversation = ensureConversationInMap(conversations, threadId, { hostId, now });
+      upsertTurn(conversation, turn, { now });
+      conversation.updatedAt = now();
+      return { threadId, changed: true };
+    }
+    case "turn/diff/updated": {
+      const threadId = readThreadIdFromParams(message.params);
+      if (!threadId || !shouldOwnThread(threadId)) {
+        return null;
+      }
+      const conversation = ensureConversationInMap(conversations, threadId, { hostId, now });
+      const turn = ensureTurn(conversation, message.params?.turnId || message.params?.turn_id, { now });
+      if (turn) {
+        turn.diff = readString(message.params?.diff) || "";
+      }
+      conversation.updatedAt = now();
+      return { threadId, changed: true };
+    }
+    case "turn/plan/updated": {
+      const threadId = readThreadIdFromParams(message.params);
+      if (!threadId || !shouldOwnThread(threadId)) {
+        return null;
+      }
+      const conversation = ensureConversationInMap(conversations, threadId, { hostId, now });
+      const turn = ensureTurn(conversation, message.params?.turnId || message.params?.turn_id, { now });
+      if (turn) {
+        upsertItem(turn, {
+          id: `todo-list-${message.params?.turnId || now()}`,
+          type: "todo-list",
+          explanation: message.params?.explanation ?? null,
+          plan: Array.isArray(message.params?.plan) ? cloneJSON(message.params.plan) : [],
+        });
+      }
+      conversation.updatedAt = now();
+      return { threadId, changed: true };
+    }
+    case "item/started":
+    case "item/completed": {
+      const threadId = readThreadIdFromParams(message.params);
+      if (!threadId || !shouldOwnThread(threadId)) {
+        return null;
+      }
+      const conversation = ensureConversationInMap(conversations, threadId, { hostId, now });
+      const turn = ensureTurn(conversation, message.params?.turnId || message.params?.turn_id, { now });
+      if (turn && message.params?.item) {
+        upsertItem(turn, cloneJSON(message.params.item));
+        if (message.params.item.type === "agentMessage" && method === "item/started") {
+          turn.finalAssistantStartedAtMs = turn.finalAssistantStartedAtMs || now();
+        }
+        if (message.params.item.type && message.params.item.type !== "userMessage") {
+          turn.firstTurnWorkItemStartedAtMs = turn.firstTurnWorkItemStartedAtMs || now();
+        }
+      }
+      conversation.updatedAt = now();
+      return { threadId, changed: true };
+    }
+    case "item/agentMessage/delta":
+    case "item/plan/delta":
+    case "item/reasoning/summaryTextDelta":
+    case "item/reasoning/textDelta":
+    case "item/commandExecution/outputDelta":
+    case "command/exec/outputDelta": {
+      const threadId = readThreadIdFromParams(message.params);
+      if (!threadId || !shouldOwnThread(threadId)) {
+        return null;
+      }
+      const conversation = ensureConversationInMap(conversations, threadId, { hostId, now });
+      applyDeltaNotification(conversation, method, message.params || {}, { now });
+      conversation.updatedAt = now();
+      return { threadId, changed: true };
+    }
+    case "item/fileChange/patchUpdated": {
+      const threadId = readThreadIdFromParams(message.params);
+      if (!threadId || !shouldOwnThread(threadId)) {
+        return null;
+      }
+      const conversation = ensureConversationInMap(conversations, threadId, { hostId, now });
+      const turn = ensureTurn(conversation, message.params?.turnId || message.params?.turn_id, { now });
+      if (turn) {
+        upsertItem(turn, {
+          type: "fileChange",
+          id: readString(message.params?.itemId) || `file-change-${now()}`,
+          changes: Array.isArray(message.params?.changes) ? cloneJSON(message.params.changes) : [],
+          status: "inProgress",
+        });
+      }
+      conversation.updatedAt = now();
+      return { threadId, changed: true };
+    }
+    case "serverRequest/resolved": {
+      const threadId = readThreadIdFromParams(message.params);
+      if (!threadId || !shouldOwnThread(threadId)) {
+        return null;
+      }
+      const conversation = ensureConversationInMap(conversations, threadId, { hostId, now });
+      const requestId = requestIdKey(message.params?.requestId || message.params?.request_id);
+      conversation.requests = conversation.requests.filter((request) => requestIdKey(request.id) !== requestId);
+      conversation.updatedAt = now();
+      return { threadId, changed: true };
+    }
+    case "error": {
+      const threadId = readThreadIdFromParams(message.params);
+      if (!threadId || !shouldOwnThread(threadId)) {
+        return null;
+      }
+      const conversation = ensureConversationInMap(conversations, threadId, { hostId, now });
+      const turn = ensureTurn(conversation, message.params?.turnId || message.params?.turn_id, { now });
+      if (turn) {
+        turn.items.push({
+          id: `error-${now()}`,
+          type: "error",
+          message: readString(message.params?.error?.message) || "Codex error",
+          willRetry: Boolean(message.params?.willRetry),
+          errorInfo: message.params?.error?.codexErrorInfo || null,
+          additionalDetails: message.params?.error?.additionalDetails || null,
+        });
+        turn.error = cloneJSON(message.params?.error || null);
+      }
+      conversation.updatedAt = now();
+      return { threadId, changed: true };
+    }
+    default:
+      return null;
+  }
+}
+
+function buildConversationStateFromThread(thread, {
+  previous = null,
+  hostId = LOCAL_HOST_ID,
+  now = () => Date.now(),
+} = {}) {
+  const threadId = readString(thread?.id);
+  const createdAtMs = timestampSecondsToMs(thread?.createdAt) || previous?.createdAt || now();
+  const updatedAtMs = timestampSecondsToMs(thread?.updatedAt) || now();
+  const cwd = readString(thread?.cwd) || previous?.cwd || "";
+  const latestModel = readString(thread?.model) || readString(thread?.modelProvider) || previous?.latestModel || "";
+  const turns = Array.isArray(thread?.turns) && thread.turns.length > 0
+    ? thread.turns.map((turn) => buildConversationTurn(turn, {
+      threadId,
+      cwd,
+      now,
+      previousTurn: previous?.turns?.find((candidate) => (
+        readString(candidate?.turnId) || readString(candidate?.id)
+      ) === readString(turn?.id)),
+    }))
+    : cloneJSON(previous?.turns || []);
+
+  return {
+    id: threadId,
+    hostId,
+    turns,
+    requests: cloneJSON(previous?.requests || []),
+    createdAt: createdAtMs,
+    updatedAt: updatedAtMs,
+    title: readString(thread?.name) || previous?.title || null,
+    latestModel,
+    latestReasoningEffort: previous?.latestReasoningEffort || null,
+    previousTurnModel: previous?.previousTurnModel || null,
+    latestCollaborationMode: previous?.latestCollaborationMode || {
+      mode: "default",
+      settings: {
+        reasoning_effort: null,
+        model: latestModel,
+        developer_instructions: null,
+      },
+    },
+    hasUnreadTurn: Boolean(previous?.hasUnreadTurn),
+    unreadMessageCount: Number.isFinite(previous?.unreadMessageCount) ? previous.unreadMessageCount : 0,
+    threadGoal: previous?.threadGoal || null,
+    completedThreadGoal: previous?.completedThreadGoal || null,
+    threadRuntimeStatus: cloneJSON(thread?.status || previous?.threadRuntimeStatus || null),
+    rolloutPath: readString(thread?.path) || previous?.rolloutPath || "",
+    cwd,
+    gitInfo: cloneJSON(thread?.gitInfo || previous?.gitInfo || null),
+    resumeState: "resumed",
+    latestTokenUsageInfo: cloneJSON(previous?.latestTokenUsageInfo || null),
+    workspaceKind: previous?.workspaceKind || "project",
+    workspaceBrowserRoot: previous?.workspaceBrowserRoot || null,
+    projectlessOutputDirectory: previous?.projectlessOutputDirectory || null,
+    currentPermissions: cloneJSON(previous?.currentPermissions || null),
+  };
+}
+
+function createEmptyConversationState(threadId, {
+  hostId = LOCAL_HOST_ID,
+  now = () => Date.now(),
+  cwd = "",
+} = {}) {
+  const timestamp = now();
+  return {
+    id: threadId,
+    hostId,
+    turns: [],
+    requests: [],
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    title: null,
+    latestModel: "",
+    latestReasoningEffort: null,
+    previousTurnModel: null,
+    latestCollaborationMode: {
+      mode: "default",
+      settings: {
+        reasoning_effort: null,
+        model: "",
+        developer_instructions: null,
+      },
+    },
+    hasUnreadTurn: false,
+    unreadMessageCount: 0,
+    threadGoal: null,
+    completedThreadGoal: null,
+    threadRuntimeStatus: null,
+    rolloutPath: "",
+    cwd: readString(cwd) || "",
+    gitInfo: null,
+    resumeState: "resumed",
+    latestTokenUsageInfo: null,
+    workspaceKind: "project",
+    workspaceBrowserRoot: null,
+    projectlessOutputDirectory: null,
+    currentPermissions: null,
+  };
+}
+
+function buildConversationTurn(turn, {
+  threadId = "",
+  cwd = "",
+  previousTurn = null,
+  now = () => Date.now(),
+} = {}) {
+  const turnId = readString(turn?.id) || readString(turn?.turnId) || readString(turn?.turn_id);
+  const params = cloneJSON(previousTurn?.params || {
+    threadId,
+    input: [],
+    cwd: cwd || null,
+    approvalPolicy: null,
+    approvalsReviewer: null,
+    sandboxPolicy: null,
+    model: null,
+    serviceTier: null,
+    effort: null,
+    summary: "none",
+    personality: null,
+    outputSchema: null,
+    collaborationMode: null,
+    attachments: [],
+  });
+  return {
+    id: turnId,
+    turnId,
+    params,
+    turnStartedAtMs: timestampSecondsToMs(turn?.startedAt) || previousTurn?.turnStartedAtMs || now(),
+    durationMs: turn?.durationMs ?? previousTurn?.durationMs ?? null,
+    firstTurnWorkItemStartedAtMs: previousTurn?.firstTurnWorkItemStartedAtMs || null,
+    finalAssistantStartedAtMs: previousTurn?.finalAssistantStartedAtMs || null,
+    status: turn?.status || previousTurn?.status || "inProgress",
+    error: cloneJSON(turn?.error || previousTurn?.error || null),
+    diff: previousTurn?.diff || null,
+    hookRuns: cloneJSON(previousTurn?.hookRuns || []),
+    commandExecutionStartedAtMsById: cloneJSON(previousTurn?.commandExecutionStartedAtMsById || {}),
+    items: Array.isArray(turn?.items) && turn.items.length > 0
+      ? cloneJSON(turn.items)
+      : cloneJSON(previousTurn?.items || []),
+  };
+}
+
+function ensureConversationInMap(conversations, threadId, options = {}) {
+  let conversation = conversations.get(threadId);
+  if (!conversation) {
+    conversation = createEmptyConversationState(threadId, options);
+    conversations.set(threadId, conversation);
+  }
+  return conversation;
+}
+
+function upsertTurn(conversation, turn, { now = () => Date.now() } = {}) {
+  const turnId = readString(turn?.id) || readString(turn?.turnId) || readString(turn?.turn_id);
+  if (!turnId) {
+    return null;
+  }
+  const index = conversation.turns.findIndex((candidate) => (
+    readString(candidate?.turnId) || readString(candidate?.id)
+  ) === turnId);
+  const previousTurn = index >= 0 ? conversation.turns[index] : null;
+  const nextTurn = buildConversationTurn(turn, {
+    threadId: conversation.id,
+    cwd: conversation.cwd,
+    previousTurn,
+    now,
+  });
+  if (index >= 0) {
+    conversation.turns[index] = nextTurn;
+  } else {
+    conversation.turns.push(nextTurn);
+  }
+  return nextTurn;
+}
+
+function ensureTurn(conversation, turnId, { now = () => Date.now() } = {}) {
+  const normalizedTurnId = readString(turnId);
+  if (!normalizedTurnId) {
+    return conversation.turns[conversation.turns.length - 1] || null;
+  }
+  let turn = conversation.turns.find((candidate) => (
+    readString(candidate?.turnId) || readString(candidate?.id)
+  ) === normalizedTurnId);
+  if (!turn) {
+    turn = buildConversationTurn({
+      id: normalizedTurnId,
+      status: "inProgress",
+      items: [],
+      startedAt: null,
+      completedAt: null,
+      durationMs: null,
+      error: null,
+    }, {
+      threadId: conversation.id,
+      cwd: conversation.cwd,
+      now,
+    });
+    conversation.turns.push(turn);
+  }
+  return turn;
+}
+
+function upsertItem(turn, item) {
+  const itemId = readString(item?.id);
+  if (!itemId) {
+    return;
+  }
+  const index = turn.items.findIndex((candidate) => readString(candidate?.id) === itemId);
+  if (index >= 0) {
+    turn.items[index] = {
+      ...turn.items[index],
+      ...cloneJSON(item),
+    };
+    return;
+  }
+  turn.items.push(cloneJSON(item));
+}
+
+function upsertRequest(conversation, request) {
+  const requestId = requestIdKey(request?.id);
+  if (!requestId) {
+    return;
+  }
+  const index = conversation.requests.findIndex((candidate) => requestIdKey(candidate?.id) === requestId);
+  const nextRequest = cloneJSON({
+    id: request.id,
+    method: request.method,
+    params: request.params || {},
+  });
+  if (index >= 0) {
+    conversation.requests[index] = nextRequest;
+  } else {
+    conversation.requests.push(nextRequest);
+  }
+}
+
+function applyDeltaNotification(conversation, method, params, { now = () => Date.now() } = {}) {
+  const turn = ensureTurn(conversation, params.turnId || params.turn_id, { now });
+  if (!turn) {
+    return;
+  }
+  const itemId = readString(params.itemId) || readString(params.item_id);
+  if (!itemId) {
+    return;
+  }
+  const delta = typeof params.delta === "string" ? params.delta : "";
+  if (!delta) {
+    return;
+  }
+
+  if (method === "item/agentMessage/delta") {
+    const item = ensureItemOfType(turn, itemId, () => ({
+      type: "agentMessage",
+      id: itemId,
+      text: "",
+      phase: null,
+      memoryCitation: null,
+    }));
+    item.text = `${item.text || ""}${delta}`;
+    turn.finalAssistantStartedAtMs = turn.finalAssistantStartedAtMs || now();
+    return;
+  }
+
+  if (method === "item/plan/delta") {
+    const item = ensureItemOfType(turn, itemId, () => ({
+      type: "plan",
+      id: itemId,
+      text: "",
+    }));
+    item.text = `${item.text || ""}${delta}`;
+    return;
+  }
+
+  if (method === "item/reasoning/summaryTextDelta" || method === "item/reasoning/textDelta") {
+    const item = ensureItemOfType(turn, itemId, () => ({
+      type: "reasoning",
+      id: itemId,
+      summary: [],
+      content: [],
+    }));
+    if (method === "item/reasoning/summaryTextDelta") {
+      const index = Number.isInteger(params.summaryIndex) ? params.summaryIndex : 0;
+      item.summary = growArray(item.summary, index, "");
+      item.summary[index] = `${item.summary[index] || ""}${delta}`;
+    } else {
+      const index = Number.isInteger(params.contentIndex) ? params.contentIndex : 0;
+      item.content = growArray(item.content, index, "");
+      item.content[index] = `${item.content[index] || ""}${delta}`;
+    }
+    return;
+  }
+
+  const item = ensureItemOfType(turn, itemId, () => ({
+    type: "commandExecution",
+    id: itemId,
+    command: "",
+    cwd: conversation.cwd || "/",
+    processId: null,
+    source: "exec",
+    status: "inProgress",
+    commandActions: [],
+    aggregatedOutput: "",
+    exitCode: null,
+    durationMs: null,
+  }));
+  item.aggregatedOutput = `${item.aggregatedOutput || ""}${delta}`;
+}
+
+function ensureItemOfType(turn, itemId, createItem) {
+  let item = turn.items.find((candidate) => readString(candidate?.id) === itemId);
+  if (!item) {
+    item = createItem();
+    turn.items.push(item);
+  }
+  return item;
+}
+
+function growArray(value, index, fillValue) {
+  const next = Array.isArray(value) ? value : [];
+  while (next.length <= index) {
+    next.push(fillValue);
+  }
+  return next;
+}
+
+function buildConversationStatePatches(previousState, currentState, {
+  maxPatchCount = DEFAULT_MAX_PATCH_COUNT,
+  maxPatchBytes = DEFAULT_MAX_PATCH_BYTES,
+} = {}) {
+  if (!previousState || typeof previousState !== "object" || !currentState || typeof currentState !== "object") {
+    return null;
+  }
+  const patches = [];
+  const ok = collectJSONPatches(previousState, currentState, [], patches, maxPatchCount);
+  if (!ok) {
+    return null;
+  }
+  if (patches.length === 0) {
+    return patches;
+  }
+  const patchBytes = Buffer.byteLength(JSON.stringify(patches), "utf8");
+  if (patchBytes > maxPatchBytes) {
+    return null;
+  }
+  return patches;
+}
+
+function collectJSONPatches(previousValue, currentValue, pathParts, patches, maxPatchCount) {
+  if (jsonValuesEqual(previousValue, currentValue)) {
+    return true;
+  }
+  if (patches.length > maxPatchCount) {
+    return false;
+  }
+
+  if (Array.isArray(previousValue) || Array.isArray(currentValue)) {
+    if (!Array.isArray(previousValue) || !Array.isArray(currentValue)) {
+      return pushPatch(patches, maxPatchCount, {
+        op: "replace",
+        path: pathParts,
+        value: cloneJSON(currentValue),
+      });
+    }
+    return collectArrayPatches(previousValue, currentValue, pathParts, patches, maxPatchCount);
+  }
+
+  if (isPlainJSONObject(previousValue) || isPlainJSONObject(currentValue)) {
+    if (!isPlainJSONObject(previousValue) || !isPlainJSONObject(currentValue)) {
+      return pushPatch(patches, maxPatchCount, {
+        op: "replace",
+        path: pathParts,
+        value: cloneJSON(currentValue),
+      });
+    }
+    return collectObjectPatches(previousValue, currentValue, pathParts, patches, maxPatchCount);
+  }
+
+  return pushPatch(patches, maxPatchCount, {
+    op: "replace",
+    path: pathParts,
+    value: cloneJSON(currentValue),
+  });
+}
+
+function collectArrayPatches(previousArray, currentArray, pathParts, patches, maxPatchCount) {
+  const sharedLength = Math.min(previousArray.length, currentArray.length);
+  for (let index = 0; index < sharedLength; index += 1) {
+    if (!collectJSONPatches(previousArray[index], currentArray[index], [...pathParts, index], patches, maxPatchCount)) {
+      return false;
+    }
+  }
+  for (let index = previousArray.length - 1; index >= currentArray.length; index -= 1) {
+    if (!pushPatch(patches, maxPatchCount, {
+      op: "remove",
+      path: [...pathParts, index],
+    })) {
+      return false;
+    }
+  }
+  for (let index = sharedLength; index < currentArray.length; index += 1) {
+    if (!pushPatch(patches, maxPatchCount, {
+      op: "add",
+      path: [...pathParts, index],
+      value: cloneJSON(currentArray[index]),
+    })) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function collectObjectPatches(previousObject, currentObject, pathParts, patches, maxPatchCount) {
+  for (const key of Object.keys(previousObject)) {
+    if (Object.prototype.hasOwnProperty.call(currentObject, key)) {
+      continue;
+    }
+    if (!pushPatch(patches, maxPatchCount, {
+      op: "remove",
+      path: [...pathParts, key],
+    })) {
+      return false;
+    }
+  }
+
+  for (const key of Object.keys(currentObject)) {
+    if (!Object.prototype.hasOwnProperty.call(previousObject, key)) {
+      if (!pushPatch(patches, maxPatchCount, {
+        op: "add",
+        path: [...pathParts, key],
+        value: cloneJSON(currentObject[key]),
+      })) {
+        return false;
+      }
+      continue;
+    }
+    if (!collectJSONPatches(previousObject[key], currentObject[key], [...pathParts, key], patches, maxPatchCount)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function pushPatch(patches, maxPatchCount, patch) {
+  if (patch.path.length === 0) {
+    return false;
+  }
+  patches.push(patch);
+  return patches.length <= maxPatchCount;
+}
+
+function isPlainJSONObject(value) {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function jsonValuesEqual(left, right) {
+  if (left === right) {
+    return true;
+  }
+  if (left == null || right == null) {
+    return left === right;
+  }
+  if (typeof left !== "object" || typeof right !== "object") {
+    return false;
+  }
+  return false;
+}
+
+function createDesktopOwnerIpcClient({
+  socketPath,
+  netModule,
+  now,
+  requestTimeoutMs,
+  reconnectMs,
+  logPrefix,
+  startRouterWhenMissing = true,
+  onConnected,
+  onBroadcast,
+  canHandleRequest,
+  handleRequest,
+}) {
+  let socket = null;
+  let isConnecting = false;
+  let isInitialized = false;
+  let clientId = "";
+  let readBuffer = Buffer.alloc(0);
+  let reconnectTimer = null;
+  let shouldReconnect = false;
+  const localRouter = startRouterWhenMissing
+    ? createDesktopIpcRouterServer({
+      socketPath,
+      netModule,
+      now,
+      requestTimeoutMs,
+      discoveryTimeoutMs: Math.min(requestTimeoutMs, DEFAULT_DISCOVERY_TIMEOUT_MS),
+      logPrefix,
+    })
+    : null;
+  const pendingResponses = new Map();
+
+  function ensureConnected() {
+    shouldReconnect = true;
+    if (socket || isConnecting) {
+      return;
+    }
+    clearReconnectTimer();
+    isConnecting = true;
+    const nextSocket = netModule.createConnection(socketPath);
+    socket = nextSocket;
+
+    nextSocket.on("connect", () => {
+      isConnecting = false;
+      sendRequest("initialize", { clientType: "remodex-bridge" }, { initializing: true })
+        .then((result) => {
+          clientId = readString(result?.clientId) || clientId;
+          isInitialized = true;
+          onConnected?.(clientId);
+        })
+        .catch((error) => {
+          console.warn(`${logPrefix} desktop IPC live owner initialize failed: ${error.message}`);
+          closeSocket();
+        });
+    });
+    nextSocket.on("data", handleData);
+    nextSocket.on("close", () => handleClose(nextSocket));
+    nextSocket.on("error", (error) => {
+      if (error?.code === "ENOENT" || error?.code === "ECONNREFUSED") {
+        startLocalRouterAfterMissingSocket(error.code);
+        return;
+      }
+      if (error?.code !== "ENOENT" && error?.code !== "ECONNREFUSED") {
+        console.warn(`${logPrefix} desktop IPC live owner connection failed: ${error.message}`);
+      }
+    });
+  }
+
+  function startLocalRouterAfterMissingSocket(reasonCode) {
+    if (!localRouter || localRouter.isStarted) {
+      return;
+    }
+    localRouter.start({ removeStaleSocket: reasonCode === "ECONNREFUSED" })
+      .then(() => {
+        if (!shouldReconnect) {
+          return;
+        }
+        closeSocket();
+        isConnecting = false;
+        clearReconnectTimer();
+        ensureConnected();
+      })
+      .catch((error) => {
+        if (error?.code !== "EADDRINUSE") {
+          console.warn(`${logPrefix} desktop IPC router fallback failed: ${error.message}`);
+        }
+      });
+  }
+
+  function sendBroadcast(method, params) {
+    ensureConnected();
+    if (!socket || socket.destroyed || !isInitialized) {
+      return false;
+    }
+    const envelope = {
+      type: "broadcast",
+      method,
+      sourceClientId: clientId,
+      params: params || {},
+      version: METHOD_VERSION_BY_NAME.get(method) || 1,
+    };
+    return writeEnvelope(envelope);
+  }
+
+  function sendRequest(method, params, { initializing = false } = {}) {
+    ensureConnected();
+    if (!socket || socket.destroyed) {
+      return Promise.reject(new Error("Desktop IPC is not connected."));
+    }
+    const requestId = `remodex-owner-${now().toString(36)}-${randomUUID()}`;
+    const envelope = {
+      type: "request",
+      requestId,
+      sourceClientId: initializing ? "initializing-client" : clientId || "remodex-bridge",
+      version: METHOD_VERSION_BY_NAME.get(method) || 1,
+      method,
+      params: params || {},
+    };
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pendingResponses.delete(requestId);
+        reject(new Error(`Desktop IPC request timed out: ${method}`));
+      }, requestTimeoutMs);
+      timeout.unref?.();
+      pendingResponses.set(requestId, {
+        method,
+        resolve,
+        reject,
+        timeout,
+      });
+      if (!writeEnvelope(envelope)) {
+        clearTimeout(timeout);
+        pendingResponses.delete(requestId);
+        reject(new Error("Desktop IPC write failed."));
+      }
+    });
+  }
+
+  function handleData(chunk) {
+    readBuffer = Buffer.concat([readBuffer, chunk]);
+    while (readBuffer.length >= FRAME_HEADER_BYTES) {
+      const frameLength = readBuffer.readUInt32LE(0);
+      if (frameLength > MAX_FRAME_BYTES) {
+        closeSocket();
+        return;
+      }
+      if (readBuffer.length < FRAME_HEADER_BYTES + frameLength) {
+        return;
+      }
+
+      const payload = readBuffer.slice(FRAME_HEADER_BYTES, FRAME_HEADER_BYTES + frameLength).toString("utf8");
+      readBuffer = readBuffer.slice(FRAME_HEADER_BYTES + frameLength);
+      const envelope = safeParseJSON(payload);
+      if (envelope) {
+        dispatchEnvelope(envelope);
+      }
+    }
+  }
+
+  function dispatchEnvelope(envelope) {
+    if (envelope.type === "response") {
+      handleResponse(envelope);
+      return;
+    }
+    if (envelope.type === "broadcast") {
+      onBroadcast?.(envelope);
+      return;
+    }
+    if (envelope.type === "client-discovery-request") {
+      const canHandle = Boolean(canHandleRequest?.(envelope));
+      writeEnvelope({
+        type: "client-discovery-response",
+        requestId: envelope.requestId,
+        response: { canHandle },
+      });
+      return;
+    }
+    if (envelope.type === "request") {
+      handleIncomingRequest(envelope);
+    }
+  }
+
+  function handleResponse(envelope) {
+    const requestId = requestIdKey(envelope.requestId);
+    const waiter = requestId ? pendingResponses.get(requestId) : null;
+    if (!waiter) {
+      return;
+    }
+    pendingResponses.delete(requestId);
+    clearTimeout(waiter.timeout);
+    if (envelope.resultType === "error") {
+      waiter.reject(new Error(envelope.error || `Desktop IPC request failed: ${waiter.method}`));
+      return;
+    }
+    waiter.resolve(envelope.result ?? null);
+  }
+
+  function handleIncomingRequest(envelope) {
+    Promise.resolve()
+      .then(() => handleRequest(envelope))
+      .then((result) => {
+        writeEnvelope({
+          type: "response",
+          requestId: envelope.requestId,
+          resultType: "success",
+          method: envelope.method,
+          handledByClientId: clientId,
+          result: result ?? null,
+        });
+      })
+      .catch((error) => {
+        writeEnvelope({
+          type: "response",
+          requestId: envelope.requestId,
+          resultType: "error",
+          method: envelope.method,
+          handledByClientId: clientId,
+          error: error?.message || "Remodex IPC owner request failed.",
+        });
+      });
+  }
+
+  function handleClose(closedSocket) {
+    if (socket && socket !== closedSocket) {
+      return;
+    }
+    socket = null;
+    isConnecting = false;
+    isInitialized = false;
+    clientId = "";
+    readBuffer = Buffer.alloc(0);
+    for (const waiter of pendingResponses.values()) {
+      clearTimeout(waiter.timeout);
+      waiter.reject(new Error("Desktop IPC connection closed."));
+    }
+    pendingResponses.clear();
+    scheduleReconnect();
+  }
+
+  function scheduleReconnect() {
+    if (!shouldReconnect || reconnectTimer) {
+      return;
+    }
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      ensureConnected();
+    }, reconnectMs);
+    reconnectTimer.unref?.();
+  }
+
+  function clearReconnectTimer() {
+    if (!reconnectTimer) {
+      return;
+    }
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+
+  function closeSocket() {
+    if (!socket) {
+      return;
+    }
+    const closingSocket = socket;
+    socket = null;
+    closingSocket.destroy();
+  }
+
+  function close() {
+    shouldReconnect = false;
+    clearReconnectTimer();
+    closeSocket();
+    localRouter?.close();
+    for (const waiter of pendingResponses.values()) {
+      clearTimeout(waiter.timeout);
+      waiter.reject(new Error("Desktop IPC live owner stopped."));
+    }
+    pendingResponses.clear();
+  }
+
+  function writeEnvelope(envelope) {
+    if (!socket || socket.destroyed) {
+      return false;
+    }
+    try {
+      writeFrame(socket, JSON.stringify(envelope));
+      return true;
+    } catch {
+      closeSocket();
+      return false;
+    }
+  }
+
+  return {
+    ensureConnected,
+    sendBroadcast,
+    close,
+    get clientId() {
+      return clientId;
+    },
+  };
+}
+
+function createDesktopIpcRouterServer({
+  socketPath,
+  netModule,
+  now,
+  requestTimeoutMs,
+  discoveryTimeoutMs,
+  logPrefix,
+}) {
+  let server = null;
+  let started = false;
+  let starting = null;
+  let closed = false;
+  let nextClientSeq = 1;
+  const clientsById = new Map();
+  const pendingDiscoveryResponses = new Map();
+  const pendingRoutedResponses = new Map();
+
+  function start({ removeStaleSocket = false } = {}) {
+    if (started) {
+      return Promise.resolve();
+    }
+    if (starting) {
+      return starting;
+    }
+    closed = false;
+    starting = new Promise((resolve, reject) => {
+      try {
+        prepareSocketPathForListen(socketPath, { removeStaleSocket });
+      } catch (error) {
+        starting = null;
+        reject(error);
+        return;
+      }
+
+      const nextServer = netModule.createServer((socket) => attachClient(socket));
+      server = nextServer;
+      nextServer.on("error", (error) => {
+        starting = null;
+        server = null;
+        reject(error);
+      });
+      nextServer.listen(socketPath, () => {
+        started = true;
+        starting = null;
+        nextServer.removeAllListeners("error");
+        nextServer.on("error", (error) => {
+          console.warn(`${logPrefix} desktop IPC router fallback error: ${error.message}`);
+        });
+        resolve();
+      });
+      nextServer.unref?.();
+    });
+    return starting;
+  }
+
+  function attachClient(socket) {
+    const client = {
+      id: "",
+      type: "",
+      socket,
+      buffer: Buffer.alloc(0),
+      initialized: false,
+    };
+    socket.on("data", (chunk) => handleClientData(client, chunk));
+    socket.on("close", () => removeClient(client));
+    socket.on("error", () => removeClient(client));
+  }
+
+  function handleClientData(client, chunk) {
+    client.buffer = Buffer.concat([client.buffer, chunk]);
+    while (client.buffer.length >= FRAME_HEADER_BYTES) {
+      const frameLength = client.buffer.readUInt32LE(0);
+      if (frameLength > MAX_FRAME_BYTES) {
+        client.socket.destroy();
+        return;
+      }
+      if (client.buffer.length < FRAME_HEADER_BYTES + frameLength) {
+        return;
+      }
+
+      const payload = client.buffer.slice(FRAME_HEADER_BYTES, FRAME_HEADER_BYTES + frameLength).toString("utf8");
+      client.buffer = client.buffer.slice(FRAME_HEADER_BYTES + frameLength);
+      const envelope = safeParseJSON(payload);
+      if (envelope) {
+        dispatchClientEnvelope(client, envelope);
+      }
+    }
+  }
+
+  function dispatchClientEnvelope(client, envelope) {
+    if (envelope.type === "request" && envelope.method === "initialize") {
+      initializeClient(client, envelope);
+      return;
+    }
+    if (envelope.type === "broadcast") {
+      relayBroadcast(client, envelope);
+      return;
+    }
+    if (envelope.type === "request") {
+      routeClientRequest(client, envelope);
+      return;
+    }
+    if (envelope.type === "response") {
+      routeClientResponse(client, envelope);
+      return;
+    }
+    if (envelope.type === "client-discovery-request") {
+      answerClientDiscoveryRequest(client, envelope);
+      return;
+    }
+    if (envelope.type === "client-discovery-response") {
+      resolveDiscoveryResponse(envelope);
+    }
+  }
+
+  function initializeClient(client, envelope) {
+    if (!client.id) {
+      client.id = `remodex-router-${now().toString(36)}-${nextClientSeq}`;
+      nextClientSeq += 1;
+      clientsById.set(client.id, client);
+    }
+    client.initialized = true;
+    client.type = readString(envelope.params?.clientType) || readString(envelope.params?.client_type);
+    writeEnvelopeToClient(client, {
+      type: "response",
+      requestId: envelope.requestId,
+      resultType: "success",
+      method: "initialize",
+      handledByClientId: "remodex-ipc-router",
+      result: { clientId: client.id },
+    });
+    relayBroadcast(client, {
+      type: "broadcast",
+      method: CLIENT_STATUS_CHANGED,
+      sourceClientId: client.id,
+      version: METHOD_VERSION_BY_NAME.get(CLIENT_STATUS_CHANGED) || 1,
+      params: {
+        clientId: client.id,
+        clientType: client.type,
+        status: "connected",
+      },
+    });
+  }
+
+  function relayBroadcast(sender, envelope) {
+    const normalizedEnvelope = {
+      ...envelope,
+      sourceClientId: readString(envelope.sourceClientId) || sender.id,
+      version: envelope.version || METHOD_VERSION_BY_NAME.get(envelope.method) || 1,
+    };
+    for (const client of clientsById.values()) {
+      if (!client.initialized || client === sender) {
+        continue;
+      }
+      writeEnvelopeToClient(client, normalizedEnvelope);
+    }
+  }
+
+  async function routeClientRequest(sender, envelope) {
+    const target = await discoverTargetForRequest(sender, envelope);
+    if (!target) {
+      writeEnvelopeToClient(sender, {
+        type: "response",
+        requestId: envelope.requestId,
+        resultType: "error",
+        method: envelope.method,
+        handledByClientId: "",
+        error: `No Codex IPC client can handle ${envelope.method}.`,
+      });
+      return;
+    }
+    const requestId = requestIdKey(envelope.requestId);
+    if (!requestId) {
+      writeEnvelopeToClient(sender, {
+        type: "response",
+        requestId: envelope.requestId,
+        resultType: "error",
+        method: envelope.method,
+        handledByClientId: target.id,
+        error: "Missing requestId.",
+      });
+      return;
+    }
+
+    const routeKey = routedResponseKey(target.id, requestId);
+    const timeout = setTimeout(() => {
+      pendingRoutedResponses.delete(routeKey);
+      writeEnvelopeToClient(sender, {
+        type: "response",
+        requestId: envelope.requestId,
+        resultType: "error",
+        method: envelope.method,
+        handledByClientId: target.id,
+        error: `Codex IPC routed request timed out: ${envelope.method}`,
+      });
+    }, requestTimeoutMs);
+    timeout.unref?.();
+    pendingRoutedResponses.set(routeKey, {
+      sender,
+      timeout,
+    });
+    if (!writeEnvelopeToClient(target, {
+      ...envelope,
+      sourceClientId: sender.id,
+    })) {
+      clearTimeout(timeout);
+      pendingRoutedResponses.delete(routeKey);
+      writeEnvelopeToClient(sender, {
+        type: "response",
+        requestId: envelope.requestId,
+        resultType: "error",
+        method: envelope.method,
+        handledByClientId: target.id,
+        error: "Codex IPC routed request write failed.",
+      });
+    }
+  }
+
+  function routeClientResponse(client, envelope) {
+    const routeKey = routedResponseKey(client.id, requestIdKey(envelope.requestId));
+    const route = pendingRoutedResponses.get(routeKey);
+    if (!route) {
+      return;
+    }
+    pendingRoutedResponses.delete(routeKey);
+    clearTimeout(route.timeout);
+    writeEnvelopeToClient(route.sender, envelope);
+  }
+
+  async function answerClientDiscoveryRequest(sender, envelope) {
+    const target = await discoverTargetForRequest(sender, envelope.request || envelope);
+    writeEnvelopeToClient(sender, {
+      type: "client-discovery-response",
+      requestId: envelope.requestId,
+      response: {
+        canHandle: Boolean(target),
+      },
+    });
+  }
+
+  async function discoverTargetForRequest(sender, request) {
+    const candidates = Array.from(clientsById.values()).filter((client) => (
+      client.initialized && client !== sender && !client.socket.destroyed
+    ));
+    const results = await Promise.all(candidates.map(async (candidate) => {
+      const canHandle = await askClientCanHandle(candidate, request);
+      return canHandle ? candidate : null;
+    }));
+    return results.find(Boolean) || null;
+  }
+
+  function askClientCanHandle(client, request) {
+    const requestId = `remodex-router-discovery-${now().toString(36)}-${randomUUID()}`;
+    return new Promise((resolve) => {
+      const timeout = setTimeout(() => {
+        pendingDiscoveryResponses.delete(requestId);
+        resolve(false);
+      }, discoveryTimeoutMs);
+      timeout.unref?.();
+      pendingDiscoveryResponses.set(requestId, {
+        resolve,
+        timeout,
+      });
+      if (!writeEnvelopeToClient(client, {
+        type: "client-discovery-request",
+        requestId,
+        request,
+      })) {
+        clearTimeout(timeout);
+        pendingDiscoveryResponses.delete(requestId);
+        resolve(false);
+      }
+    });
+  }
+
+  function resolveDiscoveryResponse(envelope) {
+    const requestId = requestIdKey(envelope.requestId);
+    const pending = requestId ? pendingDiscoveryResponses.get(requestId) : null;
+    if (!pending) {
+      return;
+    }
+    pendingDiscoveryResponses.delete(requestId);
+    clearTimeout(pending.timeout);
+    pending.resolve(Boolean(envelope.response?.canHandle));
+  }
+
+  function removeClient(client) {
+    if (client.id) {
+      clientsById.delete(client.id);
+      relayBroadcast(client, {
+        type: "broadcast",
+        method: CLIENT_STATUS_CHANGED,
+        sourceClientId: client.id,
+        version: METHOD_VERSION_BY_NAME.get(CLIENT_STATUS_CHANGED) || 1,
+        params: {
+          clientId: client.id,
+          clientType: client.type,
+          status: "disconnected",
+        },
+      });
+    }
+    for (const [routeKey, route] of Array.from(pendingRoutedResponses.entries())) {
+      if (!routeKey.startsWith(`${client.id}:`)) {
+        continue;
+      }
+      pendingRoutedResponses.delete(routeKey);
+      clearTimeout(route.timeout);
+      writeEnvelopeToClient(route.sender, {
+        type: "response",
+        requestId: routeKey.slice(client.id.length + 1),
+        resultType: "error",
+        method: "",
+        handledByClientId: client.id,
+        error: "Codex IPC target disconnected.",
+      });
+    }
+  }
+
+  function close() {
+    const shouldRemoveSocketPath = started || server;
+    closed = true;
+    started = false;
+    starting = null;
+    for (const pending of pendingDiscoveryResponses.values()) {
+      clearTimeout(pending.timeout);
+      pending.resolve(false);
+    }
+    pendingDiscoveryResponses.clear();
+    for (const route of pendingRoutedResponses.values()) {
+      clearTimeout(route.timeout);
+    }
+    pendingRoutedResponses.clear();
+    for (const client of clientsById.values()) {
+      client.socket.destroy();
+    }
+    clientsById.clear();
+    if (server) {
+      server.close();
+      server = null;
+    }
+    if (shouldRemoveSocketPath) {
+      removeSocketPathAfterClose(socketPath);
+    }
+  }
+
+  function writeEnvelopeToClient(client, envelope) {
+    if (!client?.socket || client.socket.destroyed) {
+      return false;
+    }
+    try {
+      writeFrame(client.socket, JSON.stringify(envelope));
+      return true;
+    } catch {
+      client.socket.destroy();
+      return false;
+    }
+  }
+
+  return {
+    start,
+    close,
+    get isStarted() {
+      return started && !closed;
+    },
+  };
+}
+
+function routedResponseKey(clientId, requestId) {
+  return `${clientId}:${requestId}`;
+}
+
+function prepareSocketPathForListen(socketPath, { removeStaleSocket = false } = {}) {
+  if (process.platform === "win32") {
+    return;
+  }
+  fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+  if (removeStaleSocket && fs.existsSync(socketPath)) {
+    const socketStat = fs.lstatSync(socketPath);
+    if (!socketStat.isSocket()) {
+      throw new Error(`Refusing to replace non-socket Codex IPC path: ${socketPath}`);
+    }
+    fs.unlinkSync(socketPath);
+  }
+}
+
+function removeSocketPathAfterClose(socketPath) {
+  if (process.platform === "win32") {
+    return;
+  }
+  try {
+    if (fs.existsSync(socketPath)) {
+      fs.unlinkSync(socketPath);
+    }
+  } catch {
+    // Best-effort cleanup only; the next fallback start can remove stale sockets.
+  }
+}
+
+function sanitizeTurnStartParams(params) {
+  const sanitized = {};
+  for (const [key, value] of Object.entries(params || {})) {
+    if (ALLOWED_TURN_START_PARAM_KEYS.has(key)) {
+      sanitized[key] = value;
+    }
+  }
+  if (!Array.isArray(sanitized.input)) {
+    sanitized.input = [];
+  }
+  return sanitized;
+}
+
+function readThreadFromResponse(message) {
+  const result = message?.result || message?.payload || {};
+  return result.thread && typeof result.thread === "object"
+    ? result.thread
+    : result;
+}
+
+function readThreadIdFromParams(params) {
+  return readString(params?.threadId)
+    || readString(params?.thread_id)
+    || readString(params?.conversationId)
+    || readString(params?.conversation_id)
+    || readString(params?.turn?.threadId)
+    || readString(params?.turn?.thread_id)
+    || readString(params?.thread?.id);
+}
+
+function readConversationIdFromFollowerParams(params) {
+  return readString(params?.conversationId)
+    || readString(params?.conversation_id)
+    || readString(params?.threadId)
+    || readString(params?.thread_id)
+    || readString(params?.turnStartParams?.threadId)
+    || readString(params?.turn_start_params?.threadId);
+}
+
+function timestampSecondsToMs(value) {
+  return Number.isFinite(value) && value > 0 ? Math.round(value * 1000) : 0;
+}
+
+function requestIdKey(value) {
+  if (typeof value === "string" && value) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return "";
+}
+
+function readString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function normalizeToken(value) {
+  return typeof value === "string"
+    ? value.toLowerCase().replace(/[_-\s]+/g, "")
+    : "";
+}
+
+function cloneJSON(value) {
+  if (value == null) {
+    return value;
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+function safeParseJSON(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function writeFrame(socket, payload) {
+  const body = Buffer.from(payload, "utf8");
+  const header = Buffer.alloc(FRAME_HEADER_BYTES);
+  header.writeUInt32LE(body.length, 0);
+  socket.write(Buffer.concat([header, body]));
+}
+
+function resolveDefaultIpcSocketPath() {
+  if (process.platform === "win32") {
+    return "\\\\.\\pipe\\codex-ipc";
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : 0;
+  return path.join(os.tmpdir(), "codex-ipc", `ipc-${uid}.sock`);
+}
+
+module.exports = {
+  applyAppServerMessageToConversationState,
+  buildConversationStatePatches,
+  buildConversationStateFromThread,
+  createDesktopIpcLiveOwner,
+  resolveDefaultIpcSocketPath,
+};

--- a/phodex-bridge/src/desktop-ipc-live-owner.js
+++ b/phodex-bridge/src/desktop-ipc-live-owner.js
@@ -118,6 +118,7 @@ function createDesktopIpcLiveOwner({
   const ownedThreadIds = new Set();
   const pendingThreadStartRequestIds = new Set();
   const pendingThreadReadRequestIds = new Set();
+  const pendingThreadHydrationsByThreadId = new Map();
   const cachedThreadsByThreadId = new Map();
   const lastBroadcastStatesByThreadId = new Map();
   const dirtyThreadIds = new Set();
@@ -176,10 +177,15 @@ function createDesktopIpcLiveOwner({
       return;
     }
 
+    const hadConversation = conversations.has(threadId);
+    const hadCachedThread = cachedThreadsByThreadId.has(threadId);
     markOwnedThread(threadId);
     seedOwnedConversation(threadId, {
       cwd: readString(message?.params?.cwd),
     });
+    if (!hadConversation && !hadCachedThread) {
+      hydrateOwnedThreadFromRead(threadId);
+    }
     scheduleSnapshot(threadId);
   }
 
@@ -236,6 +242,7 @@ function createDesktopIpcLiveOwner({
     dirtyThreadIds.clear();
     pendingThreadStartRequestIds.clear();
     pendingThreadReadRequestIds.clear();
+    pendingThreadHydrationsByThreadId.clear();
     cachedThreadsByThreadId.clear();
     lastBroadcastStatesByThreadId.clear();
     ownedThreadIds.clear();
@@ -260,6 +267,7 @@ function createDesktopIpcLiveOwner({
     ownedThreadIds.delete(normalizedThreadId);
     conversations.delete(normalizedThreadId);
     cachedThreadsByThreadId.delete(normalizedThreadId);
+    pendingThreadHydrationsByThreadId.delete(normalizedThreadId);
     lastBroadcastStatesByThreadId.delete(normalizedThreadId);
     dirtyThreadIds.delete(normalizedThreadId);
   }
@@ -326,12 +334,49 @@ function createDesktopIpcLiveOwner({
     const pendingThreadIds = Array.from(dirtyThreadIds);
     dirtyThreadIds.clear();
     for (const threadId of pendingThreadIds) {
+      if (pendingThreadHydrationsByThreadId.has(threadId)) {
+        dirtyThreadIds.add(threadId);
+        continue;
+      }
       broadcastConversationState(threadId);
     }
   }
 
+  function hydrateOwnedThreadFromRead(threadId) {
+    const normalizedThreadId = readString(threadId);
+    if (!normalizedThreadId || pendingThreadHydrationsByThreadId.has(normalizedThreadId)) {
+      return;
+    }
+    const hydration = Promise.resolve()
+      .then(() => sendCodexRequest("thread/read", { threadId: normalizedThreadId }))
+      .then((result) => {
+        const thread = readThreadFromPayload(result);
+        if (!thread?.id) {
+          return;
+        }
+        cachedThreadsByThreadId.set(thread.id, cloneJSON(thread));
+        if (ownedThreadIds.has(thread.id)) {
+          upsertConversationFromThread(thread);
+        }
+      })
+      .catch((error) => {
+        console.warn(`${logPrefix} desktop IPC live owner thread/read hydration failed for ${normalizedThreadId}: ${error?.message || "unknown error"}`);
+      })
+      .finally(() => {
+        pendingThreadHydrationsByThreadId.delete(normalizedThreadId);
+        if (dirtyThreadIds.has(normalizedThreadId) && ownedThreadIds.has(normalizedThreadId)) {
+          scheduleSnapshot(normalizedThreadId);
+        }
+      });
+    pendingThreadHydrationsByThreadId.set(normalizedThreadId, hydration);
+  }
+
   function broadcastAllOwnedSnapshots() {
     for (const threadId of ownedThreadIds) {
+      if (pendingThreadHydrationsByThreadId.has(threadId)) {
+        dirtyThreadIds.add(threadId);
+        continue;
+      }
       broadcastConversationState(threadId, { forceSnapshot: true });
     }
   }
@@ -782,16 +827,12 @@ function buildConversationStateFromThread(thread, {
   const updatedAtMs = timestampSecondsToMs(thread?.updatedAt) || now();
   const cwd = readString(thread?.cwd) || previous?.cwd || "";
   const latestModel = readString(thread?.model) || readString(thread?.modelProvider) || previous?.latestModel || "";
-  const turns = Array.isArray(thread?.turns) && thread.turns.length > 0
-    ? thread.turns.map((turn) => buildConversationTurn(turn, {
-      threadId,
-      cwd,
-      now,
-      previousTurn: previous?.turns?.find((candidate) => (
-        readString(candidate?.turnId) || readString(candidate?.id)
-      ) === readString(turn?.id)),
-    }))
-    : cloneJSON(previous?.turns || []);
+  const turns = mergeConversationTurnsFromThread(thread?.turns, {
+    previousTurns: previous?.turns,
+    threadId,
+    cwd,
+    now,
+  });
 
   return {
     id: threadId,
@@ -827,6 +868,61 @@ function buildConversationStateFromThread(thread, {
     projectlessOutputDirectory: previous?.projectlessOutputDirectory || null,
     currentPermissions: cloneJSON(previous?.currentPermissions || null),
   };
+}
+
+function mergeConversationTurnsFromThread(threadTurns, {
+  previousTurns = [],
+  threadId = "",
+  cwd = "",
+  now = () => Date.now(),
+} = {}) {
+  const previousList = Array.isArray(previousTurns) ? previousTurns : [];
+  if (!Array.isArray(threadTurns) || threadTurns.length === 0) {
+    return cloneJSON(previousList);
+  }
+
+  const mergedById = new Map();
+  previousList.forEach((turn, index) => {
+    const turnId = readString(turn?.turnId) || readString(turn?.id);
+    if (!turnId) {
+      return;
+    }
+    mergedById.set(turnId, {
+      turn: cloneJSON(turn),
+      order: index,
+    });
+  });
+
+  threadTurns.forEach((turn, index) => {
+    const turnId = readString(turn?.id) || readString(turn?.turnId) || readString(turn?.turn_id);
+    if (!turnId) {
+      return;
+    }
+    const previous = mergedById.get(turnId);
+    const previousTurn = previous?.turn || null;
+    mergedById.set(turnId, {
+      turn: buildConversationTurn(turn, {
+        threadId,
+        cwd,
+        previousTurn,
+        now,
+      }),
+      order: previous?.order ?? previousList.length + index,
+    });
+  });
+
+  return Array.from(mergedById.values())
+    .sort((left, right) => {
+      const leftStartedAt = Number(left.turn?.turnStartedAtMs);
+      const rightStartedAt = Number(right.turn?.turnStartedAtMs);
+      if (Number.isFinite(leftStartedAt)
+        && Number.isFinite(rightStartedAt)
+        && leftStartedAt !== rightStartedAt) {
+        return leftStartedAt - rightStartedAt;
+      }
+      return left.order - right.order;
+    })
+    .map((entry) => entry.turn);
 }
 
 function createEmptyConversationState(threadId, {
@@ -1952,6 +2048,13 @@ function sanitizeTurnStartParams(params) {
 
 function readThreadFromResponse(message) {
   const result = message?.result || message?.payload || {};
+  return readThreadFromPayload(result);
+}
+
+function readThreadFromPayload(result) {
+  if (!result || typeof result !== "object") {
+    return null;
+  }
   return result.thread && typeof result.thread === "object"
     ? result.thread
     : result;

--- a/phodex-bridge/test/bridge-desktop-ipc-integration.test.js
+++ b/phodex-bridge/test/bridge-desktop-ipc-integration.test.js
@@ -93,6 +93,7 @@ test("bridge forwards desktop IPC actions to the phone and routes replies back t
       codexBundleId: "",
       codexAppPath: "",
       desktopIpcSocketPath: ipcSocketPath,
+      desktopIpcLiveSyncEnabled: false,
     },
   });
 
@@ -254,6 +255,7 @@ test("bridge recovers desktop IPC state when the first live update is patch-only
       codexBundleId: "",
       codexAppPath: "",
       desktopIpcSocketPath: ipcSocketPath,
+      desktopIpcLiveSyncEnabled: false,
     },
   });
 
@@ -361,6 +363,7 @@ test("bridge forwards live desktop assistant deltas to the phone", async (t) => 
       codexBundleId: "",
       codexAppPath: "",
       desktopIpcSocketPath: ipcSocketPath,
+      desktopIpcLiveSyncEnabled: false,
     },
   });
 

--- a/phodex-bridge/test/codex-desktop-refresher.test.js
+++ b/phodex-bridge/test/codex-desktop-refresher.test.js
@@ -114,6 +114,8 @@ test("readBridgeConfig keeps safe defaults and explicit overrides", () => {
     env: {
       REMODEX_REFRESH_COMMAND: "echo refresh",
       REMODEX_REFRESH_ENABLED: "false",
+      REMODEX_DESKTOP_IPC_LIVE_SYNC: "false",
+      REMODEX_DESKTOP_IPC_SNAPSHOT_DEBOUNCE_MS: "25",
       REMODEX_KEEP_MAC_AWAKE: "false",
     },
     platform: "darwin",
@@ -129,6 +131,8 @@ test("readBridgeConfig keeps safe defaults and explicit overrides", () => {
   assert.equal(macConfig.keepMacAwakeEnabled, false);
   assert.equal(macConfig.relayUrl, "");
   assert.equal(macConfig.pushServiceUrl, "");
+  assert.equal(macConfig.desktopIpcLiveSyncEnabled, true);
+  assert.equal(macConfig.desktopIpcSnapshotDebounceMs, 75);
   assert.equal(persistedKeepAwakeConfig.keepMacAwakeEnabled, false);
   assert.equal(macEndpointConfig.refreshEnabled, false);
   assert.equal(linuxConfig.refreshEnabled, false);
@@ -136,6 +140,8 @@ test("readBridgeConfig keeps safe defaults and explicit overrides", () => {
   assert.equal(explicitOnConfig.refreshEnabled, true);
   assert.equal(explicitOnConfig.desktopIpcSocketPath, "/tmp/remodex-ipc.sock");
   assert.equal(explicitOffConfig.refreshEnabled, false);
+  assert.equal(explicitOffConfig.desktopIpcLiveSyncEnabled, false);
+  assert.equal(explicitOffConfig.desktopIpcSnapshotDebounceMs, 25);
   assert.equal(explicitOffConfig.keepMacAwakeEnabled, false);
 });
 

--- a/phodex-bridge/test/desktop-ipc-action-follower.test.js
+++ b/phodex-bridge/test/desktop-ipc-action-follower.test.js
@@ -1012,6 +1012,168 @@ test("desktop IPC follower forwards pending actions and routes iOS replies back 
   });
 });
 
+test("desktop IPC follower routes phone turns to Desktop-owned threads", async (t) => {
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-ipc-follower-turn-start-");
+  const serverFrames = [];
+  let serverSocket = null;
+
+  const server = net.createServer((socket) => {
+    serverSocket = socket;
+    attachFrameReader(socket, (frame) => {
+      serverFrames.push(frame);
+      if (frame.method === "initialize") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: "initialize",
+          handledByClientId: "desktop",
+          result: { clientId: "remodex-test" },
+        });
+      } else if (frame.method?.startsWith("thread-follower-")) {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: frame.method,
+          handledByClientId: "desktop",
+          result: { turn: { id: "turn-from-phone" } },
+        });
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  t.after(() => {
+    server.close();
+    serverSocket?.destroy();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const outbound = [];
+  const follower = createDesktopIpcActionFollower({
+    socketPath,
+    sendApplicationResponse(message) {
+      outbound.push(JSON.parse(message));
+    },
+    requestTimeoutMs: 500,
+  });
+  t.after(() => follower.stopAll());
+
+  follower.observeInbound(JSON.stringify({
+    method: "thread/resume",
+    params: { threadId: "thread-desktop-owned" },
+  }));
+  await waitFor(() => serverSocket);
+  writeFrame(serverSocket, {
+    type: "broadcast",
+    method: "thread-stream-state-changed",
+    sourceClientId: "desktop",
+    version: 6,
+    params: {
+      conversationId: "thread-desktop-owned",
+      change: {
+        type: "snapshot",
+        conversationState: {
+          turns: [],
+          requests: [],
+        },
+      },
+    },
+  });
+  await wait(25);
+
+  const handled = follower.observeInbound(JSON.stringify({
+    id: "phone-turn-start-1",
+    method: "turn/start",
+    params: {
+      threadId: "thread-desktop-owned",
+      input: [{ type: "input_text", text: "continue from phone" }],
+      cwd: "/repo",
+      model: "gpt-test",
+    },
+  }));
+  assert.equal(handled, true);
+
+  await waitFor(() => serverFrames.find((frame) => frame.method === "thread-follower-start-turn"));
+  const turnStartFrame = serverFrames.find((frame) => frame.method === "thread-follower-start-turn");
+  assert.equal(turnStartFrame.version, 1);
+  assert.deepEqual(turnStartFrame.params, {
+    conversationId: "thread-desktop-owned",
+    turnStartParams: {
+      threadId: "thread-desktop-owned",
+      input: [{ type: "input_text", text: "continue from phone" }],
+      cwd: "/repo",
+      model: "gpt-test",
+    },
+  });
+
+  await waitFor(() => outbound.find((message) => message.id === "phone-turn-start-1"));
+  assert.deepEqual(outbound.find((message) => message.id === "phone-turn-start-1"), {
+    id: "phone-turn-start-1",
+    result: { turn: { id: "turn-from-phone" } },
+  });
+
+  const routedRequests = [
+    {
+      id: "phone-steer-1",
+      method: "turn/steer",
+      params: {
+        threadId: "thread-desktop-owned",
+        input: [{ type: "input_text", text: "steer from phone" }],
+        expectedTurnId: "turn-from-phone",
+      },
+      expectedMethod: "thread-follower-steer-turn",
+      expectedParams: {
+        conversationId: "thread-desktop-owned",
+        input: [{ type: "input_text", text: "steer from phone" }],
+        expectedTurnId: "turn-from-phone",
+      },
+    },
+    {
+      id: "phone-interrupt-1",
+      method: "turn/interrupt",
+      params: {
+        threadId: "thread-desktop-owned",
+        turnId: "turn-from-phone",
+      },
+      expectedMethod: "thread-follower-interrupt-turn",
+      expectedParams: {
+        conversationId: "thread-desktop-owned",
+        turnId: "turn-from-phone",
+      },
+    },
+    {
+      id: "phone-compact-1",
+      method: "thread/compact/start",
+      params: {
+        threadId: "thread-desktop-owned",
+      },
+      expectedMethod: "thread-follower-compact-thread",
+      expectedParams: {
+        conversationId: "thread-desktop-owned",
+      },
+    },
+  ];
+
+  for (const request of routedRequests) {
+    const handledRoute = follower.observeInbound(JSON.stringify({
+      id: request.id,
+      method: request.method,
+      params: request.params,
+    }));
+    assert.equal(handledRoute, true);
+    await waitFor(() => serverFrames.find((frame) => frame.method === request.expectedMethod));
+    const routedFrame = serverFrames.find((frame) => frame.method === request.expectedMethod);
+    assert.equal(routedFrame.version, 1);
+    assert.deepEqual(routedFrame.params, request.expectedParams);
+    await waitFor(() => outbound.find((message) => message.id === request.id));
+    assert.deepEqual(outbound.find((message) => message.id === request.id), {
+      id: request.id,
+      result: { turn: { id: "turn-from-phone" } },
+    });
+  }
+});
+
 test("desktop IPC follower mirrors live assistant text growth from desktop state", async (t) => {
   const { tempDir, socketPath } = createIpcTestSocket("remodex-ipc-assistant-delta-");
   let serverSocket = null;

--- a/phodex-bridge/test/desktop-ipc-live-owner.test.js
+++ b/phodex-bridge/test/desktop-ipc-live-owner.test.js
@@ -335,7 +335,7 @@ test("live owner starts a local IPC router when no Codex IPC socket exists", asy
     (frame) => frame.type === "response" && frame.requestId === "desktop-start-1"
   );
   assert.equal(routedResponse.resultType, "success");
-  assert.deepEqual(codexRequests, [{
+  assert.deepEqual(codexRequests.filter((request) => request.method === "turn/start"), [{
     method: "turn/start",
     params: {
       threadId: "thread-router-owned",
@@ -481,6 +481,205 @@ test("live owner seeds existing thread snapshots from thread reads before owners
   assert.equal(state.turns[1].turnId, "turn-new");
 });
 
+test("live owner hydrates existing threads before first mobile-owned snapshot", async (t) => {
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-live-owner-hydrate-");
+  const frames = [];
+  const codexRequests = [];
+  let serverSocket = null;
+  let resolveThreadRead = null;
+
+  const server = net.createServer((socket) => {
+    serverSocket = socket;
+    attachFrameReader(socket, (frame) => {
+      frames.push(frame);
+      if (frame.method === "initialize") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: "initialize",
+          handledByClientId: "router",
+          result: { clientId: "remodex-owner-test" },
+        });
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  t.after(() => {
+    owner.stopAll();
+    server.close();
+    serverSocket?.destroy();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const owner = createDesktopIpcLiveOwner({
+    socketPath,
+    snapshotDebounceMs: 1,
+    sendCodexRequest(method, params) {
+      codexRequests.push({ method, params });
+      return new Promise((resolve) => {
+        resolveThreadRead = resolve;
+      });
+    },
+    sendRawCodexMessage() {},
+  });
+
+  owner.observeInbound(JSON.stringify({
+    id: "turn-start-hydrate",
+    method: "turn/start",
+    params: {
+      threadId: "thread-hydrate",
+      cwd: "/tmp/hydrate",
+      input: [{ type: "input_text", text: "continue" }],
+    },
+  }));
+  owner.observeOutbound(JSON.stringify({
+    method: "turn/started",
+    params: {
+      threadId: "thread-hydrate",
+      turn: {
+        id: "turn-new",
+        items: [],
+        status: "inProgress",
+        error: null,
+        startedAt: 3,
+        completedAt: null,
+        durationMs: null,
+      },
+    },
+  }));
+
+  await wait(25);
+  assert.equal(codexRequests.length, 1);
+  assert.deepEqual(codexRequests[0], {
+    method: "thread/read",
+    params: { threadId: "thread-hydrate" },
+  });
+  assert.equal(frames.some((frame) => frame.type === "broadcast"), false);
+
+  resolveThreadRead({
+    thread: {
+      id: "thread-hydrate",
+      sessionId: "session-hydrate",
+      preview: "Hydrate",
+      ephemeral: false,
+      modelProvider: "openai",
+      createdAt: 1,
+      updatedAt: 2,
+      status: { type: "idle" },
+      path: null,
+      cwd: "/tmp/hydrate",
+      cliVersion: "test",
+      source: "app-server",
+      threadSource: null,
+      gitInfo: null,
+      name: "Hydrated thread",
+      turns: [{
+        id: "turn-old",
+        items: [{
+          id: "assistant-old",
+          type: "agentMessage",
+          text: "Existing Desktop content",
+        }],
+        status: "completed",
+        error: null,
+        startedAt: 1,
+        completedAt: 2,
+        durationMs: 1000,
+      }],
+    },
+  });
+
+  const broadcast = await waitForMessage(
+    frames,
+    (frame) => frame.type === "broadcast"
+      && frame.method === "thread-stream-state-changed"
+      && frame.params?.conversationId === "thread-hydrate"
+      && frame.params?.change?.type === "snapshot"
+  );
+  const state = broadcast.params.change.conversationState;
+  assert.equal(state.title, "Hydrated thread");
+  assert.equal(state.turns.length, 2);
+  assert.equal(state.turns[0].turnId, "turn-old");
+  assert.equal(state.turns[0].items[0].text, "Existing Desktop content");
+  assert.equal(state.turns[1].turnId, "turn-new");
+});
+
+test("live owner resumes snapshots when existing thread hydration fails", async (t) => {
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-live-owner-hydrate-fail-");
+  const frames = [];
+  let serverSocket = null;
+
+  const server = net.createServer((socket) => {
+    serverSocket = socket;
+    attachFrameReader(socket, (frame) => {
+      frames.push(frame);
+      if (frame.method === "initialize") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: "initialize",
+          handledByClientId: "router",
+          result: { clientId: "remodex-owner-test" },
+        });
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  t.after(() => {
+    owner.stopAll();
+    server.close();
+    serverSocket?.destroy();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const owner = createDesktopIpcLiveOwner({
+    socketPath,
+    snapshotDebounceMs: 1,
+    sendCodexRequest: async () => {
+      throw new Error("read failed");
+    },
+    sendRawCodexMessage() {},
+  });
+
+  owner.observeInbound(JSON.stringify({
+    id: "turn-start-hydrate-fail",
+    method: "turn/start",
+    params: {
+      threadId: "thread-hydrate-fail",
+      cwd: "/tmp/hydrate-fail",
+      input: [{ type: "input_text", text: "continue" }],
+    },
+  }));
+  owner.observeOutbound(JSON.stringify({
+    method: "turn/started",
+    params: {
+      threadId: "thread-hydrate-fail",
+      turn: {
+        id: "turn-new",
+        items: [],
+        status: "inProgress",
+        error: null,
+        startedAt: 3,
+        completedAt: null,
+        durationMs: null,
+      },
+    },
+  }));
+
+  const broadcast = await waitForMessage(
+    frames,
+    (frame) => frame.type === "broadcast"
+      && frame.method === "thread-stream-state-changed"
+      && frame.params?.conversationId === "thread-hydrate-fail"
+      && frame.params?.change?.type === "snapshot"
+  );
+  const state = broadcast.params.change.conversationState;
+  assert.equal(state.turns.length, 1);
+  assert.equal(state.turns[0].turnId, "turn-new");
+});
+
 test("live owner handles discovery and start-turn follower requests for owned threads", async (t) => {
   const { tempDir, socketPath } = createIpcTestSocket("remodex-live-owner-follower-");
   const codexRequests = [];
@@ -585,7 +784,7 @@ test("live owner handles discovery and start-turn follower requests for owned th
     (frame) => frame.type === "response" && frame.requestId === "start-turn-1"
   );
   assert.equal(response.resultType, "success");
-  assert.deepEqual(codexRequests, [{
+  assert.deepEqual(codexRequests.filter((request) => request.method === "turn/start"), [{
     method: "turn/start",
     params: {
       threadId: "thread-owned",

--- a/phodex-bridge/test/desktop-ipc-live-owner.test.js
+++ b/phodex-bridge/test/desktop-ipc-live-owner.test.js
@@ -1,0 +1,755 @@
+// FILE: desktop-ipc-live-owner.test.js
+// Purpose: Verifies Remodex-owned Codex streams are exposed to Desktop/VSCode through the local IPC bus.
+// Layer: Unit test
+// Exports: node:test suite
+// Depends on: node:test, net, ../src/desktop-ipc-live-owner
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const net = require("node:net");
+const os = require("node:os");
+const path = require("node:path");
+const { setTimeout: wait } = require("node:timers/promises");
+const {
+  applyAppServerMessageToConversationState,
+  buildConversationStatePatches,
+  createDesktopIpcLiveOwner,
+} = require("../src/desktop-ipc-live-owner");
+
+test("live owner broadcasts Remodex-owned thread snapshots over Desktop IPC", async (t) => {
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-live-owner-");
+  const frames = [];
+  let serverSocket = null;
+
+  const server = net.createServer((socket) => {
+    serverSocket = socket;
+    attachFrameReader(socket, (frame) => {
+      frames.push(frame);
+      if (frame.method === "initialize") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: "initialize",
+          handledByClientId: "router",
+          result: { clientId: "remodex-owner-test" },
+        });
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  t.after(() => {
+    owner.stopAll();
+    server.close();
+    serverSocket?.destroy();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const owner = createDesktopIpcLiveOwner({
+    socketPath,
+    snapshotDebounceMs: 1,
+    sendCodexRequest: async () => ({ ok: true }),
+    sendRawCodexMessage() {},
+  });
+
+  owner.observeInbound(JSON.stringify({
+    id: "thread-start-1",
+    method: "thread/start",
+    params: { cwd: "/tmp/project" },
+  }));
+  owner.observeOutbound(JSON.stringify({
+    method: "thread/started",
+    params: {
+      thread: {
+        id: "thread-live-owner",
+        sessionId: "session-live-owner",
+        preview: "Build it",
+        ephemeral: false,
+        modelProvider: "openai",
+        createdAt: 1,
+        updatedAt: 1,
+        status: { type: "active" },
+        path: null,
+        cwd: "/tmp/project",
+        cliVersion: "test",
+        source: "app-server",
+        threadSource: null,
+        gitInfo: null,
+        name: "Live owner",
+        turns: [],
+      },
+    },
+  }));
+  owner.observeOutbound(JSON.stringify({
+    method: "turn/started",
+    params: {
+      threadId: "thread-live-owner",
+      turn: {
+        id: "turn-live-owner",
+        items: [],
+        status: "inProgress",
+        error: null,
+        startedAt: 2,
+        completedAt: null,
+        durationMs: null,
+      },
+    },
+  }));
+  owner.observeOutbound(JSON.stringify({
+    method: "item/agentMessage/delta",
+    params: {
+      threadId: "thread-live-owner",
+      turnId: "turn-live-owner",
+      itemId: "assistant-live-owner",
+      delta: "Hello",
+    },
+  }));
+
+  const broadcast = await waitForMessage(
+    frames,
+    (frame) => frame.type === "broadcast" && frame.method === "thread-stream-state-changed"
+  );
+  assert.equal(broadcast.version, 6);
+  assert.equal(broadcast.params.conversationId, "thread-live-owner");
+  assert.equal(broadcast.params.hostId, "local");
+  assert.equal(broadcast.params.change.type, "snapshot");
+  assert.equal(broadcast.params.change.conversationState.id, "thread-live-owner");
+  assert.equal(broadcast.params.change.conversationState.turns[0].turnId, "turn-live-owner");
+  assert.equal(broadcast.params.change.conversationState.turns[0].items[0].text, "Hello");
+});
+
+test("live owner broadcasts patches after the first owned thread snapshot", async (t) => {
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-live-owner-patches-");
+  const frames = [];
+  let serverSocket = null;
+
+  const server = net.createServer((socket) => {
+    serverSocket = socket;
+    attachFrameReader(socket, (frame) => {
+      frames.push(frame);
+      if (frame.method === "initialize") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: "initialize",
+          handledByClientId: "router",
+          result: { clientId: "remodex-owner-test" },
+        });
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  t.after(() => {
+    owner.stopAll();
+    server.close();
+    serverSocket?.destroy();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const owner = createDesktopIpcLiveOwner({
+    socketPath,
+    snapshotDebounceMs: 1,
+    sendCodexRequest: async () => ({ ok: true }),
+    sendRawCodexMessage() {},
+  });
+
+  owner.observeInbound(JSON.stringify({
+    id: "thread-start-patch-1",
+    method: "thread/start",
+    params: { cwd: "/tmp/project" },
+  }));
+  owner.observeOutbound(JSON.stringify({
+    method: "thread/started",
+    params: {
+      thread: {
+        id: "thread-live-patches",
+        sessionId: "session-live-patches",
+        preview: "Build it",
+        ephemeral: false,
+        modelProvider: "openai",
+        createdAt: 1,
+        updatedAt: 1,
+        status: { type: "active" },
+        path: null,
+        cwd: "/tmp/project",
+        cliVersion: "test",
+        source: "app-server",
+        threadSource: null,
+        gitInfo: null,
+        name: "Live patches",
+        turns: [],
+      },
+    },
+  }));
+
+  const snapshot = await waitForMessage(
+    frames,
+    (frame) => frame.type === "broadcast"
+      && frame.method === "thread-stream-state-changed"
+      && frame.params?.conversationId === "thread-live-patches"
+      && frame.params?.change?.type === "snapshot"
+  );
+  assert.equal(snapshot.params.change.conversationState.turns.length, 0);
+
+  owner.observeOutbound(JSON.stringify({
+    method: "turn/started",
+    params: {
+      threadId: "thread-live-patches",
+      turn: {
+        id: "turn-live-patches",
+        items: [],
+        status: "inProgress",
+        error: null,
+        startedAt: 2,
+        completedAt: null,
+        durationMs: null,
+      },
+    },
+  }));
+
+  const turnPatchBroadcast = await waitForMessage(
+    frames,
+    (frame) => frame.type === "broadcast"
+      && frame.method === "thread-stream-state-changed"
+      && frame.params?.conversationId === "thread-live-patches"
+      && frame.params?.change?.type === "patches"
+      && frame.params.change.patches.some((patch) => (
+        patch.op === "add"
+        && JSON.stringify(patch.path) === JSON.stringify(["turns", 0])
+      ))
+  );
+  assert.equal(turnPatchBroadcast.version, 6);
+
+  owner.observeOutbound(JSON.stringify({
+    method: "item/agentMessage/delta",
+    params: {
+      threadId: "thread-live-patches",
+      turnId: "turn-live-patches",
+      itemId: "assistant-live-patches",
+      delta: "Hello",
+    },
+  }));
+
+  const itemPatchBroadcast = await waitForMessage(
+    frames,
+    (frame) => frame.type === "broadcast"
+      && frame.method === "thread-stream-state-changed"
+      && frame.params?.conversationId === "thread-live-patches"
+      && frame.params?.change?.type === "patches"
+      && frame.params.change.patches.some((patch) => (
+        patch.op === "add"
+        && JSON.stringify(patch.path) === JSON.stringify(["turns", 0, "items", 0])
+        && patch.value?.text === "Hello"
+      ))
+  );
+  assert.ok(itemPatchBroadcast.params.change.patches.length > 0);
+});
+
+test("live owner starts a local IPC router when no Codex IPC socket exists", async (t) => {
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-live-owner-router-");
+  const codexRequests = [];
+  const desktopFrames = [];
+  let desktopSocket = null;
+
+  const owner = createDesktopIpcLiveOwner({
+    socketPath,
+    snapshotDebounceMs: 1,
+    reconnectMs: 10,
+    requestTimeoutMs: 500,
+    async sendCodexRequest(method, params) {
+      codexRequests.push({ method, params });
+      return { ok: true };
+    },
+    sendRawCodexMessage() {},
+  });
+
+  t.after(() => {
+    owner.stopAll();
+    desktopSocket?.destroy();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  owner.observeInbound(JSON.stringify({
+    method: "turn/start",
+    params: { threadId: "thread-router-owned", input: [] },
+  }));
+  owner.observeOutbound(JSON.stringify({
+    method: "thread/started",
+    params: {
+      thread: {
+        id: "thread-router-owned",
+        sessionId: "session-router-owned",
+        preview: "Router fallback",
+        createdAt: 1,
+        updatedAt: 1,
+        cwd: "/tmp/router-project",
+        status: { type: "active" },
+        turns: [],
+      },
+    },
+  }));
+
+  await waitFor(() => fs.existsSync(socketPath));
+
+  desktopSocket = net.createConnection(socketPath);
+  attachFrameReader(desktopSocket, (frame) => desktopFrames.push(frame));
+  await new Promise((resolve) => desktopSocket.once("connect", resolve));
+  writeFrame(desktopSocket, {
+    type: "request",
+    requestId: "desktop-init-1",
+    sourceClientId: "initializing-client",
+    version: 1,
+    method: "initialize",
+    params: { clientType: "vscode" },
+  });
+  await waitFor(() => desktopFrames.find((frame) => frame.requestId === "desktop-init-1"));
+
+  const snapshot = await waitForMessage(
+    desktopFrames,
+    (frame) => frame.type === "broadcast"
+      && frame.method === "thread-stream-state-changed"
+      && frame.params?.conversationId === "thread-router-owned"
+      && frame.params?.change?.type === "snapshot"
+  );
+  assert.equal(snapshot.version, 6);
+  assert.equal(snapshot.params.change.conversationState.id, "thread-router-owned");
+
+  writeFrame(desktopSocket, {
+    type: "request",
+    requestId: "desktop-start-1",
+    sourceClientId: "desktop-client",
+    method: "thread-follower-start-turn",
+    params: {
+      conversationId: "thread-router-owned",
+      turnStartParams: {
+        input: [{ type: "text", text: "continue from desktop" }],
+        cwd: "/tmp/router-project",
+      },
+    },
+  });
+
+  const routedResponse = await waitForMessage(
+    desktopFrames,
+    (frame) => frame.type === "response" && frame.requestId === "desktop-start-1"
+  );
+  assert.equal(routedResponse.resultType, "success");
+  assert.deepEqual(codexRequests, [{
+    method: "turn/start",
+    params: {
+      threadId: "thread-router-owned",
+      input: [{ type: "text", text: "continue from desktop" }],
+      cwd: "/tmp/router-project",
+    },
+  }]);
+});
+
+test("conversation state patch builder falls back when patches are too large", () => {
+  assert.deepEqual(
+    buildConversationStatePatches(
+      { turns: [] },
+      { turns: [{ id: "turn-1" }], updatedAt: 1 },
+      { maxPatchCount: 10, maxPatchBytes: 1024 }
+    ),
+    [
+      { op: "add", path: ["turns", 0], value: { id: "turn-1" } },
+      { op: "add", path: ["updatedAt"], value: 1 },
+    ]
+  );
+  assert.equal(
+    buildConversationStatePatches(
+      { turns: [] },
+      { turns: [{ id: "turn-1" }], updatedAt: 1 },
+      { maxPatchCount: 1, maxPatchBytes: 1024 }
+    ),
+    null
+  );
+});
+
+test("live owner seeds existing thread snapshots from thread reads before ownership", async (t) => {
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-live-owner-existing-");
+  const frames = [];
+  let serverSocket = null;
+
+  const server = net.createServer((socket) => {
+    serverSocket = socket;
+    attachFrameReader(socket, (frame) => {
+      frames.push(frame);
+      if (frame.method === "initialize") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: "initialize",
+          handledByClientId: "router",
+          result: { clientId: "remodex-owner-test" },
+        });
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  t.after(() => {
+    owner.stopAll();
+    server.close();
+    serverSocket?.destroy();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const owner = createDesktopIpcLiveOwner({
+    socketPath,
+    snapshotDebounceMs: 1,
+    sendCodexRequest: async () => ({ ok: true }),
+    sendRawCodexMessage() {},
+  });
+
+  owner.observeInbound(JSON.stringify({
+    id: "read-existing-1",
+    method: "thread/read",
+    params: { threadId: "thread-existing" },
+  }));
+  owner.observeOutbound(JSON.stringify({
+    id: "read-existing-1",
+    result: {
+      thread: {
+        id: "thread-existing",
+        sessionId: "session-existing",
+        preview: "Existing",
+        ephemeral: false,
+        modelProvider: "openai",
+        createdAt: 1,
+        updatedAt: 2,
+        status: { type: "idle" },
+        path: null,
+        cwd: "/tmp/existing",
+        cliVersion: "test",
+        source: "app-server",
+        threadSource: null,
+        gitInfo: null,
+        name: "Existing thread",
+        turns: [{
+          id: "turn-old",
+          items: [{
+            id: "assistant-old",
+            type: "agentMessage",
+            text: "Previous answer",
+          }],
+          status: "completed",
+          error: null,
+          startedAt: 1,
+          completedAt: 2,
+          durationMs: 1000,
+        }],
+      },
+    },
+  }));
+  owner.observeInbound(JSON.stringify({
+    id: "turn-start-existing",
+    method: "turn/start",
+    params: {
+      threadId: "thread-existing",
+      cwd: "/tmp/existing",
+      input: [{ type: "input_text", text: "continue" }],
+    },
+  }));
+  owner.observeOutbound(JSON.stringify({
+    method: "turn/started",
+    params: {
+      threadId: "thread-existing",
+      turn: {
+        id: "turn-new",
+        items: [],
+        status: "inProgress",
+        error: null,
+        startedAt: 3,
+        completedAt: null,
+        durationMs: null,
+      },
+    },
+  }));
+
+  const broadcast = await waitForMessage(
+    frames,
+    (frame) => frame.type === "broadcast"
+      && frame.method === "thread-stream-state-changed"
+      && frame.params?.change?.conversationState?.turns?.some((turn) => turn.turnId === "turn-new")
+  );
+  const state = broadcast.params.change.conversationState;
+  assert.equal(state.title, "Existing thread");
+  assert.equal(state.turns[0].turnId, "turn-old");
+  assert.equal(state.turns[0].items[0].text, "Previous answer");
+  assert.equal(state.turns[1].turnId, "turn-new");
+});
+
+test("live owner handles discovery and start-turn follower requests for owned threads", async (t) => {
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-live-owner-follower-");
+  const codexRequests = [];
+  let serverSocket = null;
+
+  const server = net.createServer((socket) => {
+    serverSocket = socket;
+    attachFrameReader(socket, (frame) => {
+      if (frame.method === "initialize") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: "initialize",
+          handledByClientId: "router",
+          result: { clientId: "remodex-owner-test" },
+        });
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  t.after(() => {
+    owner.stopAll();
+    server.close();
+    serverSocket?.destroy();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const owner = createDesktopIpcLiveOwner({
+    socketPath,
+    snapshotDebounceMs: 1,
+    async sendCodexRequest(method, params) {
+      codexRequests.push({ method, params });
+      return {
+        turn: {
+          id: "turn-from-follower",
+          status: "inProgress",
+        },
+      };
+    },
+    sendRawCodexMessage() {},
+  });
+
+  owner.observeInbound(JSON.stringify({
+    method: "turn/start",
+    params: { threadId: "thread-owned", input: [] },
+  }));
+  await waitFor(() => serverSocket);
+
+  writeFrame(serverSocket, {
+    type: "client-discovery-request",
+    requestId: "discovery-1",
+    request: {
+      type: "request",
+      requestId: "inner-1",
+      method: "thread-follower-start-turn",
+      params: {
+        conversationId: "thread-owned",
+      },
+    },
+  });
+  const discoveryResponse = await waitForFrame(
+    serverSocket,
+    (frame) => frame.type === "client-discovery-response"
+  );
+  assert.deepEqual(discoveryResponse.response, { canHandle: true });
+
+  writeFrame(serverSocket, {
+    type: "client-discovery-request",
+    requestId: "discovery-unsupported",
+    request: {
+      type: "request",
+      requestId: "inner-unsupported",
+      method: "thread-follower-edit-last-user-turn",
+      params: {
+        conversationId: "thread-owned",
+      },
+    },
+  });
+  const unsupportedDiscoveryResponse = await waitForFrame(
+    serverSocket,
+    (frame) => frame.type === "client-discovery-response" && frame.requestId === "discovery-unsupported"
+  );
+  assert.deepEqual(unsupportedDiscoveryResponse.response, { canHandle: false });
+
+  writeFrame(serverSocket, {
+    type: "request",
+    requestId: "start-turn-1",
+    sourceClientId: "desktop",
+    method: "thread-follower-start-turn",
+    params: {
+      conversationId: "thread-owned",
+      turnStartParams: {
+        input: [{ type: "text", text: "continue" }],
+        model: "gpt-test",
+        attachments: [{ id: "client-only" }],
+      },
+    },
+  });
+  const response = await waitForFrame(
+    serverSocket,
+    (frame) => frame.type === "response" && frame.requestId === "start-turn-1"
+  );
+  assert.equal(response.resultType, "success");
+  assert.deepEqual(codexRequests, [{
+    method: "turn/start",
+    params: {
+      threadId: "thread-owned",
+      input: [{ type: "text", text: "continue" }],
+      model: "gpt-test",
+    },
+  }]);
+});
+
+test("live owner routes follower approval responses back to app-server", async (t) => {
+  const { tempDir, socketPath } = createIpcTestSocket("remodex-live-owner-approval-");
+  const rawCodexMessages = [];
+  let serverSocket = null;
+
+  const server = net.createServer((socket) => {
+    serverSocket = socket;
+    attachFrameReader(socket, (frame) => {
+      if (frame.method === "initialize") {
+        writeFrame(socket, {
+          type: "response",
+          requestId: frame.requestId,
+          resultType: "success",
+          method: "initialize",
+          handledByClientId: "router",
+          result: { clientId: "remodex-owner-test" },
+        });
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  t.after(() => {
+    owner.stopAll();
+    server.close();
+    serverSocket?.destroy();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const owner = createDesktopIpcLiveOwner({
+    socketPath,
+    sendCodexRequest: async () => ({ ok: true }),
+    sendRawCodexMessage(rawMessage) {
+      rawCodexMessages.push(JSON.parse(rawMessage));
+    },
+  });
+
+  owner.observeInbound(JSON.stringify({
+    method: "turn/start",
+    params: { threadId: "thread-approval", input: [] },
+  }));
+  await waitFor(() => serverSocket);
+  writeFrame(serverSocket, {
+    type: "request",
+    requestId: "approval-1",
+    sourceClientId: "desktop",
+    method: "thread-follower-file-approval-decision",
+    params: {
+      conversationId: "thread-approval",
+      requestId: "file-approval-1",
+      decision: "accept",
+    },
+  });
+
+  const response = await waitForFrame(
+    serverSocket,
+    (frame) => frame.type === "response" && frame.requestId === "approval-1"
+  );
+  assert.equal(response.resultType, "success");
+  assert.deepEqual(rawCodexMessages, [{
+    id: "file-approval-1",
+    result: {
+      decision: "accept",
+    },
+  }]);
+});
+
+test("conversation adapter tracks requests and resolved notifications", () => {
+  const conversations = new Map();
+  const owned = new Set(["thread-adapter"]);
+  const now = () => 42;
+  let update = applyAppServerMessageToConversationState({
+    conversations,
+    now,
+    shouldOwnThread: (threadId) => owned.has(threadId),
+    message: {
+      id: "request-1",
+      method: "item/tool/requestUserInput",
+      params: {
+        threadId: "thread-adapter",
+        turnId: "turn-adapter",
+        itemId: "item-adapter",
+        questions: [{ id: "q1", question: "Continue?" }],
+      },
+    },
+  });
+  assert.deepEqual(update, { threadId: "thread-adapter", changed: true });
+  assert.equal(conversations.get("thread-adapter").requests.length, 1);
+
+  update = applyAppServerMessageToConversationState({
+    conversations,
+    now,
+    shouldOwnThread: (threadId) => owned.has(threadId),
+    message: {
+      method: "serverRequest/resolved",
+      params: {
+        threadId: "thread-adapter",
+        requestId: "request-1",
+      },
+    },
+  });
+  assert.deepEqual(update, { threadId: "thread-adapter", changed: true });
+  assert.equal(conversations.get("thread-adapter").requests.length, 0);
+});
+
+function attachFrameReader(socket, onFrame) {
+  let buffer = Buffer.alloc(0);
+  socket.on("data", (chunk) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    while (buffer.length >= 4) {
+      const frameLength = buffer.readUInt32LE(0);
+      if (buffer.length < 4 + frameLength) {
+        return;
+      }
+      const payload = buffer.slice(4, 4 + frameLength).toString("utf8");
+      buffer = buffer.slice(4 + frameLength);
+      onFrame(JSON.parse(payload));
+    }
+  });
+}
+
+function writeFrame(socket, payload) {
+  const body = Buffer.from(JSON.stringify(payload), "utf8");
+  const header = Buffer.alloc(4);
+  header.writeUInt32LE(body.length, 0);
+  socket.write(Buffer.concat([header, body]));
+}
+
+async function waitForMessage(messages, predicate, timeoutMs = 1_000) {
+  await waitFor(() => messages.find(predicate), timeoutMs);
+  return messages.find(predicate);
+}
+
+async function waitForFrame(socket, predicate, timeoutMs = 1_000) {
+  const frames = [];
+  const onFrame = (frame) => frames.push(frame);
+  attachFrameReader(socket, onFrame);
+  await waitFor(() => frames.find(predicate), timeoutMs);
+  socket.off("data", onFrame);
+  return frames.find(predicate);
+}
+
+async function waitFor(predicate, timeoutMs = 1_000) {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await wait(5);
+  }
+}
+
+function createIpcTestSocket(prefix) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const socketPath = process.platform === "win32"
+    ? `\\\\.\\pipe\\${path.basename(tempDir)}-ipc`
+    : path.join(tempDir, "ipc.sock");
+  return { tempDir, socketPath };
+}


### PR DESCRIPTION
## Summary

- Add Codex Desktop / VSCode IPC live sync for Remodex-owned active threads.
- Broadcast live conversation state as snapshots/patches over the local IPC bus.
- Route Desktop follower actions back to the bridge, including continue, steer, interrupt, approvals, and user input.
- Fix existing Desktop GUI content being replaced when mobile sends a follow-up by hydrating existing threads before the first mobile-owned snapshot.
- Merge hydrated `thread/read` turns with live turns by turn id so existing history and the newest mobile turn are both preserved.

## Tests

- `node --test test/desktop-ipc-live-owner.test.js`
- `npm test` in `phodex-bridge`
- `git diff --check`