### PR TITLE
Collapse finished command execution rows

### DIFF
--- a/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineBlockAccessories.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineBlockAccessories.swift
@@ -275,6 +275,8 @@ extension TurnTimelineView {
                 ids.insert(message.id)
             case .toolBurst(let group):
                 ids.formUnion(group.visibleMessages.map(\.id))
+            case .commandGroup:
+                break
             case .previousMessages:
                 break
             }

--- a/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineRenderProjection.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineRenderProjection.swift
@@ -52,9 +52,24 @@ struct TurnTimelinePreviousMessagesGroup: Identifiable, Equatable {
     }
 }
 
+struct TurnTimelineCommandGroup: Identifiable, Equatable {
+    let id: String
+    let messages: [CodexMessage]
+
+    init(messages: [CodexMessage]) {
+        self.messages = messages
+        self.id = "command-group:\(messages.first?.id ?? "unknown")"
+    }
+
+    var commandCount: Int {
+        messages.count
+    }
+}
+
 enum TurnTimelineRenderItem: Identifiable, Equatable {
     case message(CodexMessage)
     case toolBurst(TurnTimelineToolBurstGroup)
+    case commandGroup(TurnTimelineCommandGroup)
     case previousMessages(TurnTimelinePreviousMessagesGroup)
 
     var id: String {
@@ -62,6 +77,8 @@ enum TurnTimelineRenderItem: Identifiable, Equatable {
         case .message(let message):
             return message.id
         case .toolBurst(let group):
+            return group.id
+        case .commandGroup(let group):
             return group.id
         case .previousMessages(let group):
             return group.id
@@ -85,6 +102,7 @@ enum TurnTimelineRenderProjection {
     ) -> [TurnTimelineRenderItem] {
         var items: [TurnTimelineRenderItem] = []
         var bufferedToolMessages: [CodexMessage] = []
+        var bufferedCommandMessages: [CodexMessage] = []
         let fileChangePlan = fileChangeCollapsePlan(in: messages)
         let finalCollapsePlan = previousMessagesCollapsePlan(
             in: messages,
@@ -111,9 +129,16 @@ enum TurnTimelineRenderProjection {
             bufferedToolMessages.removeAll(keepingCapacity: true)
         }
 
+        func flushBufferedCommandMessages() {
+            guard !bufferedCommandMessages.isEmpty else { return }
+            items.append(.commandGroup(TurnTimelineCommandGroup(messages: bufferedCommandMessages)))
+            bufferedCommandMessages.removeAll(keepingCapacity: true)
+        }
+
         for (index, message) in messages.enumerated() {
             if let group = groupByInsertionIndex[index] {
                 flushBufferedToolMessages()
+                flushBufferedCommandMessages()
                 if group.group.hiddenCount > 0 {
                     items.append(.previousMessages(group.group))
                 }
@@ -133,10 +158,22 @@ enum TurnTimelineRenderProjection {
             }
             guard isToolBurstCandidate(message) else {
                 flushBufferedToolMessages()
+                flushBufferedCommandMessages()
                 items.append(.message(renderedMessage))
                 continue
             }
 
+            guard !isFinishedCommandGroupCandidate(renderedMessage) else {
+                flushBufferedToolMessages()
+                if let previous = bufferedCommandMessages.last,
+                   !canShareToolBurst(previous: previous, incoming: renderedMessage) {
+                    flushBufferedCommandMessages()
+                }
+                bufferedCommandMessages.append(renderedMessage)
+                continue
+            }
+
+            flushBufferedCommandMessages()
             if let previous = bufferedToolMessages.last,
                !canShareToolBurst(previous: previous, incoming: renderedMessage) {
                 flushBufferedToolMessages()
@@ -145,6 +182,7 @@ enum TurnTimelineRenderProjection {
         }
 
         flushBufferedToolMessages()
+        flushBufferedCommandMessages()
         return mergeAdjacentFileChangeItems(items)
     }
 
@@ -468,7 +506,9 @@ enum TurnTimelineRenderProjection {
                 return true
             case .plan:
                 return message.shouldDisplayInlinePlanResult
-            case .thinking, .toolActivity, .commandExecution, .chat:
+            case .commandExecution:
+                return isFinishedCommandGroupCandidate(message)
+            case .thinking, .toolActivity, .chat:
                 return false
             }
         }
@@ -709,6 +749,26 @@ enum TurnTimelineRenderProjection {
         case .thinking, .chat, .plan, .userInputPrompt, .fileChange, .subagentAction:
             return false
         }
+    }
+
+    private static func isFinishedCommandGroupCandidate(_ message: CodexMessage) -> Bool {
+        guard message.role == .system,
+              message.kind == .commandExecution,
+              !message.isStreaming else {
+            return false
+        }
+
+        guard let firstWord = message.text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: \.isWhitespace)
+            .first?
+            .lowercased() else {
+            return false
+        }
+
+        return firstWord == "completed"
+            || firstWord == "failed"
+            || firstWord == "stopped"
     }
 
     // Late turn ids can arrive mid-stream, so split only when both rows already

--- a/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineRows.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Timeline/TurnTimelineRows.swift
@@ -372,6 +372,80 @@ private struct TurnTimelinePreviousMessagesView: View {
     }
 }
 
+private struct TurnTimelineCommandGroupView: View {
+    let group: TurnTimelineCommandGroup
+    let isRetryAvailable: Bool
+    let cachedBlockInfoByMessageID: [String: AssistantBlockAccessoryState]
+    let planSessionSource: CodexPlanSessionSource?
+    let allowsAssistantPlanFallbackRecovery: Bool
+    let completedTurnIDs: Set<String>
+    let threadMessagesForPlanMatching: [CodexMessage]
+    let currentWorkingDirectory: String?
+    let planMatchingFingerprint: Int
+    let newestStreamingMessageID: String?
+    let autoScrollMode: TurnAutoScrollMode
+    let showsGlobalRunningIndicator: Bool
+    let onRetryUserMessage: (String) -> Void
+    let onTapAssistantRevert: (CodexMessage) -> Void
+    let onTapSubagent: (CodexSubagentThreadPresentation) -> Void
+
+    @State private var isExpanded = false
+
+    private var title: String {
+        group.commandCount == 1 ? "Ran 1 command" : "Ran \(group.commandCount) commands"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.18)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    RemodexIcon.image(systemName: "terminal", size: 14, relativeTo: .body)
+                        .foregroundStyle(.secondary)
+                    Text(title)
+                        .font(AppFont.body(weight: .regular))
+                        .foregroundStyle(.secondary)
+                    RemodexIcon.image(systemName: "chevron.right", size: 13, relativeTo: .body)
+                        .foregroundStyle(.secondary)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    Spacer(minLength: 0)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(title)
+            .accessibilityHint(isExpanded ? "Collapse commands" : "Expand commands")
+
+            if isExpanded {
+                ForEach(group.messages) { message in
+                    TurnTimelineMessageRow(
+                        message: message,
+                        isRetryAvailable: isRetryAvailable,
+                        cachedBlockInfoByMessageID: cachedBlockInfoByMessageID,
+                        planSessionSource: planSessionSource,
+                        allowsAssistantPlanFallbackRecovery: allowsAssistantPlanFallbackRecovery,
+                        completedTurnIDs: completedTurnIDs,
+                        threadMessagesForPlanMatching: threadMessagesForPlanMatching,
+                        currentWorkingDirectory: currentWorkingDirectory,
+                        planMatchingFingerprint: planMatchingFingerprint,
+                        newestStreamingMessageID: newestStreamingMessageID,
+                        autoScrollMode: autoScrollMode,
+                        showsGlobalRunningIndicator: showsGlobalRunningIndicator,
+                        movesCopyAndRunningToGroupFooter: false,
+                        onRetryUserMessage: onRetryUserMessage,
+                        onTapAssistantRevert: onTapAssistantRevert,
+                        onTapSubagent: onTapSubagent
+                    )
+                }
+            }
+        }
+        .id(group.id)
+    }
+}
+
 struct TurnTimelineRowsSection: View {
     let shouldWarmRecentTailProgressively: Bool
     let hasEarlierMessages: Bool
@@ -449,6 +523,24 @@ struct TurnTimelineRowsSection: View {
                     )
                 case .toolBurst(let group):
                     TurnTimelineToolBurstView(
+                        group: group,
+                        isRetryAvailable: isRetryAvailable,
+                        cachedBlockInfoByMessageID: cachedBlockInfoByMessageID,
+                        planSessionSource: planSessionSource,
+                        allowsAssistantPlanFallbackRecovery: allowsAssistantPlanFallbackRecovery,
+                        completedTurnIDs: completedTurnIDs,
+                        threadMessagesForPlanMatching: threadMessagesForPlanMatching,
+                        currentWorkingDirectory: currentWorkingDirectory,
+                        planMatchingFingerprint: planMatchingFingerprint,
+                        newestStreamingMessageID: newestStreamingMessageID,
+                        autoScrollMode: autoScrollMode,
+                        showsGlobalRunningIndicator: shouldUseGlobalRunningIndicator,
+                        onRetryUserMessage: onRetryUserMessage,
+                        onTapAssistantRevert: onTapAssistantRevert,
+                        onTapSubagent: onTapSubagent
+                    )
+                case .commandGroup(let group):
+                    TurnTimelineCommandGroupView(
                         group: group,
                         isRetryAvailable: isRetryAvailable,
                         cachedBlockInfoByMessageID: cachedBlockInfoByMessageID,

--- a/CodexMobile/CodexMobileTests/TurnTimelineReducerTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnTimelineReducerTests.swift
@@ -549,7 +549,11 @@ final class TurnTimelineReducerTests: XCTestCase {
         ]
 
         let items = TurnTimelineRenderProjection.project(messages: messages)
-        XCTAssertEqual(items.map(\.id), ["tool-1", "tool-2"])
+        XCTAssertEqual(items.map(\.id), ["command-group:tool-1"])
+        guard case .commandGroup(let group) = items.first else {
+            return XCTFail("Expected completed commands behind one disclosure")
+        }
+        XCTAssertEqual(group.messages.map(\.id), ["tool-1", "tool-2"])
     }
 
     func testTimelineRenderProjectionSplitsToolRunsAcrossStableTurnIDs() {
@@ -588,6 +592,125 @@ final class TurnTimelineReducerTests: XCTestCase {
         }
 
         XCTAssertEqual(messageIDs, ["tool-1", "tool-2"])
+    }
+
+    func testTimelineRenderProjectionGroupsFinishedCommandsIntoDisclosureItem() {
+        let now = Date()
+        let messages = [
+            makeMessage(
+                id: "command-1",
+                threadID: "thread",
+                role: .system,
+                kind: .commandExecution,
+                text: "Completed rg -n \"needle\" Sources",
+                createdAt: now,
+                turnID: "turn-1",
+                itemID: "command-1"
+            ),
+            makeMessage(
+                id: "command-2",
+                threadID: "thread",
+                role: .system,
+                kind: .commandExecution,
+                text: "Completed sed -n '1,40p' Sources/App.swift",
+                createdAt: now.addingTimeInterval(1),
+                turnID: "turn-1",
+                itemID: "command-2"
+            ),
+        ]
+
+        let items = TurnTimelineRenderProjection.project(messages: messages)
+
+        XCTAssertEqual(items.map(\.id), ["command-group:command-1"])
+    }
+
+    func testTimelineRenderProjectionKeepsRunningCommandsVisibleUntilFinished() {
+        let now = Date()
+        let messages = [
+            makeMessage(
+                id: "running",
+                threadID: "thread",
+                role: .system,
+                kind: .commandExecution,
+                text: "Running rg -n \"needle\" Sources",
+                createdAt: now,
+                turnID: "turn-1",
+                itemID: "running",
+                isStreaming: true
+            ),
+            makeMessage(
+                id: "finished",
+                threadID: "thread",
+                role: .system,
+                kind: .commandExecution,
+                text: "Completed sed -n '1,40p' Sources/App.swift",
+                createdAt: now.addingTimeInterval(1),
+                turnID: "turn-1",
+                itemID: "finished"
+            ),
+        ]
+
+        let items = TurnTimelineRenderProjection.project(messages: messages)
+
+        XCTAssertEqual(items.map(\.id), ["running", "command-group:finished"])
+    }
+
+    func testTimelineRenderProjectionKeepsFinishedCommandGroupOutsideCompletedTurnPreviousMessages() {
+        let now = Date()
+        let messages = [
+            makeMessage(
+                id: "user",
+                threadID: "thread",
+                role: .user,
+                text: "Inspect the timeline",
+                createdAt: now,
+                turnID: "turn-1",
+                orderIndex: 1
+            ),
+            makeMessage(
+                id: "status",
+                threadID: "thread",
+                role: .assistant,
+                text: "I’ll inspect the projection.",
+                createdAt: now.addingTimeInterval(1),
+                turnID: "turn-1",
+                itemID: "status",
+                orderIndex: 2
+            ),
+            makeMessage(
+                id: "command",
+                threadID: "thread",
+                role: .system,
+                kind: .commandExecution,
+                text: "Completed rg -n \"TurnTimelineRenderProjection\" CodexMobile",
+                createdAt: now.addingTimeInterval(2),
+                turnID: "turn-1",
+                itemID: "command",
+                orderIndex: 3
+            ),
+            makeMessage(
+                id: "final",
+                threadID: "thread",
+                role: .assistant,
+                text: "The projection is ready.",
+                createdAt: now.addingTimeInterval(3),
+                turnID: "turn-1",
+                itemID: "final",
+                orderIndex: 4
+            ),
+        ]
+
+        let items = TurnTimelineRenderProjection.project(
+            messages: messages,
+            completedTurnIDs: ["turn-1"]
+        )
+
+        XCTAssertEqual(items.map(\.id), [
+            "user",
+            "previous-messages:final",
+            "command-group:command",
+            "final",
+        ])
     }
 
     func testTimelineRenderProjectionCollapsesCompletedTurnBeforeFinalAnswer() {


### PR DESCRIPTION
## Summary

Collapses finished command execution rows into a single timeline disclosure so completed command bursts do not keep every command row expanded in the visible thread history.

- **Projection**: adds a dedicated command-group render item, buffers terminal `Completed` / `Failed` / `Stopped` command execution rows by turn, and keeps running command rows visible until they finish.
- **UI**: renders a compact `Ran N commands` disclosure with the terminal icon and expands back to the original command rows on tap.
- **Completed turns**: keeps finished command groups outside the completed-turn previous-message disclosure so the final answer still has an accessible command summary.
- **Tests**: covers finished command grouping, running command visibility, completed-turn placement, and the existing placeholder-thinking projection case.

## Test plan

- [x] `git diff --check`
- [x] Focused `TurnTimelineReducerTests` projection set passes (10 tests)
- [x] Before/after screenshots captured locally for the collapsed command disclosure
- [ ] Full `TurnTimelineReducerTests` class: existing unrelated failures remain in upstream main. Representative failures reproduce on the clean upstream worktree (file-change merge, Mermaid label normalizer, late status ordering).

Made with [Codex](https://openai.com/codex)


<img width="736" height="800" alt="Before and after collapsed command executions" src="https://github.com/user-attachments/assets/45582044-c08c-4c29-aafb-ad0bf0b020d0" />
