### PR TITLE
Restore terminal Copy menu and add native Select text sheet

### DIFF
--- a/CodexMobile/CodexMobile.xcodeproj/project.pbxproj
+++ b/CodexMobile/CodexMobile.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		A4B0C1D2E3F4051627384A0E /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = A4B0C1D2E3F4051627384A0D /* libz.tbd */; };
 		A4B0C1D2E3F4051627384A10 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4B0C1D2E3F4051627384A0F /* UIKit.framework */; };
 		A7D1C9E4B6F84321ABCD1201 /* TerminalPasteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D1C9E4B6F84321ABCD1202 /* TerminalPasteTests.swift */; };
+		BFA160000000000000000001 /* TerminalSelectableTextNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA160000000000000000002 /* TerminalSelectableTextNormalizerTests.swift */; };
 		A9F1B2C3D4E5F60718293A40 /* TurnSkillAutocompleteTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F1B2C3D4E5F60718293A41 /* TurnSkillAutocompleteTokenTests.swift */; };
 		A9F1B2C3D4E5F60718293A42 /* CodexSkillsListDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F1B2C3D4E5F60718293A43 /* CodexSkillsListDecodeTests.swift */; };
 		A9F1B2C3D4E5F60718293A44 /* CodexTurnInputPayloadSkillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F1B2C3D4E5F60718293A45 /* CodexTurnInputPayloadSkillTests.swift */; };
@@ -179,6 +180,7 @@
 		A4B0C1D2E3F4051627384A0D /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		A4B0C1D2E3F4051627384A0F /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		A7D1C9E4B6F84321ABCD1202 /* TerminalPasteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TerminalPasteTests.swift; sourceTree = "<group>"; };
+		BFA160000000000000000002 /* TerminalSelectableTextNormalizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TerminalSelectableTextNormalizerTests.swift; sourceTree = "<group>"; };
 		A932BE773A84EFEA525DF684 /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = CodexMobile/Assets.xcassets; sourceTree = "<group>"; };
 		A9F1B2C3D4E5F60718293A41 /* TurnSkillAutocompleteTokenTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TurnSkillAutocompleteTokenTests.swift; sourceTree = "<group>"; };
 		A9F1B2C3D4E5F60718293A43 /* CodexSkillsListDecodeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodexSkillsListDecodeTests.swift; sourceTree = "<group>"; };
@@ -319,6 +321,7 @@
 				7D4F2A91C8E64B3DA5F67002 /* CodexThreadGitControlScopeTests.swift */,
 				B7A1C2D3E4F5061728394052 /* SidebarThreadGroupingTests.swift */,
 				A7D1C9E4B6F84321ABCD1202 /* TerminalPasteTests.swift */,
+				BFA160000000000000000002 /* TerminalSelectableTextNormalizerTests.swift */,
 				8CE11223A4B5C6D7E8F90124 /* SidebarRunBadgePerformanceTests.swift */,
 				8B4A2F5E7D1C4B9AA1234568 /* TurnComposerAttachmentIntakePlanTests.swift */,
 				74BE370810CFD7A76DC2A25F /* TurnComposerSendAvailabilityTests.swift */,
@@ -734,6 +737,7 @@
 				7D4F2A91C8E64B3DA5F67001 /* CodexThreadGitControlScopeTests.swift in Sources */,
 				B7A1C2D3E4F5061728394051 /* SidebarThreadGroupingTests.swift in Sources */,
 				A7D1C9E4B6F84321ABCD1201 /* TerminalPasteTests.swift in Sources */,
+				BFA160000000000000000001 /* TerminalSelectableTextNormalizerTests.swift in Sources */,
 				8CE11223A4B5C6D7E8F90123 /* SidebarRunBadgePerformanceTests.swift in Sources */,
 				8B4A2F5E7D1C4B9AA1234567 /* TurnComposerAttachmentIntakePlanTests.swift in Sources */,
 				4C0F0D55A5051D8301463C69 /* TurnComposerSendAvailabilityTests.swift in Sources */,

--- a/CodexMobile/CodexMobile/Views/Terminal/GhosttyTerminalSurface.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/GhosttyTerminalSurface.swift
@@ -68,6 +68,17 @@ struct RemodexTerminalTheme: Equatable {
     }
 }
 
+/// Lets SwiftUI callers pull text out of the live UIKit terminal view on
+/// demand (e.g. for the "Select text" sheet) without owning the view itself.
+@MainActor
+final class GhosttyTerminalTextReader {
+    fileprivate weak var view: GhosttyTerminalView?
+
+    func visibleText() -> String? {
+        view?.visibleTextForSelection()
+    }
+}
+
 struct GhosttyTerminalSurface: UIViewRepresentable {
     let terminalKey: String
     let buffer: Data
@@ -77,6 +88,7 @@ struct GhosttyTerminalSurface: UIViewRepresentable {
     let onInput: (Data) -> Void
     let onResize: (Int, Int) -> Void
     var onNativeAvailabilityChanged: ((Bool) -> Void)? = nil
+    var textReader: GhosttyTerminalTextReader? = nil
 
     func makeUIView(context: Context) -> GhosttyTerminalView {
         let view = GhosttyTerminalView()
@@ -99,5 +111,6 @@ struct GhosttyTerminalSurface: UIViewRepresentable {
         view.backgroundColorHex = theme.background
         view.themeConfig = theme.ghosttyConfig
         view.initialBuffer = buffer
+        textReader?.view = view
     }
 }

--- a/CodexMobile/CodexMobile/Views/Terminal/GhosttyTerminalView.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/GhosttyTerminalView.swift
@@ -285,7 +285,7 @@ private final class TerminalSelectionOverlayView: UIView {
     }
 }
 
-final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognizerDelegate {
+final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognizerDelegate, UIEditMenuInteractionDelegate {
     private static let minimumVerticalScrollStepPoints: CGFloat = 18
     private static let verticalScrollStepMultiplier: CGFloat = 1.15
     private static let selectionDragActivationDistance: CGFloat = 10
@@ -301,6 +301,9 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognize
     private let focusTapGesture = UITapGestureRecognizer()
     private let scrollPanGesture = UIPanGestureRecognizer()
     private let selectionLongPressGesture = UILongPressGestureRecognizer()
+    // Created in configureViewHierarchy (not lazy) so teardown paths can never
+    // instantiate a UIKit interaction while the view is deinitializing.
+    private var selectionEditMenuInteraction: UIEditMenuInteraction?
     private var lastViewportSize: CGSize = .zero
     private var lastContentScale: CGFloat = 0
     private var lastReportedGrid: (cols: Int, rows: Int)?
@@ -315,6 +318,8 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognize
     private var handleDragTouchOffset: CGPoint?
     private var selectionGestureStartPoint: CGPoint?
     private var selectionGestureDidDrag = false
+    private var selectedTextForEditMenu = ""
+    private var selectionMenuTargetRect: CGRect?
     private var app: ghostty_app_t?
     private var surface: ghostty_surface_t?
     private var isCreatingSurface = false
@@ -508,6 +513,10 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognize
         selectionLongPressGesture.cancelsTouchesInView = false
         selectionLongPressGesture.delegate = self
         terminalViewport.addGestureRecognizer(selectionLongPressGesture)
+
+        let editMenuInteraction = UIEditMenuInteraction(delegate: self)
+        terminalViewport.addInteraction(editMenuInteraction)
+        selectionEditMenuInteraction = editMenuInteraction
 
         addSubview(terminalViewport)
         addSubview(selectionOverlay)
@@ -710,8 +719,10 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognize
                   let initialRange = wordSelectionRange(at: cell) else { return }
             selectionGestureStartPoint = location
             selectionGestureDidDrag = false
+            selectedTextForEditMenu = ""
             selectionAnchorCell = initialRange.anchor
             selectionFocusCell = initialRange.focus
+            selectionMenuTargetRect = nil
             isSelectingText = true
             updateSelectionOverlay()
             HapticFeedback.shared.triggerImpactFeedback(style: .light)
@@ -727,7 +738,7 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognize
             isSelectingText = false
             selectionGestureStartPoint = nil
             selectionGestureDidDrag = false
-            copyCurrentSelectionToPasteboard()
+            presentCopyMenuIfSelectionExists()
         case .cancelled, .failed:
             clearAppSelection()
         default:
@@ -744,6 +755,30 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognize
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
     ) -> Bool {
         false
+    }
+
+    func editMenuInteraction(
+        _ interaction: UIEditMenuInteraction,
+        menuFor configuration: UIEditMenuConfiguration,
+        suggestedActions: [UIMenuElement]
+    ) -> UIMenu? {
+        guard !selectedTextForEditMenu.isEmpty else { return nil }
+        let copyAction = UIAction(title: "Copy", image: RemodexIcon.menuUIImage(systemName: "doc.on.doc")) { [weak self] _ in
+            self?.copyCurrentSelectionToPasteboard()
+        }
+        return UIMenu(children: [copyAction])
+    }
+
+    func editMenuInteraction(
+        _ interaction: UIEditMenuInteraction,
+        targetRectFor configuration: UIEditMenuConfiguration
+    ) -> CGRect {
+        selectionMenuTargetRect ?? CGRect(
+            x: configuration.sourcePoint.x - 1,
+            y: configuration.sourcePoint.y - max(fontSize * 1.4, 18),
+            width: 2,
+            height: max(fontSize * 1.4, 18)
+        )
     }
 
     private func requestKeyboardFocus() {
@@ -784,13 +819,42 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognize
         )
     }
 
-    // Avoid UIKit's edit menu inside the Ghostty surface; presenting/dismissing
-    // it during route teardown can crash, so selection copies directly.
+    // Reads Ghostty text only when the gesture ends, while UIKit owns the
+    // mobile selection handles/highlight above the renderer. Copies to the
+    // pasteboard immediately, then surfaces the "Copy" menu as visible
+    // confirmation; presentation is skipped when the view is mid-teardown so
+    // the edit menu cannot animate against a dead window (previous crash).
+    private func presentCopyMenuIfSelectionExists() {
+        guard let selectedText = readTextForCurrentSelection(),
+              !selectedText.isEmpty else {
+            clearAppSelection()
+            return
+        }
+
+        selectedTextForEditMenu = selectedText
+        copyCurrentSelectionToPasteboard()
+
+        guard window != nil, canRenderSurface else { return }
+        selectionMenuTargetRect = selectionOverlay.menuTargetRect() ?? terminalViewport.bounds
+        let sourcePoint = CGPoint(x: selectionMenuTargetRect?.midX ?? 0, y: selectionMenuTargetRect?.minY ?? 0)
+        let configuration = UIEditMenuConfiguration(identifier: nil, sourcePoint: sourcePoint)
+        selectionEditMenuInteraction?.presentEditMenu(with: configuration)
+    }
+
+    // Copy uses the captured menu text so live terminal output cannot change
+    // what the user selected while the menu is open.
     private func copyCurrentSelectionToPasteboard() {
-        let latestSelection = readTextForCurrentSelection() ?? ""
+        let latestSelection = selectedTextForEditMenu.isEmpty
+            ? readTextForCurrentSelection() ?? ""
+            : selectedTextForEditMenu
         guard !latestSelection.isEmpty else { return }
         UIPasteboard.general.string = latestSelection
         HapticFeedback.shared.triggerImpactFeedback(style: .light)
+    }
+
+    private func dismissSelectionEditMenu() {
+        guard window != nil else { return }
+        selectionEditMenuInteraction?.dismissMenu()
     }
 
     private func shouldExtendSelectionDrag(to location: CGPoint) -> Bool {
@@ -807,6 +871,7 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognize
     private func updateSelectionFocus(at location: CGPoint) {
         guard let cell = terminalCell(at: location), cell != selectionFocusCell else { return }
         selectionFocusCell = cell
+        selectedTextForEditMenu = ""
         updateSelectionOverlay()
     }
 
@@ -821,6 +886,7 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognize
             guard let metrics = currentSelectionMetrics() else { return }
             let startCell = handle == .start ? currentRange.start : currentRange.end
             let startLocation = handleBoundaryPoint(for: startCell, handle: handle, metrics: metrics)
+            dismissSelectionEditMenu()
             handleDragOppositeCell = handle == .start ? currentRange.end : currentRange.start
             handleDragStartCell = startCell
             handleDragStartLocation = startLocation
@@ -848,6 +914,7 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognize
             selectionFocusCell = cell
         }
 
+        selectedTextForEditMenu = ""
         updateSelectionOverlay()
 
         if state == .ended {
@@ -855,7 +922,7 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognize
             handleDragStartCell = nil
             handleDragStartLocation = nil
             handleDragTouchOffset = nil
-            copyCurrentSelectionToPasteboard()
+            presentCopyMenuIfSelectionExists()
         }
     }
 
@@ -863,12 +930,15 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognize
         selectionOverlay.metrics = currentSelectionMetrics()
         if let selectionRange {
             selectionOverlay.selectionRange = selectionRange
+            selectionMenuTargetRect = selectionOverlay.menuTargetRect()
         } else {
             selectionOverlay.selectionRange = nil
+            selectionMenuTargetRect = nil
         }
     }
 
     private func clearAppSelection() {
+        dismissSelectionEditMenu()
         isSelectingText = false
         selectionAnchorCell = nil
         selectionFocusCell = nil
@@ -878,6 +948,8 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognize
         handleDragTouchOffset = nil
         selectionGestureStartPoint = nil
         selectionGestureDidDrag = false
+        selectedTextForEditMenu = ""
+        selectionMenuTargetRect = nil
         selectionOverlay.selectionRange = nil
     }
 

--- a/CodexMobile/CodexMobile/Views/Terminal/GhosttyTerminalView.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/GhosttyTerminalView.swift
@@ -1268,16 +1268,11 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognize
     /// Plain text of the currently visible grid, with per-line trailing blanks
     /// removed. Backs the "Select text" sheet that offers classic iOS selection.
     func visibleTextForSelection() -> String? {
-        guard let visibleText = readVisibleTerminalText() else { return nil }
-        let lines = visibleText
-            .components(separatedBy: "\n")
-            .map { line -> String in
-                let cleaned = line.replacingOccurrences(of: "\r", with: "")
-                guard let lastVisible = cleaned.lastIndex(where: { $0 != " " }) else { return "" }
-                return String(cleaned[...lastVisible])
-            }
-        let joined = lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
-        return joined.isEmpty ? nil : joined
+        guard let metrics = currentSelectionMetrics(),
+              let visualRows = visibleTerminalRows(metrics: metrics) else { return nil }
+        return TerminalSelectableTextNormalizer.normalizedText(
+            fromLines: visualRows.map(\.text)
+        )
     }
 
     private func readText(for selectionRange: TerminalSelectionRange) -> String? {

--- a/CodexMobile/CodexMobile/Views/Terminal/GhosttyTerminalView.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/GhosttyTerminalView.swift
@@ -1265,6 +1265,21 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIGestureRecognize
         )
     }
 
+    /// Plain text of the currently visible grid, with per-line trailing blanks
+    /// removed. Backs the "Select text" sheet that offers classic iOS selection.
+    func visibleTextForSelection() -> String? {
+        guard let visibleText = readVisibleTerminalText() else { return nil }
+        let lines = visibleText
+            .components(separatedBy: "\n")
+            .map { line -> String in
+                let cleaned = line.replacingOccurrences(of: "\r", with: "")
+                guard let lastVisible = cleaned.lastIndex(where: { $0 != " " }) else { return "" }
+                return String(cleaned[...lastVisible])
+            }
+        let joined = lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        return joined.isEmpty ? nil : joined
+    }
+
     private func readText(for selectionRange: TerminalSelectionRange) -> String? {
         guard let surface else { return nil }
         let normalizedRange = selectionRange.normalized

--- a/CodexMobile/CodexMobile/Views/Terminal/TerminalOptionsMenu.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/TerminalOptionsMenu.swift
@@ -17,6 +17,7 @@ struct TerminalOptionsMenu: View {
     let isRunning: Bool
     let hasConnectionConfiguration: Bool
     let canPaste: Bool
+    let canSelectText: Bool
     let canClear: Bool
     let canResetKnownHost: Bool
     let onSelectSession: (String) -> Void
@@ -24,6 +25,7 @@ struct TerminalOptionsMenu: View {
     let onToggleConnection: () -> Void
     let onOpenConnectionEditor: () -> Void
     let onPaste: () -> Void
+    let onSelectText: () -> Void
     let onClear: () -> Void
     let onResetKnownHost: () -> Void
     let onAdjustFontSize: (Double) -> Void
@@ -105,6 +107,11 @@ struct TerminalOptionsMenu: View {
                 RemodexIcon.menuLabel("Paste", systemName: "doc.on.clipboard")
             }
             .disabled(!canPaste)
+
+            Button(action: onSelectText) {
+                RemodexIcon.menuLabel("Select text", systemName: "text.cursor")
+            }
+            .disabled(!canSelectText)
         }
     }
 

--- a/CodexMobile/CodexMobile/Views/Terminal/TerminalScreen.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/TerminalScreen.swift
@@ -404,8 +404,15 @@ struct TerminalScreen: View {
     }
 
     private func presentSelectableTerminalText() {
-        guard let text = terminalTextReader.visibleText() else { return }
+        guard let text = terminalTextReader.visibleText() ?? fallbackSelectableTerminalText else { return }
         selectableTextState = TerminalSelectableTextState(text: text)
+    }
+
+    private var fallbackSelectableTerminalText: String? {
+        let rawText = String(decoding: activeSnapshot.bufferData, as: UTF8.self)
+        // Prevents a dead menu tap during transient native-view remounts; the
+        // live Ghostty reader remains preferred whenever it is available.
+        return TerminalSelectableTextNormalizer.normalizedText(from: rawText)
     }
 
     private func saveConnectionAndOpen() async {

--- a/CodexMobile/CodexMobile/Views/Terminal/TerminalScreen.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/TerminalScreen.swift
@@ -25,6 +25,8 @@ struct TerminalScreen: View {
     @State private var didApplyPreferredWorkingDirectory = false
     @State private var pendingModifier: TerminalPendingModifier?
     @State private var selectedModifier: TerminalPendingModifier = .ctrl
+    @State private var terminalTextReader = GhosttyTerminalTextReader()
+    @State private var selectableTextState: TerminalSelectableTextState?
     @AppStorage("codex.terminal.fontSize") private var terminalFontSize = remodexTerminalDefaultFontSize
 
     let preferredWorkingDirectory: String?
@@ -195,6 +197,12 @@ struct TerminalScreen: View {
         activeSnapshot.status == .running && UIPasteboard.general.hasStrings
     }
 
+    // The selectable-text sheet mirrors the native Ghostty grid; the fallback
+    // surface already renders selectable SwiftUI text inline.
+    private var canSelectTerminalText: Bool {
+        isNativeTerminalAvailable && !activeSnapshot.bufferData.isEmpty
+    }
+
     var body: some View {
         ZStack {
             Color(hexString: theme.background)
@@ -227,6 +235,7 @@ struct TerminalScreen: View {
                     isRunning: isRunning,
                     hasConnectionConfiguration: hasConnectionConfiguration,
                     canPaste: canPasteIntoActiveTerminal,
+                    canSelectText: canSelectTerminalText,
                     canClear: !activeSnapshot.bufferData.isEmpty,
                     canResetKnownHost: !profileResolvedFromConnection.host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
                     onSelectSession: selectTerminalSession,
@@ -234,6 +243,7 @@ struct TerminalScreen: View {
                     onToggleConnection: toggleTerminalConnection,
                     onOpenConnectionEditor: showConnectionEditor,
                     onPaste: pasteIntoActiveTerminal,
+                    onSelectText: presentSelectableTerminalText,
                     onClear: clearTerminal,
                     onResetKnownHost: resetKnownHost,
                     onAdjustFontSize: adjustFontSize
@@ -253,6 +263,13 @@ struct TerminalScreen: View {
                     onDirectionalInput: sendDirectionalInput
                 )
             }
+        }
+        .sheet(item: $selectableTextState) { state in
+            TerminalSelectableTextSheet(
+                state: state,
+                fontSize: CGFloat(terminalFontSize),
+                theme: theme
+            )
         }
         .sheet(isPresented: $isShowingConnectionEditor) {
             TerminalConnectionEditorSheet(
@@ -301,7 +318,8 @@ struct TerminalScreen: View {
                     onResize: resizeTerminal,
                     onNativeAvailabilityChanged: { isAvailable in
                         isNativeTerminalAvailable = isAvailable
-                    }
+                    },
+                    textReader: terminalTextReader
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 // Keep a small vertical breathing room from the toolbar / accessory bar
@@ -383,6 +401,11 @@ struct TerminalScreen: View {
 
     private func showConnectionEditor() {
         isShowingConnectionEditor = true
+    }
+
+    private func presentSelectableTerminalText() {
+        guard let text = terminalTextReader.visibleText() else { return }
+        selectableTextState = TerminalSelectableTextState(text: text)
     }
 
     private func saveConnectionAndOpen() async {

--- a/CodexMobile/CodexMobile/Views/Terminal/TerminalSelectableTextSheet.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/TerminalSelectableTextSheet.swift
@@ -1,14 +1,36 @@
 // FILE: TerminalSelectableTextSheet.swift
 // Purpose: Presents the visible terminal text as plain text with classic iOS selection.
 // Layer: View Component
-// Exports: TerminalSelectableTextState, TerminalSelectableTextSheet
-// Depends on: SwiftUI, RemodexTerminalTheme
+// Exports: TerminalSelectableTextState, TerminalSelectableTextSheet, TerminalSelectableTextNormalizer
+// Depends on: Foundation, SwiftUI, RemodexTerminalTheme
 
+import Foundation
 import SwiftUI
 
 struct TerminalSelectableTextState: Identifiable {
     let id = UUID()
     let text: String
+}
+
+enum TerminalSelectableTextNormalizer {
+    static func normalizedText(from rawText: String) -> String? {
+        normalizedText(fromLines: rawText.components(separatedBy: "\n"))
+    }
+
+    static func normalizedText(fromLines rawLines: [String]) -> String? {
+        let lines = rawLines.map(cleanedLine)
+        guard let firstContentIndex = lines.firstIndex(where: { !$0.isEmpty }),
+              let lastContentIndex = lines.lastIndex(where: { !$0.isEmpty }) else {
+            return nil
+        }
+        return Array(lines[firstContentIndex...lastContentIndex]).joined(separator: "\n")
+    }
+
+    private static func cleanedLine(_ line: String) -> String {
+        let cleaned = line.replacingOccurrences(of: "\r", with: "")
+        guard let lastVisible = cleaned.lastIndex(where: { $0 != " " }) else { return "" }
+        return String(cleaned[...lastVisible])
+    }
 }
 
 /// Native-selection escape hatch for the GPU-rendered terminal: the Ghostty

--- a/CodexMobile/CodexMobile/Views/Terminal/TerminalSelectableTextSheet.swift
+++ b/CodexMobile/CodexMobile/Views/Terminal/TerminalSelectableTextSheet.swift
@@ -1,0 +1,46 @@
+// FILE: TerminalSelectableTextSheet.swift
+// Purpose: Presents the visible terminal text as plain text with classic iOS selection.
+// Layer: View Component
+// Exports: TerminalSelectableTextState, TerminalSelectableTextSheet
+// Depends on: SwiftUI, RemodexTerminalTheme
+
+import SwiftUI
+
+struct TerminalSelectableTextState: Identifiable {
+    let id = UUID()
+    let text: String
+}
+
+/// Native-selection escape hatch for the GPU-rendered terminal: the Ghostty
+/// surface cannot host UIKit text selection in place, so this sheet mirrors
+/// the visible grid as real text where loupe/handles/Copy all work natively.
+struct TerminalSelectableTextSheet: View {
+    let state: TerminalSelectableTextState
+    let fontSize: CGFloat
+    let theme: RemodexTerminalTheme
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                Text(state.text)
+                    .font(.system(size: max(fontSize, 13), design: .monospaced))
+                    .foregroundStyle(Color(hexString: theme.foreground))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(16)
+            }
+            .background(Color(hexString: theme.background))
+            .navigationTitle("Select Text")
+            .navigationBarTitleDisplayMode(.inline)
+            .adaptiveNavigationBar()
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+}

--- a/CodexMobile/CodexMobileTests/TerminalSelectableTextNormalizerTests.swift
+++ b/CodexMobile/CodexMobileTests/TerminalSelectableTextNormalizerTests.swift
@@ -1,0 +1,34 @@
+// FILE: TerminalSelectableTextNormalizerTests.swift
+// Purpose: Verifies selectable terminal text cleanup preserves visible grid content.
+// Layer: Unit Test
+// Exports: TerminalSelectableTextNormalizerTests
+// Depends on: XCTest, CodexMobile
+
+import XCTest
+@testable import CodexMobile
+
+final class TerminalSelectableTextNormalizerTests: XCTestCase {
+    func testPreservesLeadingIndentationOnFirstContentLine() {
+        let normalized = TerminalSelectableTextNormalizer.normalizedText(
+            fromLines: ["", "    indented command   ", ""]
+        )
+
+        XCTAssertEqual(normalized, "    indented command")
+    }
+
+    func testDropsOnlyEmptyEdgeRows() {
+        let normalized = TerminalSelectableTextNormalizer.normalizedText(
+            fromLines: ["", "first", "", "third", ""]
+        )
+
+        XCTAssertEqual(normalized, "first\n\nthird")
+    }
+
+    func testKeepsVisualRowBreaksFromWrappedTerminalRows() {
+        let normalized = TerminalSelectableTextNormalizer.normalizedText(
+            fromLines: ["long output part one", "part two   "]
+        )
+
+        XCTAssertEqual(normalized, "long output part one\npart two")
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Selection + copy on the SSH terminal stopped being usable. Commit `107fd41` ("Fix composer input scrolling and thumbnail sizing") removed the `UIEditMenuInteraction` from `GhosttyTerminalView` to avoid a crash when the edit menu was presented/dismissed during route teardown. Since then, releasing a long-press selection copies text to the pasteboard silently — no Copy menu, no visible confirmation — so the flow reads as broken.

## Fix 1: restore the visible Copy menu (in-place selection)

`CodexMobile/CodexMobile/Views/Terminal/GhosttyTerminalView.swift`:

- Reintroduce the `UIEditMenuInteraction` with the "Copy" action anchored to the selection rect, for both long-press release and selection-handle drag release.
- Keep the immediate copy-to-pasteboard on gesture end as a safety net, so copy works even if menu presentation is skipped.
- Guard against the original teardown crash:
  - The interaction is created once in `configureViewHierarchy` (not `lazy`), so teardown paths can never instantiate a UIKit interaction mid-deinit.
  - `presentEditMenu` only runs while the view is attached to a window and the renderer is not suspended.
  - `dismissMenu` (from `clearAppSelection`, including the `destroySurface`/deinit path) is skipped when the view has no window.
- Restore the captured-selection semantics: the menu's Copy action reuses the text captured at gesture end, so live terminal output cannot change what gets copied while the menu is open.

## Fix 2: classic iOS text selection via "Select text" sheet

The Ghostty surface is GPU-rendered, so UIKit's native selection (loupe, system handles, edit menu) cannot work in place without implementing the full `UITextInput` protocol over the terminal grid. Instead, this adds the standard terminal-app "copy mode" escape hatch:

- New "Select text" entry in `TerminalOptionsMenu` (clipboard section), enabled when the native surface is active and the buffer is non-empty.
- `GhosttyTerminalView.visibleTextForSelection()` reads the visible grid as plain text via `ghostty_surface_read_text` (no ANSI noise) and strips per-line trailing blanks.
- `GhosttyTerminalTextReader` (in `GhosttyTerminalSurface.swift`) bridges the on-demand text read from SwiftUI to the live UIKit view without owning it.
- New `TerminalSelectableTextSheet` presents that text monospaced on the terminal theme with `.textSelection(.enabled)`, so loupe, handles, Copy, and Select All are fully native — same pattern as the existing `SelectableMessageTextSheet` for chat messages.

## Verification

Inspection-level review (per repo build guardrails, no simulator run for small mobile fixes): the restored menu flow matches the pre-regression implementation from `3ece820` plus lifecycle guards; the sheet reuses the existing selection-read pipeline and app sheet patterns. The project uses Xcode synced folder groups, so the new file needs no pbxproj changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f375c-cc84-7b15-89ad-05d1f010cc65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f375c-cc84-7b15-89ad-05d1f010cc65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

