### PR TITLE
Support markdown rendering in user message bubbles

### DIFF
--- a/CodexMobile/CodexMobile/Views/Turn/Messages/MarkdownTextFormatter.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Messages/MarkdownTextFormatter.swift
@@ -29,15 +29,10 @@ enum MarkdownTextFormatter {
             in: raw,
             style: .displayName
         )
-        let headingNormalized = replaceMatches(
-            in: normalizedSkills,
-            regex: TurnMessageRegexCache.heading,
-            template: "**$1**"
-        )
-        return linkifyFileReferenceLines(in: headingNormalized, profile: profile)
+        return transformLinesOutsideFences(in: normalizedSkills, profile: profile)
     }
 
-    private static func linkifyFileReferenceLines(in text: String, profile: MarkdownRenderProfile) -> String {
+    private static func transformLinesOutsideFences(in text: String, profile: MarkdownRenderProfile) -> String {
         let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
         var isInsideFence = false
 
@@ -48,11 +43,17 @@ enum MarkdownTextFormatter {
                 return line
             }
 
+            // Fenced code stays verbatim: no heading bolding, no linkification.
             guard !isInsideFence else {
                 return line
             }
 
-            return linkifyInlineFileReferences(in: line, profile: profile)
+            let headingNormalized = replaceMatches(
+                in: line,
+                regex: TurnMessageRegexCache.heading,
+                template: "**$1**"
+            )
+            return linkifyInlineFileReferences(in: headingNormalized, profile: profile)
         }
 
         return transformed.joined(separator: "\n")
@@ -62,6 +63,9 @@ enum MarkdownTextFormatter {
         switch profile {
         case .assistantProse, .fileChangeSystem:
             break
+        case .userProse:
+            // User prose renders mentions as chips upstream; typed paths stay literal text.
+            return line
         }
 
         var transformedLine = line

--- a/CodexMobile/CodexMobile/Views/Turn/Messages/MarkdownTextFormatter.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Messages/MarkdownTextFormatter.swift
@@ -34,17 +34,20 @@ enum MarkdownTextFormatter {
 
     private static func transformLinesOutsideFences(in text: String, profile: MarkdownRenderProfile) -> String {
         let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-        var isInsideFence = false
+        var openFenceCloser: String?
 
         let transformed = lines.map { line -> String in
             let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed.hasPrefix("```") {
-                isInsideFence.toggle()
+            if let fenceCloser = openFenceCloser {
+                if trimmed.hasPrefix(fenceCloser) {
+                    openFenceCloser = nil
+                }
                 return line
             }
 
             // Fenced code stays verbatim: no heading bolding, no linkification.
-            guard !isInsideFence else {
+            if let fenceCloser = markdownFenceCloser(for: trimmed) {
+                openFenceCloser = fenceCloser
                 return line
             }
 
@@ -57,6 +60,16 @@ enum MarkdownTextFormatter {
         }
 
         return transformed.joined(separator: "\n")
+    }
+
+    private static func markdownFenceCloser(for trimmedLine: String) -> String? {
+        if trimmedLine.hasPrefix("```") {
+            return "```"
+        }
+        if trimmedLine.hasPrefix("~~~") {
+            return "~~~"
+        }
+        return nil
     }
 
     private static func linkifyInlineFileReferences(in line: String, profile: MarkdownRenderProfile) -> String {

--- a/CodexMobile/CodexMobile/Views/Turn/Messages/TurnMarkdownModels.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Messages/TurnMarkdownModels.swift
@@ -8,6 +8,7 @@ import Foundation
 
 enum MarkdownRenderProfile {
     case assistantProse
+    case userProse
     case fileChangeSystem
 }
 
@@ -16,6 +17,8 @@ extension MarkdownRenderProfile {
         switch self {
         case .assistantProse:
             return "assistantProse"
+        case .userProse:
+            return "userProse"
         case .fileChangeSystem:
             return "fileChangeSystem"
         }

--- a/CodexMobile/CodexMobile/Views/Turn/Messages/TurnMarkdownTextRendering.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Messages/TurnMarkdownTextRendering.swift
@@ -76,6 +76,9 @@ struct MarkdownTextView: View {
     var constrainsToAvailableWidth: Bool = false
     var usesCaches: Bool = true
     var usesScrollableCodeBlocks: Bool = false
+    // Overrides the accent-derived link color, e.g. inside tinted user bubbles
+    // where the accent palette can match the bubble background.
+    var linkColor: Color? = nil
 
     @Environment(\.colorScheme) private var colorScheme
     @AppStorage(UserBubbleColor.storageKey)
@@ -150,6 +153,9 @@ struct MarkdownTextView: View {
     }
 
     private var markdownLinkColor: Color {
+        if let linkColor {
+            return linkColor
+        }
         let palette = (UserBubbleColor(rawValue: userBubbleColorRawValue) ?? .default).ctaPalette
         return palette.bubbleBackground(for: colorScheme)
     }

--- a/CodexMobile/CodexMobile/Views/Turn/Messages/TurnMessageCaches.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Messages/TurnMessageCaches.swift
@@ -390,7 +390,7 @@ enum DiffBlockDetectionCache {
 
     static func isDiffBlock(code: String, profile: MarkdownRenderProfile) -> Bool {
         switch profile {
-        case .assistantProse, .fileChangeSystem:
+        case .assistantProse, .userProse, .fileChangeSystem:
             break
         }
 

--- a/CodexMobile/CodexMobile/Views/Turn/Messages/TurnMessageCaches.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Messages/TurnMessageCaches.swift
@@ -21,6 +21,7 @@ enum TurnCacheManager {
         MarkdownParseCacheReset.reset()
         MarkdownRenderableTextCache.reset()
         UserBubbleRenderModelCache.reset()
+        UserBubbleCollapsedMarkdownPreview.reset()
         MessageRowRenderModelCache.reset()
         CommandExecutionStatusCache.reset()
         ToolActivityRenderCache.reset()

--- a/CodexMobile/CodexMobile/Views/Turn/Messages/UserBubbleInlineMarkdownText.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Messages/UserBubbleInlineMarkdownText.swift
@@ -1,8 +1,9 @@
 // FILE: UserBubbleInlineMarkdownText.swift
 // Purpose: Renders lightweight inline markdown inside user prompt bubbles.
 // Layer: View Support
-// Exports: UserBubbleInlineMarkdownText, UserBubbleInlineMarkdownRenderer, UserBubbleBlockMarkdownDetector
-// Depends on: Foundation, SwiftUI, TurnMessageCacheCore, TurnMessageRegexCache
+// Exports: UserBubbleInlineMarkdownText, UserBubbleInlineMarkdownRenderer, UserBubbleBlockMarkdownDetector,
+//   UserBubbleCollapsedMarkdownPreview
+// Depends on: Foundation, SwiftUI, TurnMessageCacheCore, TurnMessageRegexCache, StreamingInlineMarkupAutoCloser
 
 import Foundation
 import SwiftUI
@@ -82,6 +83,95 @@ enum UserBubbleBlockMarkdownDetector {
             return false
         }
         return line.allSatisfy { $0 == marker }
+    }
+}
+
+// Collapsed block-markdown bubbles render only this bounded prefix, so a long
+// paste never pays full StructuredText layout just to be clipped to ~10 lines.
+enum UserBubbleCollapsedMarkdownPreview {
+    private static let cache = BoundedCache<String, String>(maxEntries: 256)
+    private static let maxLines = 10
+    private static let maxCharacters = 1_200
+
+    static func previewText(for rawText: String) -> String {
+        guard needsTruncation(rawText) else {
+            return rawText
+        }
+
+        let key = TurnTextCacheKey.stableKey(namespace: "user-bubble-collapsed-preview", text: rawText)
+        return cache.getOrSet(key) {
+            truncatedPreview(from: rawText)
+        }
+    }
+
+    static func reset() {
+        cache.removeAll()
+    }
+
+    // Bounded scan; text within both limits is already its own preview.
+    private static func needsTruncation(_ rawText: String) -> Bool {
+        var characterCount = 0
+        var newlineCount = 0
+        for character in rawText {
+            characterCount += 1
+            if characterCount > maxCharacters {
+                return true
+            }
+            if character == "\n" {
+                newlineCount += 1
+                if newlineCount >= maxLines {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    private static func truncatedPreview(from rawText: String) -> String {
+        var openFenceCloser: String?
+        var includedLines = 0
+        var remainingCharacters = maxCharacters
+        var cutIndex = rawText.endIndex
+        var lineStart = rawText.startIndex
+
+        while lineStart < rawText.endIndex {
+            let lineEnd = rawText[lineStart...].firstIndex(of: "\n") ?? rawText.endIndex
+            let line = rawText[lineStart..<lineEnd]
+
+            if let budgetIndex = line.index(line.startIndex, offsetBy: remainingCharacters, limitedBy: line.endIndex),
+               budgetIndex < line.endIndex {
+                // Single overlong line (minified pastes): cut mid-line at the budget.
+                cutIndex = budgetIndex
+                break
+            }
+
+            // A tilde fence is only closed by tildes, so remember which closer is owed.
+            let content = line.drop(while: { $0 == " " || $0 == "\t" })
+            if let fenceCloser = openFenceCloser {
+                if content.hasPrefix(fenceCloser) {
+                    openFenceCloser = nil
+                }
+            } else if content.hasPrefix("```") {
+                openFenceCloser = "```"
+            } else if content.hasPrefix("~~~") {
+                openFenceCloser = "~~~"
+            }
+
+            includedLines += 1
+            remainingCharacters -= line.count + 1
+            if includedLines >= maxLines || remainingCharacters <= 0 {
+                cutIndex = lineEnd
+                break
+            }
+            lineStart = lineEnd < rawText.endIndex ? rawText.index(after: lineEnd) : rawText.endIndex
+        }
+
+        let preview = String(rawText[..<cutIndex])
+        if let openFenceCloser {
+            // An unterminated fence would swallow the rest of the preview's styling.
+            return preview + "\n" + openFenceCloser
+        }
+        return StreamingInlineMarkupAutoCloser.autoClosed(preview)
     }
 }
 

--- a/CodexMobile/CodexMobile/Views/Turn/Messages/UserBubbleInlineMarkdownText.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Messages/UserBubbleInlineMarkdownText.swift
@@ -1,7 +1,7 @@
 // FILE: UserBubbleInlineMarkdownText.swift
 // Purpose: Renders lightweight inline markdown inside user prompt bubbles.
 // Layer: View Support
-// Exports: UserBubbleInlineMarkdownText, UserBubbleInlineMarkdownRenderer
+// Exports: UserBubbleInlineMarkdownText, UserBubbleInlineMarkdownRenderer, UserBubbleBlockMarkdownDetector
 // Depends on: Foundation, SwiftUI, TurnMessageCacheCore, TurnMessageRegexCache
 
 import Foundation
@@ -32,6 +32,57 @@ struct UserBubbleInlineMarkdownText: View {
 enum UserBubbleInlineMarkdownRenderResult {
     case plain
     case rich(AttributedString)
+}
+
+// Detects block-level markdown the inline renderer cannot express; those user
+// messages take the shared MarkdownTextView pipeline used by assistant rows.
+enum UserBubbleBlockMarkdownDetector {
+    static func containsBlockMarkdown(_ rawText: String) -> Bool {
+        if rawText.contains("```") || rawText.contains("~~~") {
+            return true
+        }
+
+        return rawText
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .contains { isBlockSyntaxLine($0.drop(while: { $0 == " " || $0 == "\t" })) }
+    }
+
+    private static func isBlockSyntaxLine(_ line: Substring) -> Bool {
+        guard let first = line.first else {
+            return false
+        }
+
+        switch first {
+        case "#":
+            let hashes = line.prefix(while: { $0 == "#" })
+            return hashes.count <= 6 && line.dropFirst(hashes.count).first == " "
+        case "-", "*", "+":
+            return line.dropFirst().first == " " || isThematicBreak(line)
+        case ">":
+            return true
+        case "|":
+            return line.dropFirst().contains("|")
+        default:
+            return isOrderedListItem(line)
+        }
+    }
+
+    private static func isOrderedListItem(_ line: Substring) -> Bool {
+        let digits = line.prefix(while: { $0.isASCII && $0.isNumber })
+        guard !digits.isEmpty, digits.count <= 3 else {
+            return false
+        }
+
+        let rest = line.dropFirst(digits.count)
+        return rest.hasPrefix(". ") || rest.hasPrefix(") ")
+    }
+
+    private static func isThematicBreak(_ line: Substring) -> Bool {
+        guard let marker = line.first, line.count >= 3 else {
+            return false
+        }
+        return line.allSatisfy { $0 == marker }
+    }
 }
 
 enum UserBubbleInlineMarkdownRenderer {

--- a/CodexMobile/CodexMobile/Views/Turn/Messages/UserBubbleTextBlock.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Messages/UserBubbleTextBlock.swift
@@ -2,9 +2,10 @@
 // Purpose: Collapses long user messages without making MessageRow own the state.
 // Layer: View Component
 // Exports: UserBubbleTextBlock
-// Depends on: SwiftUI
+// Depends on: SwiftUI, UIKit
 
 import SwiftUI
+import UIKit
 
 struct UserBubbleTextBlock<Content: View>: View {
     private static var collapseLineLimit: Int { 10 }
@@ -14,6 +15,9 @@ struct UserBubbleTextBlock<Content: View>: View {
     let contentIdentity: String
     let rawText: String
     var contentResetKey: String? = nil
+    // Block markdown renders through StructuredText, which opts out of lineLimit;
+    // those bubbles collapse by capping the rendered height instead.
+    var collapsesWithLineLimit: Bool = true
     @ViewBuilder let content: () -> Content
 
     @State private var isExpanded = false
@@ -40,10 +44,15 @@ struct UserBubbleTextBlock<Content: View>: View {
         "\(contentIdentity)|\(contentResetKey ?? TurnTextCacheKey.stableFingerprint(for: rawText))"
     }
 
+    // Follows Dynamic Type so the height-capped collapse shows roughly the same
+    // amount of content as the lineLimit-based one.
+    private static var collapsedContentMaxHeight: CGFloat {
+        UIFont.preferredFont(forTextStyle: .body).lineHeight * CGFloat(collapseLineLimit)
+    }
+
     var body: some View {
         VStack(alignment: .trailing, spacing: 4) {
-            content()
-                .lineLimit(canCollapse ? (isExpanded ? nil : Self.collapseLineLimit) : nil)
+            collapsibleContent
 
             if canCollapse {
                 Button(isExpanded ? "Show less" : "Show more") {
@@ -58,6 +67,21 @@ struct UserBubbleTextBlock<Content: View>: View {
         }
         .onChange(of: collapseResetKey) { _, _ in
             isExpanded = false
+        }
+    }
+
+    @ViewBuilder
+    private var collapsibleContent: some View {
+        let isCollapsed = canCollapse && !isExpanded
+        if collapsesWithLineLimit {
+            content()
+                .lineLimit(isCollapsed ? Self.collapseLineLimit : nil)
+        } else {
+            content()
+                .frame(maxHeight: isCollapsed ? Self.collapsedContentMaxHeight : nil, alignment: .top)
+                .clipped()
+                // Clipped overflow still hit-tests; disable taps until expanded.
+                .allowsHitTesting(!isCollapsed)
         }
     }
 }

--- a/CodexMobile/CodexMobile/Views/Turn/Messages/UserBubbleTextBlock.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Messages/UserBubbleTextBlock.swift
@@ -18,7 +18,8 @@ struct UserBubbleTextBlock<Content: View>: View {
     // Block markdown renders through StructuredText, which opts out of lineLimit;
     // those bubbles collapse by capping the rendered height instead.
     var collapsesWithLineLimit: Bool = true
-    @ViewBuilder let content: () -> Content
+    // Receives the collapsed state so callers can render a cheaper preview while collapsed.
+    @ViewBuilder let content: (_ isCollapsed: Bool) -> Content
 
     @State private var isExpanded = false
 
@@ -74,10 +75,10 @@ struct UserBubbleTextBlock<Content: View>: View {
     private var collapsibleContent: some View {
         let isCollapsed = canCollapse && !isExpanded
         if collapsesWithLineLimit {
-            content()
+            content(isCollapsed)
                 .lineLimit(isCollapsed ? Self.collapseLineLimit : nil)
         } else {
-            content()
+            content(isCollapsed)
                 .frame(maxHeight: isCollapsed ? Self.collapsedContentMaxHeight : nil, alignment: .top)
                 .clipped()
                 // Clipped overflow still hit-tests; disable taps until expanded.

--- a/CodexMobile/CodexMobile/Views/Turn/Messages/UserMessageBubble.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Messages/UserMessageBubble.swift
@@ -122,15 +122,15 @@ struct UserMessageBubble: View {
     @ViewBuilder
     private func userBubbleTextContent(_ renderModel: UserBubbleRenderModel, bubbleColor: UserBubbleColor) -> some View {
         if isProgressiveTextWindow {
-            userBubbleText(renderModel, bubbleColor: bubbleColor)
+            userBubbleText(renderModel, bubbleColor: bubbleColor, isCollapsed: false)
         } else {
             UserBubbleTextBlock(
                 contentIdentity: message.id,
                 rawText: renderModel.text,
                 contentResetKey: renderModel.textFingerprint,
                 collapsesWithLineLimit: !renderModel.usesBlockMarkdown
-            ) {
-                userBubbleText(renderModel, bubbleColor: bubbleColor)
+            ) { isCollapsed in
+                userBubbleText(renderModel, bubbleColor: bubbleColor, isCollapsed: isCollapsed)
             }
         }
     }
@@ -138,11 +138,19 @@ struct UserMessageBubble: View {
     // Simple prompts keep the lightweight inline renderer; block-level markdown
     // (fences, headings, lists, quotes, tables) takes the assistant pipeline.
     @ViewBuilder
-    private func userBubbleText(_ renderModel: UserBubbleRenderModel, bubbleColor: UserBubbleColor) -> some View {
+    private func userBubbleText(
+        _ renderModel: UserBubbleRenderModel,
+        bubbleColor: UserBubbleColor,
+        isCollapsed: Bool
+    ) -> some View {
         let foreground = userBubbleForeground(for: bubbleColor)
         if renderModel.usesBlockMarkdown {
+            // While collapsed, lay out only a bounded preview instead of the full
+            // message clipped to bubble height; expanding renders the full text.
             MarkdownTextView(
-                text: renderModel.text,
+                text: isCollapsed
+                    ? UserBubbleCollapsedMarkdownPreview.previewText(for: renderModel.text)
+                    : renderModel.text,
                 profile: .userProse,
                 constrainsToAvailableWidth: true,
                 linkColor: foreground

--- a/CodexMobile/CodexMobile/Views/Turn/Messages/UserMessageBubble.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Messages/UserMessageBubble.swift
@@ -122,24 +122,37 @@ struct UserMessageBubble: View {
     @ViewBuilder
     private func userBubbleTextContent(_ renderModel: UserBubbleRenderModel, bubbleColor: UserBubbleColor) -> some View {
         if isProgressiveTextWindow {
-            userBubbleText(renderModel.text, bubbleColor: bubbleColor)
+            userBubbleText(renderModel, bubbleColor: bubbleColor)
         } else {
             UserBubbleTextBlock(
                 contentIdentity: message.id,
                 rawText: renderModel.text,
-                contentResetKey: renderModel.textFingerprint
+                contentResetKey: renderModel.textFingerprint,
+                collapsesWithLineLimit: !renderModel.usesBlockMarkdown
             ) {
-                userBubbleText(renderModel.text, bubbleColor: bubbleColor)
+                userBubbleText(renderModel, bubbleColor: bubbleColor)
             }
         }
     }
 
-    private func userBubbleText(_ rawText: String, bubbleColor: UserBubbleColor) -> some View {
-        UserBubbleInlineMarkdownText(
-            rawText,
-            foreground: userBubbleForeground(for: bubbleColor)
-        )
-            .font(AppFont.body())
+    // Simple prompts keep the lightweight inline renderer; block-level markdown
+    // (fences, headings, lists, quotes, tables) takes the assistant pipeline.
+    @ViewBuilder
+    private func userBubbleText(_ renderModel: UserBubbleRenderModel, bubbleColor: UserBubbleColor) -> some View {
+        let foreground = userBubbleForeground(for: bubbleColor)
+        if renderModel.usesBlockMarkdown {
+            MarkdownTextView(
+                text: renderModel.text,
+                profile: .userProse,
+                constrainsToAvailableWidth: true,
+                linkColor: foreground
+            )
+            .foregroundStyle(foreground)
+            .tint(foreground)
+        } else {
+            UserBubbleInlineMarkdownText(renderModel.text, foreground: foreground)
+                .font(AppFont.body())
+        }
     }
 }
 
@@ -147,6 +160,7 @@ private struct UserBubbleRenderModel: Equatable {
     let text: String
     let textFingerprint: String
     let chips: [TurnMentionChipRef]
+    let usesBlockMarkdown: Bool
 }
 
 enum UserBubbleRenderModelCache {
@@ -266,7 +280,8 @@ private enum UserBubbleMentionExtractor {
         return UserBubbleRenderModel(
             text: displayText,
             textFingerprint: TurnTextCacheKey.stableFingerprint(for: displayText),
-            chips: chips
+            chips: chips,
+            usesBlockMarkdown: UserBubbleBlockMarkdownDetector.containsBlockMarkdown(displayText)
         )
     }
 
@@ -396,6 +411,25 @@ private struct UserBubblePreviewCatalog: View {
                         skillMentions: ["frontend-design"],
                         actionText: "/review run on local changes $frontend-design",
                         bubbleColor: .blue
+                    )
+                }
+
+                previewSection("Block markdown") {
+                    bubblePreview(
+                        text: """
+                        Fix this snippet:
+
+                        ```swift
+                        // TODO: guard against nil
+                        let value = cache[key]!
+                        ```
+
+                        Then check:
+                        - the reconnect path
+                        - the pairing flow
+                        """,
+                        actionText: "Fix this snippet",
+                        bubbleColor: .green
                     )
                 }
             }

--- a/CodexMobile/CodexMobileTests/TurnMessageCachesTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnMessageCachesTests.swift
@@ -61,6 +61,37 @@ final class TurnMessageCachesTests: XCTestCase {
         )
     }
 
+    func testMarkdownFormatterKeepsFencedCodeVerbatim() {
+        let raw = """
+        # Steps
+
+        ```bash
+        # install deps
+        npm install
+        ```
+        """
+
+        let rendered = MarkdownTextFormatter.renderableText(
+            from: raw,
+            profile: .assistantProse,
+            usesCache: false
+        )
+
+        XCTAssertTrue(rendered.hasPrefix("**Steps**"))
+        XCTAssertTrue(rendered.contains("# install deps"))
+        XCTAssertFalse(rendered.contains("**install deps**"))
+    }
+
+    func testMarkdownFormatterUserProseSkipsFilePathLinkification() {
+        let rendered = MarkdownTextFormatter.renderableText(
+            from: "please check `phodex-bridge/test/secure-transport.test.js` again",
+            profile: .userProse,
+            usesCache: false
+        )
+
+        XCTAssertEqual(rendered, "please check `phodex-bridge/test/secure-transport.test.js` again")
+    }
+
     func testStableTextFingerprintChangesForUnsampledTextEdits() {
         let prefix = String(repeating: "a", count: 48)
         let suffix = String(repeating: "z", count: 48)

--- a/CodexMobile/CodexMobileTests/TurnMessageCachesTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnMessageCachesTests.swift
@@ -82,6 +82,27 @@ final class TurnMessageCachesTests: XCTestCase {
         XCTAssertFalse(rendered.contains("**install deps**"))
     }
 
+    func testMarkdownFormatterKeepsTildeFencedCodeVerbatim() {
+        let raw = """
+        # Steps
+
+        ~~~bash
+        # install deps
+        npm install
+        ~~~
+        """
+
+        let rendered = MarkdownTextFormatter.renderableText(
+            from: raw,
+            profile: .userProse,
+            usesCache: false
+        )
+
+        XCTAssertTrue(rendered.hasPrefix("**Steps**"))
+        XCTAssertTrue(rendered.contains("# install deps"))
+        XCTAssertFalse(rendered.contains("**install deps**"))
+    }
+
     func testMarkdownFormatterUserProseSkipsFilePathLinkification() {
         let rendered = MarkdownTextFormatter.renderableText(
             from: "please check `phodex-bridge/test/secure-transport.test.js` again",

--- a/CodexMobile/CodexMobileTests/UserBubbleInlineMarkdownRendererTests.swift
+++ b/CodexMobile/CodexMobileTests/UserBubbleInlineMarkdownRendererTests.swift
@@ -90,6 +90,42 @@ final class UserBubbleInlineMarkdownRendererTests: XCTestCase {
         XCTAssertTrue(UserBubbleBlockMarkdownDetector.containsBlockMarkdown("> quoted reply"))
         XCTAssertTrue(UserBubbleBlockMarkdownDetector.containsBlockMarkdown("| a | b |\n| - | - |"))
     }
+
+    // MARK: - Collapsed markdown preview
+
+    func testCollapsedPreviewKeepsShortTextVerbatim() {
+        let text = "fix this:\n```swift\nlet x = 1\n```"
+
+        XCTAssertEqual(UserBubbleCollapsedMarkdownPreview.previewText(for: text), text)
+    }
+
+    func testCollapsedPreviewTruncatesLongTextAndClosesOpenFence() {
+        let codeLines = (1...40).map { "let value\($0) = \($0)" }.joined(separator: "\n")
+        let text = "fix this:\n```swift\n" + codeLines + "\n```"
+
+        let preview = UserBubbleCollapsedMarkdownPreview.previewText(for: text)
+
+        XCTAssertLessThan(preview.count, text.count)
+        XCTAssertTrue(preview.hasSuffix("\n```"))
+        XCTAssertFalse(preview.contains("value40"))
+    }
+
+    func testCollapsedPreviewCutsSingleOverlongLineAtCharacterBudget() {
+        let text = "```\n" + String(repeating: "x", count: 5_000)
+
+        let preview = UserBubbleCollapsedMarkdownPreview.previewText(for: text)
+
+        XCTAssertLessThan(preview.count, 1_300)
+        XCTAssertTrue(preview.hasSuffix("\n```"))
+    }
+
+    func testCollapsedPreviewClosesOpenInlineMarkup() {
+        let lines = ["- **important start", "plain line"] + (1...12).map { "line \($0)" }
+        let preview = UserBubbleCollapsedMarkdownPreview.previewText(for: lines.joined(separator: "\n"))
+
+        XCTAssertLessThan(preview.count, lines.joined(separator: "\n").count)
+        XCTAssertTrue(preview.hasSuffix("**"))
+    }
 }
 
 private extension UserBubbleInlineMarkdownRenderResult {

--- a/CodexMobile/CodexMobileTests/UserBubbleInlineMarkdownRendererTests.swift
+++ b/CodexMobile/CodexMobileTests/UserBubbleInlineMarkdownRendererTests.swift
@@ -65,6 +65,31 @@ final class UserBubbleInlineMarkdownRendererTests: XCTestCase {
 
         XCTAssertFalse(rendered.visibleText.isEmpty)
     }
+
+    // MARK: - Block markdown detection
+
+    func testPlainAndInlineOnlyTextIsNotBlockMarkdown() {
+        XCTAssertFalse(UserBubbleBlockMarkdownDetector.containsBlockMarkdown("is this safe to merge?"))
+        XCTAssertFalse(UserBubbleBlockMarkdownDetector.containsBlockMarkdown("Use **bold** and `code` here."))
+        XCTAssertFalse(UserBubbleBlockMarkdownDetector.containsBlockMarkdown("run ls *.swift"))
+        XCTAssertFalse(UserBubbleBlockMarkdownDetector.containsBlockMarkdown("*.swift files only"))
+        XCTAssertFalse(UserBubbleBlockMarkdownDetector.containsBlockMarkdown("the answer is 10. maybe 11"))
+        XCTAssertFalse(UserBubbleBlockMarkdownDetector.containsBlockMarkdown("#hashtag without space"))
+    }
+
+    func testFencedCodeIsBlockMarkdown() {
+        XCTAssertTrue(
+            UserBubbleBlockMarkdownDetector.containsBlockMarkdown("fix this:\n```swift\nlet x = 1\n```")
+        )
+    }
+
+    func testHeadingListQuoteAndTableAreBlockMarkdown() {
+        XCTAssertTrue(UserBubbleBlockMarkdownDetector.containsBlockMarkdown("# Plan\nreview the diff"))
+        XCTAssertTrue(UserBubbleBlockMarkdownDetector.containsBlockMarkdown("check:\n- reconnect\n- pairing"))
+        XCTAssertTrue(UserBubbleBlockMarkdownDetector.containsBlockMarkdown("steps:\n1. build\n2. run"))
+        XCTAssertTrue(UserBubbleBlockMarkdownDetector.containsBlockMarkdown("> quoted reply"))
+        XCTAssertTrue(UserBubbleBlockMarkdownDetector.containsBlockMarkdown("| a | b |\n| - | - |"))
+    }
 }
 
 private extension UserBubbleInlineMarkdownRenderResult {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

User bubbles now render markdown like assistant messages. Prompts containing block-level markdown (code fences, headings, lists, block quotes, tables, thematic breaks) go through the same `MarkdownTextView`/`StructuredText` pipeline assistant rows use; simple prompts keep the existing lightweight inline renderer (bold/italic/code/links) so the common path stays cheap.

## Changes

- **`UserBubbleBlockMarkdownDetector`** (`UserBubbleInlineMarkdownText.swift`): fast line-scan that decides when a user message needs block rendering; the result is cached in the existing `UserBubbleRenderModel`.
- **`.userProse` render profile** (`TurnMarkdownModels.swift`, `MarkdownTextFormatter.swift`): reuses the assistant markdown cleanup (skill refs, heading normalization) but keeps typed file paths literal, since user file mentions already render as chips.
- **`UserMessageBubble`**: block-markdown messages render via `MarkdownTextView(profile: .userProse)` with the bubble foreground applied and links tinted to the bubble foreground (the default accent-derived link color can match a tinted bubble background). Inline/plain messages are unchanged.
- **`MarkdownTextView`**: new optional `linkColor` override for the inline link style.
- **`UserBubbleTextBlock`**: block markdown ignores `lineLimit` (`StructuredText` opts out), so those bubbles collapse by capping rendered height (Dynamic Type–aware, ~10 body lines) with clipping and hit-testing disabled while collapsed; "Show more/less" behavior is unchanged.
- **`UserBubbleCollapsedMarkdownPreview`**: while collapsed, block-markdown bubbles lay out only a bounded, cached prefix (10 lines / 1,200 chars, open fences closed, dangling inline markup auto-closed via `StreamingInlineMarkupAutoCloser`) instead of the full message clipped visually — so long pastes never pay full `StructuredText` layout on row mount. Expanding renders the full text.
- **Formatter fix**: heading normalization now runs inside the existing fence-aware line walk, so `#` comments inside fenced code are no longer bolded (benefits assistant rows too).

## Performance notes

- Plain and inline-only messages are untouched (same fast path, zero added cost).
- Block detection is one linear scan per message revision, cached in `UserBubbleRenderModel`.
- Block-markdown bubbles reuse the assistant pipeline's bounded caches (`MarkdownRenderableTextCache`, `CachingMarkdownParser`); user messages don't stream, so nothing re-parses per frame.
- Collapsed layout cost is proportional to the visible preview, not the full message; the preview cache participates in `TurnCacheManager.resetAll()`.

## Testing

- Extended `UserBubbleInlineMarkdownRendererTests` with block-detection cases and collapsed-preview cases (verbatim short text, fence truncation + closing, overlong single-line cut, inline markup auto-close).
- Extended `TurnMessageCachesTests` with formatter coverage: fenced code stays verbatim, `.userProse` skips file-path linkification, `.assistantProse` linkification unchanged.
- Verified formatter + detector + preview logic on Linux with a Swift 6.1 harness compiling the real sources (36/36 checks pass) and syntax-parsed all edited files. Xcode build/tests not run here (Linux CI VM; per repo guardrails tests are not run unless requested).
- Added a "Block markdown" case to the `UserMessageBubble` preview catalog for visual verification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3784-83e6-73e2-be3f-c402123a48fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3784-83e6-73e2-be3f-c402123a48fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

