### PR TITLE
Add isolated lifecycle handling for side conversations

### DIFF
--- a/CodexMobile/CodexMobile/ContentView.swift
+++ b/CodexMobile/CodexMobile/ContentView.swift
@@ -77,6 +77,7 @@ struct ContentView: View {
     @State private var suppressAutomaticThreadSelection = false
     @State private var sidebarPrewarmTask: Task<Void, Never>?
     @State private var presentedRootSheet: RootSheetRoute?
+    @State private var pendingSideConversationPresentation: CodexSideConversationPresentation?
     @State private var isWhatsNewPresentationReady = false
     @State private var sidebarGestureDebugSequence = 0
     @State private var activeSidebarGestureDebugID: Int?
@@ -1601,18 +1602,15 @@ struct ContentView: View {
 
     // Keeps the side fork in the root-owned modal slot while the parent remains selected underneath.
     private func presentSideConversation(_ presentation: CodexSideConversationPresentation) {
-        guard presentedRootSheet == nil else {
-            Task { @MainActor in
-                do {
-                    try await codex.closeSideConversation(threadID: presentation.thread.id)
-                    codex.acknowledgeSideConversationDismissal(threadID: presentation.thread.id)
-                } catch {
-                    codex.abandonSideConversationLocally(threadID: presentation.thread.id)
-                }
-            }
+        if presentedRootSheet == nil {
+            presentedRootSheet = .sideConversation(presentation)
             return
         }
-        presentedRootSheet = .sideConversation(presentation)
+
+        // A deferred root sheet may win the same render pass in which `thread/fork`
+        // completes. Keep the live ephemeral fork queued instead of silently closing it.
+        pendingSideConversationPresentation = presentation
+        syncRootSheetPresentationIfNeeded()
     }
 
     private var missingNotificationThreadAlertIsPresented: Binding<Bool> {
@@ -1641,7 +1639,15 @@ struct ContentView: View {
         // Let bridge recovery take over immediately without marking What's New as already seen.
         if case .whatsNew = presentedRootSheet,
            case .bridgeUpdate = desiredRoute {
-            presentedRootSheet = desiredRoute
+            presentRootSheet(desiredRoute)
+            return
+        }
+
+        // A user-requested side conversation outranks a delayed announcement. Keep
+        // What's New pending so it can be presented again after the side sheet closes.
+        if case .whatsNew = presentedRootSheet,
+           case .sideConversation = desiredRoute {
+            presentRootSheet(desiredRoute)
             return
         }
 
@@ -1649,7 +1655,7 @@ struct ContentView: View {
         if case .bridgeUpdate = presentedRootSheet,
            case .bridgeUpdate = desiredRoute,
            presentedRootSheet?.id != desiredRoute.id {
-            presentedRootSheet = desiredRoute
+            presentRootSheet(desiredRoute)
             return
         }
 
@@ -1657,7 +1663,15 @@ struct ContentView: View {
             return
         }
 
-        presentedRootSheet = desiredRoute
+        presentRootSheet(desiredRoute)
+    }
+
+    private func presentRootSheet(_ route: RootSheetRoute) {
+        presentedRootSheet = route
+        if case .sideConversation(let presentation) = route,
+           pendingSideConversationPresentation?.id == presentation.id {
+            pendingSideConversationPresentation = nil
+        }
     }
 
     private var desiredRootSheetRoute: RootSheetRoute? {
@@ -1667,6 +1681,10 @@ struct ContentView: View {
 
         if let prompt = codex.bridgeUpdatePrompt {
             return .bridgeUpdate(prompt)
+        }
+
+        if let pendingSideConversationPresentation {
+            return .sideConversation(pendingSideConversationPresentation)
         }
 
         if let whatsNewVersion = pendingWhatsNewVersion {
@@ -1718,6 +1736,7 @@ struct ContentView: View {
         [
             String(canPresentDeferredRootSheet),
             codex.bridgeUpdatePrompt?.id.uuidString ?? "nil",
+            pendingSideConversationPresentation?.id ?? "nil",
             pendingWhatsNewVersion ?? "nil",
             presentedRootSheet?.id ?? "nil",
         ].joined(separator: "|")

--- a/CodexMobile/CodexMobile/ContentView.swift
+++ b/CodexMobile/CodexMobile/ContentView.swift
@@ -9,12 +9,15 @@ import UIKit
 
 private enum RootSheetRoute: Identifiable, Equatable {
     case bridgeUpdate(CodexBridgeUpdatePrompt)
+    case sideConversation(CodexSideConversationPresentation)
     case whatsNew(version: String)
 
     var id: String {
         switch self {
         case .bridgeUpdate(let prompt):
             return "bridge-update-\(prompt.id.uuidString)"
+        case .sideConversation(let presentation):
+            return "side-conversation-\(presentation.id)"
         case .whatsNew(let version):
             return "whats-new-\(version)"
         }
@@ -170,6 +173,11 @@ struct ContentView: View {
             }
             .onChange(of: codex.activeThreadId) { _, activeThreadId in
                 debugSidebarLog("activeThreadId changed to=\(activeThreadId ?? "nil")")
+                if case .sideConversation(let presentation) = presentedRootSheet,
+                   activeThreadId == presentation.thread.id {
+                    // The modal owns this displayed thread; keep primary navigation on its parent.
+                    return
+                }
                 guard let activeThreadId,
                       let matchingThread = codex.threads.first(where: { $0.id == activeThreadId }),
                       selectedThread?.id != matchingThread.id else {
@@ -271,6 +279,9 @@ struct ContentView: View {
                 switch route {
                 case .bridgeUpdate(let prompt):
                     bridgeUpdateSheet(prompt: prompt)
+                case .sideConversation(let presentation):
+                    SideConversationSheet(presentation: presentation)
+                        .environment(codex)
                 case .whatsNew(let version):
                     whatsNewSheet(version: version)
                 }
@@ -746,7 +757,8 @@ struct ContentView: View {
                 },
                 onOpenTerminal: { workingDirectory in
                     openTerminal(preferredWorkingDirectory: workingDirectory)
-                }
+                },
+                onOpenSideConversation: presentSideConversation
             )
             .id(thread.id)
             .adaptiveNavigationBar()
@@ -813,7 +825,8 @@ struct ContentView: View {
                 },
                 onOpenTerminal: { workingDirectory in
                     openTerminal(preferredWorkingDirectory: workingDirectory)
-                }
+                },
+                onOpenSideConversation: presentSideConversation
             )
                 .id(thread.id)
                 .environment(\.reconnectAction, {
@@ -1586,6 +1599,22 @@ struct ContentView: View {
         )
     }
 
+    // Keeps the side fork in the root-owned modal slot while the parent remains selected underneath.
+    private func presentSideConversation(_ presentation: CodexSideConversationPresentation) {
+        guard presentedRootSheet == nil else {
+            Task { @MainActor in
+                do {
+                    try await codex.closeSideConversation(threadID: presentation.thread.id)
+                    codex.acknowledgeSideConversationDismissal(threadID: presentation.thread.id)
+                } catch {
+                    codex.abandonSideConversationLocally(threadID: presentation.thread.id)
+                }
+            }
+            return
+        }
+        presentedRootSheet = .sideConversation(presentation)
+    }
+
     private var missingNotificationThreadAlertIsPresented: Binding<Bool> {
         Binding(
             get: { codex.missingNotificationThreadPrompt != nil },
@@ -1727,6 +1756,19 @@ struct ContentView: View {
         switch route {
         case .bridgeUpdate:
             dismissBridgeUpdatePrompt()
+        case .sideConversation(let presentation):
+            guard codex.sideConversationThreadIDs.contains(presentation.thread.id) else {
+                codex.acknowledgeSideConversationDismissal(threadID: presentation.thread.id)
+                break
+            }
+            Task { @MainActor in
+                do {
+                    try await codex.closeSideConversation(threadID: presentation.thread.id)
+                    codex.acknowledgeSideConversationDismissal(threadID: presentation.thread.id)
+                } catch {
+                    codex.abandonSideConversationLocally(threadID: presentation.thread.id)
+                }
+            }
         case .whatsNew(let version):
             dismissWhatsNewSheet(version: version)
         }

--- a/CodexMobile/CodexMobile/Models/CodexThread.swift
+++ b/CodexMobile/CodexMobile/Models/CodexThread.swift
@@ -85,6 +85,8 @@ struct CodexThread: Identifiable, Codable, Hashable, Sendable {
     var modelProvider: String?
     var reasoningEffort: String?
     var serviceTier: String?
+    // Ephemeral app-server threads are in-memory surfaces such as `/side`, not saved chats.
+    var ephemeral: Bool
     var runtimeSettingsRevision: Int?
     var runtimeSettingsUpdatedAt: Double?
     var runtimeSettingsSource: String?
@@ -110,6 +112,7 @@ struct CodexThread: Identifiable, Codable, Hashable, Sendable {
         modelProvider: String? = nil,
         reasoningEffort: String? = nil,
         serviceTier: String? = nil,
+        ephemeral: Bool = false,
         runtimeSettingsRevision: Int? = nil,
         runtimeSettingsUpdatedAt: Double? = nil,
         runtimeSettingsSource: String? = nil,
@@ -132,6 +135,7 @@ struct CodexThread: Identifiable, Codable, Hashable, Sendable {
         self.modelProvider = Self.normalizeIdentifier(modelProvider)
         self.reasoningEffort = Self.normalizeIdentifier(reasoningEffort)
         self.serviceTier = Self.normalizeIdentifier(serviceTier)
+        self.ephemeral = ephemeral
         self.runtimeSettingsRevision = runtimeSettingsRevision
         self.runtimeSettingsUpdatedAt = runtimeSettingsUpdatedAt
         self.runtimeSettingsSource = Self.normalizeIdentifier(runtimeSettingsSource)
@@ -172,6 +176,7 @@ struct CodexThread: Identifiable, Codable, Hashable, Sendable {
         case reasoningEffortSnake = "reasoning_effort"
         case serviceTier
         case serviceTierSnake = "service_tier"
+        case ephemeral
         case runtimeSettingsRevision
         case runtimeSettingsRevisionSnake = "runtime_settings_revision"
         case runtimeSettingsUpdatedAt
@@ -242,6 +247,7 @@ struct CodexThread: Identifiable, Codable, Hashable, Sendable {
             keys: [.reasoningEffort, .reasoningEffortSnake]
         )
         serviceTier = Self.decodeIdentifierIfPresent(from: container, keys: [.serviceTier, .serviceTierSnake])
+        ephemeral = try container.decodeIfPresent(Bool.self, forKey: .ephemeral) ?? false
         runtimeSettingsRevision = Self.decodeIntegerIfPresent(
             from: container,
             keys: [.runtimeSettingsRevision, .runtimeSettingsRevisionSnake]
@@ -279,6 +285,7 @@ struct CodexThread: Identifiable, Codable, Hashable, Sendable {
         try container.encodeIfPresent(Self.normalizeIdentifier(modelProvider), forKey: .modelProvider)
         try container.encodeIfPresent(Self.normalizeIdentifier(reasoningEffort), forKey: .reasoningEffort)
         try container.encodeIfPresent(Self.normalizeIdentifier(serviceTier), forKey: .serviceTier)
+        try container.encode(ephemeral, forKey: .ephemeral)
         try container.encodeIfPresent(runtimeSettingsRevision, forKey: .runtimeSettingsRevision)
         try container.encodeIfPresent(runtimeSettingsUpdatedAt, forKey: .runtimeSettingsUpdatedAt)
         try container.encodeIfPresent(Self.normalizeIdentifier(runtimeSettingsSource), forKey: .runtimeSettingsSource)

--- a/CodexMobile/CodexMobile/RemodexQuickActionCenter.swift
+++ b/CodexMobile/CodexMobile/RemodexQuickActionCenter.swift
@@ -48,7 +48,7 @@ enum RemodexQuickActionCenter {
 
     private static func shortcutItems(for threads: [CodexThread]) -> [UIApplicationShortcutItem] {
         let recentThreads = threads
-            .filter { $0.syncState == .live }
+            .filter { $0.syncState == .live && !$0.ephemeral }
             .prefix(2)
 
         return [newChatShortcutItem()] + recentThreads.map(threadShortcutItem)

--- a/CodexMobile/CodexMobile/Services/CodexService+AIChangeSets.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+AIChangeSets.swift
@@ -399,6 +399,11 @@ extension CodexService {
             .first { isSameOrDescendantPath(normalizedWorkingDirectory, root: $0) }
         return matchingRoot ?? normalizedWorkingDirectory
     }
+
+    // Flushes the filtered store after an ephemeral side thread is discarded.
+    func persistAIChangeSetsAfterEphemeralCleanup() {
+        persistAIChangeSets()
+    }
 }
 
 private extension CodexService {
@@ -639,7 +644,7 @@ private extension CodexService {
 
     func persistAIChangeSets() {
         aiChangeSetPersistence.save(
-            aiChangeSetsByID.values.sorted {
+            aiChangeSetsEligibleForPersistence.sorted {
                 if $0.createdAt != $1.createdAt {
                     return $0.createdAt < $1.createdAt
                 }

--- a/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
@@ -108,6 +108,7 @@ extension CodexService {
             isConnected = true
             lastErrorMessage = nil
             try await initializeSession()
+            await recoverSideConversationsAfterReconnect()
             flushPendingReplayDiscontinuityHistoryRefresh()
             shouldAutoReconnectOnForeground = false
             connectionRecoveryState = .idle
@@ -153,6 +154,13 @@ extension CodexService {
 
         isConnected = false
         isInitialized = false
+        if preserveReconnectIntent {
+            markSideConversationsForReconnect()
+        } else {
+            invalidateAllSideConversations(
+                message: "The temporary side conversation ended when Remodex disconnected. The main conversation is unchanged."
+            )
+        }
         isLoadingThreads = false
         isLoadingModels = false
         pendingRuntimeOptionRefresh = false
@@ -238,6 +246,9 @@ extension CodexService {
 
     // Clears all remembered relay metadata when the pairing itself is no longer trustworthy.
     func clearSavedRelaySession() {
+        invalidateAllSideConversations(
+            message: "The temporary side conversation ended because this Mac pairing was cleared. The main conversation is unchanged."
+        )
         SecureStore.deleteValue(for: CodexSecureKeys.relaySessionId)
         SecureStore.deleteValue(for: CodexSecureKeys.relayUrl)
         SecureStore.deleteValue(for: CodexSecureKeys.relayMacDeviceId)
@@ -513,6 +524,13 @@ extension CodexService {
         }
         connectionRecoveryState = disposition.connectionRecoveryState
         lastErrorMessage = disposition.lastErrorMessage
+        if disposition.shouldAutoReconnectOnForeground {
+            markSideConversationsForReconnect()
+        } else {
+            invalidateAllSideConversations(
+                message: "The temporary side conversation ended when its runtime disconnected. The main conversation is unchanged."
+            )
+        }
         finalizeAllStreamingState()
         endBackgroundRunGraceTask(reason: "receive-error")
         clearConnectionSyncState()
@@ -672,6 +690,9 @@ extension CodexService {
 
     // Clears volatile runtime state on server switch.
     func resetThreadRuntimeStateForServerSwitch() {
+        invalidateAllSideConversations(
+            message: "The temporary side conversation ended because Remodex switched Mac runtimes. The main conversation is unchanged."
+        )
         activeThreadId = nil
         activeTurnId = nil
         activeTurnIdByThread.removeAll()

--- a/CodexMobile/CodexMobile/Services/CodexService+Helpers.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Helpers.swift
@@ -15,7 +15,9 @@ extension CodexService {
                 (thread.id, index)
             }
         )
-        firstLiveThreadIDCache = threads.first(where: { $0.syncState == .live })?.id
+        firstLiveThreadIDCache = threads.first(where: {
+            $0.syncState == .live && !$0.ephemeral
+        })?.id
         refreshSubagentIdentityDirectoryFromThreads()
     }
 
@@ -58,11 +60,13 @@ extension CodexService {
             with: existingThread,
             treatAsServerState: treatAsServerState
         )
-        if resolvedThread.forkedFromThreadId == nil {
+        if !resolvedThread.ephemeral, resolvedThread.forkedFromThreadId == nil {
             resolvedThread.forkedFromThreadId = persistedForkOrigin(for: resolvedThread.id)
         }
         applyPersistedThreadRename(to: &resolvedThread)
-        rememberForkOriginIfNeeded(sourceThreadId: resolvedThread.forkedFromThreadId, forkedThreadId: resolvedThread.id)
+        if !resolvedThread.ephemeral {
+            rememberForkOriginIfNeeded(sourceThreadId: resolvedThread.forkedFromThreadId, forkedThreadId: resolvedThread.id)
+        }
         let derivedIdentity = resolvedThread.derivedSubagentIdentity
         upsertSubagentIdentity(
             threadId: resolvedThread.id,
@@ -127,6 +131,7 @@ extension CodexService {
            merged.runtimeSettingsRevision == nil {
             merged.serviceTier = existing.serviceTier
         }
+        merged.ephemeral = merged.ephemeral || existing.ephemeral
         if merged.runtimeSettingsRevision == nil {
             merged.runtimeSettingsRevision = existing.runtimeSettingsRevision
             merged.runtimeSettingsUpdatedAt = existing.runtimeSettingsUpdatedAt

--- a/CodexMobile/CodexMobile/Services/CodexService+Incoming.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Incoming.swift
@@ -177,7 +177,7 @@ extension CodexService {
     func handleNotification(method: String, params: JSONValue?) {
         let paramsObject = params?.objectValue
         if let threadID = extractThreadID(from: paramsObject),
-           closedSideConversationThreadIDs.contains(threadID) {
+           shouldDropRetiredSideConversationEvent(threadID) {
             return
         }
         let previousReplayScope = isApplyingReplayedBridgeEvent
@@ -749,9 +749,6 @@ extension CodexService {
                 lastRunStartTurnIDByThread.removeValue(forKey: threadId)
             }
             markThreadAsRunning(threadId)
-            if isSideConversationIsolated(threadId) {
-                threadsPendingCompletionHaptic.remove(threadId)
-            }
             if isDesktopMirroredTurn {
                 markDesktopMirroredRunning(for: threadId)
                 markMirroredRunningCatchupNeeded(for: threadId)

--- a/CodexMobile/CodexMobile/Services/CodexService+Incoming.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Incoming.swift
@@ -176,6 +176,10 @@ extension CodexService {
     // Handles stream notifications to keep UI state in sync.
     func handleNotification(method: String, params: JSONValue?) {
         let paramsObject = params?.objectValue
+        if let threadID = extractThreadID(from: paramsObject),
+           closedSideConversationThreadIDs.contains(threadID) {
+            return
+        }
         let previousReplayScope = isApplyingReplayedBridgeEvent
         if isBufferedReplayResetEvent(paramsObject) {
             handleBufferedReplayReset(paramsObject)
@@ -476,7 +480,8 @@ extension CodexService {
             if activeTurnID(for: threadId) == nil, let turnId = mirroredTurnID {
                 setActiveTurnID(turnId, for: threadId)
                 threadIdByTurnID[turnId] = threadId
-                if !isBackgroundDiscoveryBridgeEvent(paramsObject) || threadId == activeThreadId {
+                if (!isBackgroundDiscoveryBridgeEvent(paramsObject) || threadId == activeThreadId),
+                   !isSideConversationIsolated(threadId) {
                     activeTurnId = turnId
                 }
                 setProtectedRunningFallback(false, for: threadId)
@@ -744,6 +749,9 @@ extension CodexService {
                 lastRunStartTurnIDByThread.removeValue(forKey: threadId)
             }
             markThreadAsRunning(threadId)
+            if isSideConversationIsolated(threadId) {
+                threadsPendingCompletionHaptic.remove(threadId)
+            }
             if isDesktopMirroredTurn {
                 markDesktopMirroredRunning(for: threadId)
                 markMirroredRunningCatchupNeeded(for: threadId)
@@ -768,7 +776,8 @@ extension CodexService {
 
         if let turnID,
            !isReplayedEvent,
-           !isBackgroundDiscoveryTurn || threadId == activeThreadId {
+           (!isBackgroundDiscoveryTurn || threadId == activeThreadId),
+           threadId.map({ !isSideConversationIsolated($0) }) ?? true {
             activeTurnId = turnID
         }
 

--- a/CodexMobile/CodexMobile/Services/CodexService+IncomingAssistant.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+IncomingAssistant.swift
@@ -382,20 +382,8 @@ extension CodexService {
 }
 
 private extension CodexService {
-    // Side conversations retain their own running state, but must not arm app-wide
-    // completion feedback that belongs to regular foreground/background turns.
     func markAssistantThreadAsRunning(_ threadId: String) {
-        if isSideConversationIsolated(threadId),
-           runningThreadIDs.contains(threadId),
-           latestTurnTerminalStateByThread[threadId] == nil,
-           !readyThreadIDs.contains(threadId),
-           !failedThreadIDs.contains(threadId) {
-            return
-        }
         markThreadAsRunning(threadId)
-        if isSideConversationIsolated(threadId) {
-            threadsPendingCompletionHaptic.remove(threadId)
-        }
     }
 
     // Upserts Desktop-mirrored user prompts delivered as item lifecycle events

--- a/CodexMobile/CodexMobile/Services/CodexService+IncomingAssistant.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+IncomingAssistant.swift
@@ -43,7 +43,7 @@ extension CodexService {
                for: extractTurnID(from: paramsObject),
                threadId: directThreadId
            ) == nil {
-            markThreadAsRunning(directThreadId)
+            markAssistantThreadAsRunning(directThreadId)
         }
 
         guard let context = resolveAssistantEventContext(
@@ -57,11 +57,13 @@ extension CodexService {
 
         if !isReplayedEvent,
            turnTerminalState(for: turnId, threadId: context.threadId) == nil {
-            markThreadAsRunning(context.threadId)
+            markAssistantThreadAsRunning(context.threadId)
             if activeTurnID(for: context.threadId) == nil {
                 setActiveTurnID(turnId, for: context.threadId)
                 threadIdByTurnID[turnId] = context.threadId
-                activeTurnId = turnId
+                if !isSideConversationIsolated(context.threadId) {
+                    activeTurnId = turnId
+                }
                 setProtectedRunningFallback(false, for: context.threadId)
             }
         }
@@ -310,7 +312,7 @@ extension CodexService {
         if let directThreadId = extractThreadID(from: paramsObject),
            !directThreadId.isEmpty,
            !isReplayedBridgeEvent(paramsObject) {
-            markThreadAsRunning(directThreadId)
+            markAssistantThreadAsRunning(directThreadId)
         }
 
         guard let itemObject = extractIncomingItemObject(from: paramsObject, eventObject: eventObject) else {
@@ -380,6 +382,22 @@ extension CodexService {
 }
 
 private extension CodexService {
+    // Side conversations retain their own running state, but must not arm app-wide
+    // completion feedback that belongs to regular foreground/background turns.
+    func markAssistantThreadAsRunning(_ threadId: String) {
+        if isSideConversationIsolated(threadId),
+           runningThreadIDs.contains(threadId),
+           latestTurnTerminalStateByThread[threadId] == nil,
+           !readyThreadIDs.contains(threadId),
+           !failedThreadIDs.contains(threadId) {
+            return
+        }
+        markThreadAsRunning(threadId)
+        if isSideConversationIsolated(threadId) {
+            threadsPendingCompletionHaptic.remove(threadId)
+        }
+    }
+
     // Upserts Desktop-mirrored user prompts delivered as item lifecycle events
     // (item/started for active turns, item/completed for non-active ones).
     func handleMirroredUserMessageItem(

--- a/CodexMobile/CodexMobile/Services/CodexService+MacContext.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+MacContext.swift
@@ -35,9 +35,45 @@ extension CodexService {
     // Persists the currently loaded local state under the provided Mac namespace.
     func saveLocalState(for macDeviceId: String?) {
         let normalizedMacDeviceId = normalizedMacScopedDeviceId(macDeviceId)
-        messagePersistence.save(messagesByThread, macDeviceId: normalizedMacDeviceId)
-        composerDraftPersistence.save(composerDraftsByThreadID, macDeviceId: normalizedMacDeviceId)
-        aiChangeSetPersistence.save(Array(aiChangeSetsByID.values), macDeviceId: normalizedMacDeviceId)
+        messagePersistence.save(messagesEligibleForPersistence, macDeviceId: normalizedMacDeviceId)
+        composerDraftPersistence.save(composerDraftsEligibleForPersistence, macDeviceId: normalizedMacDeviceId)
+        aiChangeSetPersistence.save(aiChangeSetsEligibleForPersistence, macDeviceId: normalizedMacDeviceId)
+    }
+
+    // `/side` timelines and drafts are connection-scoped RAM, never cold-start state.
+    var messagesEligibleForPersistence: [String: [CodexMessage]] {
+        let ephemeralThreadIDs = ephemeralThreadIDsExcludedFromLocalPersistence
+        return messagesByThread.filter { !ephemeralThreadIDs.contains($0.key) }
+    }
+
+    var composerDraftsEligibleForPersistence: [String: TurnComposerLocalDraft] {
+        let ephemeralThreadIDs = ephemeralThreadIDsExcludedFromLocalPersistence
+        return composerDraftsByThreadID.filter { !ephemeralThreadIDs.contains($0.key) }
+    }
+
+    var aiChangeSetsEligibleForPersistence: [AIChangeSet] {
+        let ephemeralThreadIDs = ephemeralThreadIDsExcludedFromLocalPersistence
+        return aiChangeSetsByID.values.filter { !ephemeralThreadIDs.contains($0.threadId) }
+    }
+
+    var terminalStatesEligibleForPersistence: [String: CodexTurnTerminalState] {
+        let ephemeralThreadIDs = ephemeralThreadIDsExcludedFromLocalPersistence
+        var ephemeralTurnIDs = Set(
+            threadIdByTurnID.compactMap { turnID, threadID in
+                ephemeralThreadIDs.contains(threadID) ? turnID : nil
+            }
+        )
+        for threadID in ephemeralThreadIDs {
+            ephemeralTurnIDs.formUnion((messagesByThread[threadID] ?? []).compactMap(\.turnId))
+        }
+        return terminalStateByTurnID.filter { turnID, _ in
+            !CodexSyntheticIdentifiers.isProjectedDesktopTurnID(turnID)
+                && !ephemeralTurnIDs.contains(turnID)
+        }
+    }
+
+    var ephemeralThreadIDsExcludedFromLocalPersistence: Set<String> {
+        sideConversationIsolationThreadIDs.union(threads.lazy.filter(\.ephemeral).map(\.id))
     }
 
     // Loads messages, drafts, and assistant change-set metadata for the provided Mac namespace.
@@ -435,7 +471,8 @@ extension CodexService {
             return
         }
 
-        let capturedThreads = threads
+        // In-memory `/side` forks must never survive into the cold-start sidebar snapshot.
+        let capturedThreads = threads.filter { !$0.ephemeral }
         let capturedMacDeviceId = currentMacScopedPersistenceDeviceId
         threadListSnapshotPersistenceTask?.cancel()
         threadListSnapshotPersistenceTask = Task { @MainActor [weak self] in
@@ -459,7 +496,9 @@ extension CodexService {
 
         threadListSnapshotPersistenceTask?.cancel()
         threadListSnapshotPersistenceTask = nil
-        let snapshot = Array(sortThreads(threads).prefix(recentActiveThreadListLimit))
+        let snapshot = Array(
+            sortThreads(threads.filter { !$0.ephemeral }).prefix(recentActiveThreadListLimit)
+        )
         threadListPersistence.save(
             snapshot,
             macDeviceId: currentMacScopedPersistenceDeviceId

--- a/CodexMobile/CodexMobile/Services/CodexService+Messages.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Messages.swift
@@ -798,18 +798,26 @@ extension CodexService {
 
     // Marks thread as actively running while ensuring stale outcomes are cleared.
     func markThreadAsRunning(_ threadId: String) {
+        let shouldArmCompletionHaptic = !isSideConversationIsolated(threadId)
+        let hasExpectedHapticState = shouldArmCompletionHaptic
+            ? threadsPendingCompletionHaptic.contains(threadId)
+            : !threadsPendingCompletionHaptic.contains(threadId)
         // Streaming deltas re-assert running on every chunk; when nothing would
         // change, skip the busy-roots rebuild and timeline refresh entirely so
         // token streaming stays O(1) instead of O(threads) per delta.
         if runningThreadIDs.contains(threadId),
-           threadsPendingCompletionHaptic.contains(threadId),
+           hasExpectedHapticState,
            latestTurnTerminalStateByThread[threadId] == nil,
            !readyThreadIDs.contains(threadId),
            !failedThreadIDs.contains(threadId) {
             return
         }
         runningThreadIDs.insert(threadId)
-        threadsPendingCompletionHaptic.insert(threadId)
+        if shouldArmCompletionHaptic {
+            threadsPendingCompletionHaptic.insert(threadId)
+        } else {
+            threadsPendingCompletionHaptic.remove(threadId)
+        }
         latestTurnTerminalStateByThread.removeValue(forKey: threadId)
         clearOutcomeBadge(for: threadId)
         refreshBusyRepoRootsAndDependentTimelineStates()
@@ -5979,7 +5987,8 @@ extension CodexService {
     ) {
         // Always consume the pending marker so stopped/failed turns don't leak.
         let wasPending = threadsPendingCompletionHaptic.remove(threadId) != nil
-        guard state == .completed,
+        guard !isSideConversationIsolated(threadId),
+              state == .completed,
               previousState != .completed,
               isAppInForeground,
               wasPending else {

--- a/CodexMobile/CodexMobile/Services/CodexService+Messages.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Messages.swift
@@ -837,6 +837,9 @@ extension CodexService {
         clearRunningThreadWatch(threadId)
         let wasAlreadyReady = readyThreadIDs.contains(threadId)
         clearOutcomeBadge(for: threadId)
+        guard !isSideConversationIsolated(threadId) else {
+            return
+        }
         guard activeThreadId != threadId else {
             return
         }
@@ -851,6 +854,9 @@ extension CodexService {
     func markFailedIfUnread(threadId: String) {
         clearRunningThreadWatch(threadId)
         clearOutcomeBadge(for: threadId)
+        guard !isSideConversationIsolated(threadId) else {
+            return
+        }
         guard activeThreadId != threadId else {
             return
         }
@@ -902,17 +908,31 @@ extension CodexService {
     // Sets the active thread and lazily hydrates old messages from server history.
     @discardableResult
     func prepareThreadForDisplay(threadId: String) async -> Bool {
-        activeThreadId = threadId
+        let isSideConversation = sideConversationThreadIDs.contains(threadId)
+        if !isSideConversation {
+            activeThreadId = threadId
+        }
         markThreadAsViewed(threadId)
         // Opening a thread mid-mirror-batch must render immediately: settle any
         // open catch-up burst so the initial updateCurrentOutput below is not
         // deferred to the batch flush (finish is idempotent when no burst is open).
         finishTimelineCatchUpBurst(threadId: threadId)
-        updateCurrentOutput(for: threadId)
+        if !isSideConversation {
+            updateCurrentOutput(for: threadId)
+        }
         var didRefreshRunningState = false
         var shouldRequestImmediateSync = true
 
         guard isConnected else {
+            return true
+        }
+
+        // A side fork is already loaded and subscribed by `thread/fork`. Reading its
+        // inherited turns would expose the parent transcript that `/side` intentionally hides.
+        if isSideConversation {
+            hydratedThreadIDs.insert(threadId)
+            initialTurnsLoadedByThreadID.insert(threadId)
+            refreshThreadTimelineState(for: threadId)
             return true
         }
 
@@ -5250,7 +5270,7 @@ extension CodexService {
             try? await Task.sleep(nanoseconds: 250_000_000)
             guard !Task.isCancelled, let self else { return }
 
-            let snapshot = self.messagesByThread
+            let snapshot = self.messagesEligibleForPersistence
             let macDeviceId = self.currentMacScopedPersistenceDeviceId
             self.messagePersistenceDebounceTask = nil
 
@@ -5266,11 +5286,12 @@ extension CodexService {
             return
         }
 
-        let persistableStates = terminalStateByTurnID.filter { turnId, _ in
+        let persistableStates = terminalStatesEligibleForPersistence
+        let runtimeStatesWithoutProjectedIDs = terminalStateByTurnID.filter { turnId, _ in
             !CodexSyntheticIdentifiers.isProjectedDesktopTurnID(turnId)
         }
-        if persistableStates.count != terminalStateByTurnID.count {
-            terminalStateByTurnID = persistableStates
+        if runtimeStatesWithoutProjectedIDs.count != terminalStateByTurnID.count {
+            terminalStateByTurnID = runtimeStatesWithoutProjectedIDs
         }
 
         guard !persistableStates.isEmpty else {

--- a/CodexMobile/CodexMobile/Services/CodexService+Notifications.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Notifications.swift
@@ -224,7 +224,7 @@ extension CodexService {
 
     // Schedules a local alert only when a run finishes while the app is away from the foreground.
     func notifyRunCompletionIfNeeded(threadId: String, turnId: String?, result: CodexRunCompletionResult) {
-        guard !isAppInForeground else {
+        guard !isSideConversationIsolated(threadId), !isAppInForeground else {
             return
         }
 
@@ -245,7 +245,7 @@ extension CodexService {
         requestID: JSONValue,
         questions: [CodexStructuredUserInputQuestion]
     ) {
-        guard !isAppInForeground else {
+        guard !isSideConversationIsolated(threadId), !isAppInForeground else {
             return
         }
 

--- a/CodexMobile/CodexMobile/Services/CodexService+SideConversation.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+SideConversation.swift
@@ -16,7 +16,7 @@ struct CodexSideConversationPresentation: Identifiable, Equatable, Sendable {
 
 extension CodexService {
     var hasOpenSideConversation: Bool {
-        !sideConversationThreadIDs.isEmpty || !pendingSideConversationCleanupThreadIDs.isEmpty
+        !sideConversationThreadIDs.isEmpty
     }
 
     // Active sheets and remote-cleanup tombstones share the same isolation contract.
@@ -27,7 +27,15 @@ extension CodexService {
     }
 
     func isSideConversationIsolated(_ threadID: String) -> Bool {
-        sideConversationIsolationThreadIDs.contains(threadID)
+        sideConversationThreadIDs.contains(threadID)
+            || pendingSideConversationCleanupThreadIDs.contains(threadID)
+            || closedSideConversationThreadIDs.contains(threadID)
+    }
+
+    func shouldDropRetiredSideConversationEvent(_ threadID: String) -> Bool {
+        !sideConversationThreadIDs.contains(threadID)
+            && (pendingSideConversationCleanupThreadIDs.contains(threadID)
+                || closedSideConversationThreadIDs.contains(threadID))
     }
 
     func sideConversationRuntimeState(for threadID: String) -> CodexSideConversationRuntimeState {
@@ -175,15 +183,15 @@ extension CodexService {
         finishSideConversationCleanup(threadID: normalizedThreadID)
     }
 
-    // Clears the final observable tombstone after the owning sheet has dismissed.
+    // Clears sheet-visible runtime state; the transport tombstone remains for buffered replay safety.
     func acknowledgeSideConversationDismissal(threadID: String) {
         sideConversationRuntimeStateByThreadID.removeValue(forKey: threadID)
     }
 
     // Keeps the in-memory transcript visible while a short transport recovery is in progress.
     func markSideConversationsForReconnect() {
-        // The previous socket is closed, so it cannot deliver more events for retired side IDs.
-        closedSideConversationThreadIDs.removeAll()
+        // Closed IDs remain isolated because the replacement transport may replay
+        // buffered notifications emitted before the previous socket was cancelled.
         for threadID in sideConversationThreadIDs
             where !pendingSideConversationCleanupThreadIDs.contains(threadID) {
             sideConversationRuntimeStateByThreadID[threadID] = .recovering
@@ -291,12 +299,13 @@ extension CodexService {
     }
 
     func invalidateAllSideConversations(message: String) {
+        // Pending cleanup IDs can still have buffered events even though they no
+        // longer own a visible sheet. Promote them to durable in-memory tombstones.
+        closedSideConversationThreadIDs.formUnion(pendingSideConversationCleanupThreadIDs)
         for threadID in sideConversationThreadIDs.sorted() {
             invalidateSideConversation(threadID: threadID, message: message)
         }
-        // This path is used only when the old runtime/transport is no longer recoverable.
         pendingSideConversationCleanupThreadIDs.removeAll()
-        closedSideConversationThreadIDs.removeAll()
     }
 }
 

--- a/CodexMobile/CodexMobile/Services/CodexService+SideConversation.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+SideConversation.swift
@@ -1,0 +1,416 @@
+// FILE: CodexService+SideConversation.swift
+// Purpose: Orchestrates native Codex `/side` as an ephemeral fork with a hidden history boundary.
+// Layer: Service
+// Exports: CodexSideConversationPresentation, CodexService side-conversation lifecycle
+// Depends on: Foundation, CodexThread, JSONValue
+
+import Foundation
+
+struct CodexSideConversationPresentation: Identifiable, Equatable, Sendable {
+    let thread: CodexThread
+    let parentThreadID: String
+    let initialPrompt: String?
+
+    var id: String { thread.id }
+}
+
+extension CodexService {
+    var hasOpenSideConversation: Bool {
+        !sideConversationThreadIDs.isEmpty || !pendingSideConversationCleanupThreadIDs.isEmpty
+    }
+
+    // Active sheets and remote-cleanup tombstones share the same isolation contract.
+    var sideConversationIsolationThreadIDs: Set<String> {
+        sideConversationThreadIDs
+            .union(pendingSideConversationCleanupThreadIDs)
+            .union(closedSideConversationThreadIDs)
+    }
+
+    func isSideConversationIsolated(_ threadID: String) -> Bool {
+        sideConversationIsolationThreadIDs.contains(threadID)
+    }
+
+    func sideConversationRuntimeState(for threadID: String) -> CodexSideConversationRuntimeState {
+        sideConversationRuntimeStateByThreadID[threadID]
+            ?? .unavailable(message: "This temporary side conversation is no longer available.")
+    }
+
+    // Creates the same client-orchestrated ephemeral fork used by the native Codex TUI.
+    @discardableResult
+    func startSideConversation(from sourceThreadID: String) async throws -> CodexThread {
+        try await awaitRuntimeInitializedIfNeeded()
+
+        let parentThreadID = normalizedInterruptIdentifier(sourceThreadID) ?? sourceThreadID
+        guard !parentThreadID.isEmpty, let parentThread = thread(for: parentThreadID) else {
+            throw CodexServiceError.invalidInput("A started parent conversation is required for /side.")
+        }
+        guard !sideConversationThreadIDs.contains(parentThreadID), !hasOpenSideConversation else {
+            throw CodexServiceError.invalidInput("A side conversation is already open.")
+        }
+
+        var params: RPCObject = [
+            "threadId": .string(parentThreadID),
+            "ephemeral": .bool(true),
+            "developerInstructions": .string(Self.sideConversationDeveloperInstructions),
+        ]
+        if let model = parentThread.model?.trimmingCharacters(in: .whitespacesAndNewlines), !model.isEmpty {
+            params["model"] = .string(model)
+        }
+        if let serviceTier = parentThread.serviceTier?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !serviceTier.isEmpty {
+            params["serviceTier"] = .string(serviceTier)
+        }
+
+        let response: RPCMessage
+        do {
+            response = try await sendRequestWithApprovalPolicyFallback(
+                method: "thread/fork",
+                baseParams: params,
+                context: "minimal"
+            )
+        } catch {
+            if consumeUnsupportedThreadFork(error) {
+                throw CodexServiceError.invalidInput(
+                    "This device bridge does not support native side conversations yet. Update Remodex on your device and retry."
+                )
+            }
+            if Self.isUnmaterializedSideConversationError(error) {
+                throw CodexServiceError.invalidInput(
+                    "Send a message in the main conversation before starting /side."
+                )
+            }
+            throw error
+        }
+
+        guard let result = response.result?.objectValue,
+              let threadValue = result["thread"],
+              var sideThread = decodeModel(CodexThread.self, from: threadValue) else {
+            throw CodexServiceError.invalidResponse("thread/fork response missing side thread")
+        }
+
+        sideThread.ephemeral = true
+        sideThread.syncState = .live
+        sideThread.forkedFromThreadId = parentThreadID
+        sideThread.title = "Side conversation"
+        sideThread.name = nil
+        sideThread.preview = ""
+        sideThread.cwd = sideThread.cwd ?? parentThread.cwd
+        sideThread.model = sideThread.model ?? parentThread.model
+        sideThread.modelProvider = sideThread.modelProvider ?? parentThread.modelProvider
+        sideThread.reasoningEffort = sideThread.reasoningEffort ?? parentThread.reasoningEffort
+        sideThread.serviceTier = sideThread.serviceTier ?? parentThread.serviceTier
+        sideThread.createdAt = sideThread.createdAt ?? Date()
+        sideThread.updatedAt = sideThread.updatedAt ?? sideThread.createdAt
+
+        sideConversationThreadIDs.insert(sideThread.id)
+        sideConversationRuntimeStateByThreadID[sideThread.id] = .active
+        upsertThread(sideThread, treatAsServerState: true)
+        inheritThreadRuntimeOverrides(from: parentThreadID, to: sideThread.id)
+        resumedThreadIDs.insert(sideThread.id)
+        hydratedThreadIDs.insert(sideThread.id)
+        initialTurnsLoadedByThreadID.insert(sideThread.id)
+        messagesByThread[sideThread.id] = []
+
+        do {
+            _ = try await sendRequest(
+                method: "thread/inject_items",
+                params: .object([
+                    "threadId": .string(sideThread.id),
+                    "items": .array([Self.sideConversationBoundaryItem]),
+                ])
+            )
+            // Some transports deliver injected items as lifecycle notifications before the
+            // request response. Clear them again so the inherited boundary stays model-only.
+            messagesByThread[sideThread.id] = []
+            refreshThreadTimelineState(for: sideThread.id)
+        } catch {
+            pendingSideConversationCleanupThreadIDs.insert(sideThread.id)
+            try? await cleanupRemoteSideConversation(threadID: sideThread.id)
+            closedSideConversationThreadIDs.insert(sideThread.id)
+            sideConversationThreadIDs.remove(sideThread.id)
+            sideConversationRuntimeStateByThreadID.removeValue(forKey: sideThread.id)
+            discardEphemeralThreadLocally(sideThread.id)
+            throw CodexServiceError.invalidInput(
+                "Could not prepare the native side-conversation boundary. Update Remodex on your device and retry."
+            )
+        }
+
+        return thread(for: sideThread.id) ?? sideThread
+    }
+
+    // Interrupts any running side turn before releasing the app-server subscription.
+    func closeSideConversation(threadID: String) async throws {
+        let normalizedThreadID = normalizedInterruptIdentifier(threadID) ?? threadID
+        guard sideConversationThreadIDs.contains(normalizedThreadID)
+                || pendingSideConversationCleanupThreadIDs.contains(normalizedThreadID) else {
+            sideConversationRuntimeStateByThreadID[normalizedThreadID] = .closing
+            return
+        }
+
+        let previousRuntimeState = sideConversationRuntimeStateByThreadID[normalizedThreadID] ?? .active
+        let previousQueuePauseState = queuePauseStateByThread[normalizedThreadID]
+        sideConversationRuntimeStateByThreadID[normalizedThreadID] = .closing
+        queuePauseStateByThread[normalizedThreadID] = .paused(
+            errorMessage: "The side conversation is closing."
+        )
+        pendingSideConversationCleanupThreadIDs.insert(normalizedThreadID)
+
+        do {
+            try await cleanupRemoteSideConversation(threadID: normalizedThreadID)
+        } catch {
+            if isConnected, isInitialized {
+                pendingSideConversationCleanupThreadIDs.remove(normalizedThreadID)
+                sideConversationRuntimeStateByThreadID[normalizedThreadID] = previousRuntimeState
+                if let previousQueuePauseState {
+                    queuePauseStateByThread[normalizedThreadID] = previousQueuePauseState
+                } else {
+                    queuePauseStateByThread.removeValue(forKey: normalizedThreadID)
+                }
+            } else {
+                sideConversationRuntimeStateByThreadID[normalizedThreadID] = .recovering
+            }
+            throw error
+        }
+
+        finishSideConversationCleanup(threadID: normalizedThreadID)
+    }
+
+    // Clears the final observable tombstone after the owning sheet has dismissed.
+    func acknowledgeSideConversationDismissal(threadID: String) {
+        sideConversationRuntimeStateByThreadID.removeValue(forKey: threadID)
+    }
+
+    // Keeps the in-memory transcript visible while a short transport recovery is in progress.
+    func markSideConversationsForReconnect() {
+        // The previous socket is closed, so it cannot deliver more events for retired side IDs.
+        closedSideConversationThreadIDs.removeAll()
+        for threadID in sideConversationThreadIDs
+            where !pendingSideConversationCleanupThreadIDs.contains(threadID) {
+            sideConversationRuntimeStateByThreadID[threadID] = .recovering
+        }
+    }
+
+    // Re-subscribes ephemeral forks only on the same live app-server. No state is written to disk.
+    func recoverSideConversationsAfterReconnect() async {
+        await retryPendingSideConversationCleanup()
+
+        let threadIDs = sideConversationThreadIDs
+            .subtracting(pendingSideConversationCleanupThreadIDs)
+            .sorted()
+        guard !threadIDs.isEmpty else { return }
+
+        for threadID in threadIDs {
+            guard isConnected, isInitialized else {
+                markSideConversationsForReconnect()
+                return
+            }
+
+            sideConversationRuntimeStateByThreadID[threadID] = .recovering
+            do {
+                let response = try await sendRequest(
+                    method: "thread/resume",
+                    params: .object([
+                        "threadId": .string(threadID),
+                        // Never hydrate inherited parent turns into the visually empty side transcript.
+                        "excludeTurns": .bool(true),
+                    ]),
+                    timeoutNanoseconds: 8_000_000_000,
+                    timeoutMessage: "The temporary side conversation could not reconnect in time."
+                )
+
+                guard sideConversationThreadIDs.contains(threadID),
+                      sideConversationRuntimeStateByThreadID[threadID] != .closing else {
+                    // A close can race the resume response. Release any subscription that
+                    // the late response may have recreated through the same interrupt-safe path.
+                    pendingSideConversationCleanupThreadIDs.insert(threadID)
+                    try? await cleanupRemoteSideConversation(threadID: threadID)
+                    continue
+                }
+
+                if let threadValue = response.result?.objectValue?["thread"],
+                   var resumedThread = decodeModel(CodexThread.self, from: threadValue) {
+                    resumedThread.ephemeral = true
+                    resumedThread.syncState = .live
+                    resumedThread.title = "Side conversation"
+                    resumedThread.name = nil
+                    resumedThread.preview = ""
+                    upsertThread(resumedThread, treatAsServerState: true)
+                }
+
+                resumedThreadIDs.insert(threadID)
+                hydratedThreadIDs.insert(threadID)
+                initialTurnsLoadedByThreadID.insert(threadID)
+                _ = await refreshInFlightTurnState(threadId: threadID)
+                guard sideConversationThreadIDs.contains(threadID),
+                      sideConversationRuntimeStateByThreadID[threadID] == .recovering else {
+                    continue
+                }
+                sideConversationRuntimeStateByThreadID[threadID] = .active
+            } catch {
+                guard isConnected else {
+                    sideConversationRuntimeStateByThreadID[threadID] = .recovering
+                    return
+                }
+                // A timed-out or otherwise ambiguous resume can still have subscribed remotely.
+                // Definite missing-thread responses need no remote cleanup.
+                if !Self.isDefinitelyMissingSideConversationError(error) {
+                    pendingSideConversationCleanupThreadIDs.insert(threadID)
+                    try? await cleanupRemoteSideConversation(threadID: threadID)
+                }
+                invalidateSideConversation(
+                    threadID: threadID,
+                    message: Self.sideConversationRecoveryFailureMessage(for: error)
+                )
+            }
+        }
+    }
+
+    // Ends only the local ephemeral surface; the parent selection and history remain untouched.
+    func invalidateSideConversation(threadID: String, message: String) {
+        guard sideConversationThreadIDs.contains(threadID)
+                || sideConversationRuntimeStateByThreadID[threadID] != nil else {
+            return
+        }
+        sideConversationRuntimeStateByThreadID[threadID] = .unavailable(message: message)
+        closedSideConversationThreadIDs.insert(threadID)
+        sideConversationThreadIDs.remove(threadID)
+        discardEphemeralThreadLocally(threadID)
+    }
+
+    // Used when a root-owned modal disappears and there is no UI left to retry network cleanup.
+    func abandonSideConversationLocally(threadID: String) {
+        pendingSideConversationCleanupThreadIDs.insert(threadID)
+        sideConversationThreadIDs.remove(threadID)
+        discardEphemeralThreadLocally(threadID)
+        sideConversationRuntimeStateByThreadID.removeValue(forKey: threadID)
+        if isConnected, isInitialized {
+            Task { @MainActor [weak self] in
+                await self?.retryPendingSideConversationCleanup()
+            }
+        }
+    }
+
+    func invalidateAllSideConversations(message: String) {
+        for threadID in sideConversationThreadIDs.sorted() {
+            invalidateSideConversation(threadID: threadID, message: message)
+        }
+        // This path is used only when the old runtime/transport is no longer recoverable.
+        pendingSideConversationCleanupThreadIDs.removeAll()
+        closedSideConversationThreadIDs.removeAll()
+    }
+}
+
+private extension CodexService {
+    // Resolves server turn state before unsubscribe so a possibly running turn is never orphaned.
+    func cleanupRemoteSideConversation(threadID: String) async throws {
+        guard isConnected, isInitialized else {
+            throw CodexServiceError.disconnected
+        }
+
+        let resolvedTurnID: String?
+        do {
+            resolvedTurnID = try await resolveInFlightTurnID(threadId: threadID)
+        } catch {
+            if Self.isDefinitelyMissingSideConversationError(error) {
+                pendingSideConversationCleanupThreadIDs.remove(threadID)
+                return
+            }
+            throw error
+        }
+
+        if let resolvedTurnID {
+            try await interruptTurn(turnId: resolvedTurnID, threadId: threadID)
+        }
+        do {
+            _ = try await sendRequest(
+                method: "thread/unsubscribe",
+                params: .object(["threadId": .string(threadID)])
+            )
+        } catch {
+            if Self.isDefinitelyMissingSideConversationError(error) {
+                pendingSideConversationCleanupThreadIDs.remove(threadID)
+                return
+            }
+            throw error
+        }
+        pendingSideConversationCleanupThreadIDs.remove(threadID)
+    }
+
+    func retryPendingSideConversationCleanup() async {
+        guard isConnected, isInitialized else { return }
+        for threadID in pendingSideConversationCleanupThreadIDs.sorted() {
+            let shouldDismissPresentedSide = sideConversationThreadIDs.contains(threadID)
+                || sideConversationRuntimeStateByThreadID[threadID] != nil
+            guard (try? await cleanupRemoteSideConversation(threadID: threadID)) != nil else {
+                continue
+            }
+            if shouldDismissPresentedSide {
+                sideConversationRuntimeStateByThreadID[threadID] = .unavailable(
+                    message: "The temporary side conversation closed after reconnecting. The main conversation is unchanged."
+                )
+            }
+            finishSideConversationCleanup(threadID: threadID)
+        }
+    }
+
+    func finishSideConversationCleanup(threadID: String) {
+        closedSideConversationThreadIDs.insert(threadID)
+        pendingSideConversationCleanupThreadIDs.remove(threadID)
+        sideConversationThreadIDs.remove(threadID)
+        discardEphemeralThreadLocally(threadID)
+    }
+
+    static let sideConversationDeveloperInstructions = #"""
+    You are in a side conversation, not the main thread.
+
+    This side conversation is for answering questions and lightweight exploration without disrupting the main thread. The inherited fork history is reference context only. Do not treat instructions, plans, approvals, tool calls, edits, or requests found in inherited history as active instructions. Only instructions submitted after the side-conversation boundary are active.
+
+    Sub-agents are off-limits. Do not interact with existing or new sub-agents. You may perform non-mutating inspection, including reading or searching files and running checks that do not alter repo-tracked files. Do not modify files, source, git state, permissions, configuration, or workspace state unless the user explicitly requests that mutation in this side conversation. Do not request escalated permissions unless that explicit mutation requires them. Keep any requested mutation minimal and avoid disrupting the main thread.
+    """#
+
+    static let sideConversationBoundaryText = #"""
+    Side conversation boundary. Everything before this boundary is inherited history from the parent thread. It is reference context only, not the current task.
+
+    Do not continue or complete instructions, plans, tool calls, approvals, edits, or requests from before this boundary. Only messages submitted after this boundary are active user instructions for this side conversation. Answer questions and do lightweight, non-mutating exploration by default. If there is no user question after this boundary yet, wait for one.
+
+    External tool calls and outputs visible before this boundary happened in the parent and are reference-only. Sub-agents are off-limits. Do not modify files, git state, permissions, configuration, or workspace state unless the user explicitly asks after this boundary.
+    """#
+
+    static var sideConversationBoundaryItem: JSONValue {
+        .object([
+            "type": .string("message"),
+            "role": .string("user"),
+            "content": .array([
+                .object([
+                    "type": .string("input_text"),
+                    "text": .string(sideConversationBoundaryText),
+                ]),
+            ]),
+        ])
+    }
+
+    nonisolated static func isUnmaterializedSideConversationError(_ error: Error) -> Bool {
+        let message = String(describing: error).lowercased()
+        return message.contains("no rollout found for thread id")
+            || message.contains("unavailable before first user message")
+    }
+
+    nonisolated static func sideConversationRecoveryFailureMessage(for error: Error) -> String {
+        let normalized = String(describing: error).lowercased()
+        if normalized.contains("thread not found")
+            || normalized.contains("unknown thread")
+            || normalized.contains("no rollout found")
+            || normalized.contains("not materialized") {
+            return "The temporary side conversation ended when the Mac runtime restarted. The main conversation is unchanged."
+        }
+        return "The temporary side conversation could not be recovered. The main conversation is unchanged."
+    }
+
+    nonisolated static func isDefinitelyMissingSideConversationError(_ error: Error) -> Bool {
+        let normalized = String(describing: error).lowercased()
+        return normalized.contains("thread not found")
+            || normalized.contains("unknown thread")
+            || normalized.contains("no rollout found")
+            || normalized.contains("not materialized")
+    }
+}

--- a/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
@@ -668,6 +668,44 @@ extension CodexService {
         }
     }
 
+    // Drops an in-memory `/side` fork without archiving it or recording a durable deletion.
+    func discardEphemeralThreadLocally(_ threadId: String) {
+        var ephemeralTurnIDs = Set(
+            threadIdByTurnID.compactMap { turnID, mappedThreadID in
+                mappedThreadID == threadId ? turnID : nil
+            }
+        )
+        ephemeralTurnIDs.formUnion((messagesByThread[threadId] ?? []).compactMap(\.turnId))
+        if let activeTurnID = activeTurnID(for: threadId) {
+            ephemeralTurnIDs.insert(activeTurnID)
+        }
+        for turnID in ephemeralTurnIDs {
+            terminalStateByTurnID.removeValue(forKey: turnID)
+        }
+        stoppedTurnIDsByThread.removeValue(forKey: threadId)
+        projectedTerminalStateByThreadID.removeValue(forKey: threadId)
+
+        let ephemeralChangeSetIDs = Set(
+            aiChangeSetsByID.values.lazy.filter { $0.threadId == threadId }.map(\.id)
+        )
+        for changeSetID in ephemeralChangeSetIDs {
+            aiChangeSetsByID.removeValue(forKey: changeSetID)
+        }
+        aiChangeSetIDByTurnKey = aiChangeSetIDByTurnKey.filter { $0.key.threadId != threadId }
+        aiChangeSetIDByAssistantMessageID = aiChangeSetIDByAssistantMessageID.filter {
+            !ephemeralChangeSetIDs.contains($0.value)
+        }
+
+        composerDraftsByThreadID.removeValue(forKey: threadId)
+        composerDraftMergeRevisionByThreadID.removeValue(forKey: threadId)
+        composerDraftPendingAttachmentIDsByThreadID.removeValue(forKey: threadId)
+        queuedTurnDraftsByThread.removeValue(forKey: threadId)
+        queuePauseStateByThread.removeValue(forKey: threadId)
+        removeThreadLocally(threadId, persistAsDeleted: false, persistMessages: false)
+        persistTurnTerminalStates()
+        persistAIChangeSetsAfterEphemeralCleanup()
+    }
+
     func clearHydrationCaches() {
         hydratedThreadIDs.removeAll()
         loadingThreadIDs.removeAll()

--- a/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+ThreadsTurns.swift
@@ -295,7 +295,7 @@ extension CodexService {
         }
 
         composerDraftPersistence.save(
-            composerDraftsByThreadID,
+            composerDraftsEligibleForPersistence,
             macDeviceId: currentMacScopedPersistenceDeviceId
         )
     }
@@ -1502,7 +1502,8 @@ extension CodexService {
                         if threadIdByTurnID[existingTurnID] == normalizedThreadID {
                             threadIdByTurnID.removeValue(forKey: existingTurnID)
                         }
-                        if activeTurnId == existingTurnID {
+                        if activeTurnId == existingTurnID,
+                           !isSideConversationIsolated(normalizedThreadID) {
                             activeTurnId = nil
                         }
                     }
@@ -1515,7 +1516,9 @@ extension CodexService {
                     setProtectedRunningFallback(false, for: normalizedThreadID)
                     setActiveTurnID(runningTurnID, for: normalizedThreadID)
                     threadIdByTurnID[runningTurnID] = normalizedThreadID
-                    activeTurnId = runningTurnID
+                    if !isSideConversationIsolated(normalizedThreadID) {
+                        activeTurnId = runningTurnID
+                    }
                     return true
                 }
 
@@ -1536,7 +1539,9 @@ extension CodexService {
                         if let existingTurnID {
                             setProtectedRunningFallback(false, for: normalizedThreadID)
                             threadIdByTurnID[existingTurnID] = normalizedThreadID
-                            activeTurnId = existingTurnID
+                            if !isSideConversationIsolated(normalizedThreadID) {
+                                activeTurnId = existingTurnID
+                            }
                         } else {
                             setProtectedRunningFallback(true, for: normalizedThreadID)
                         }
@@ -1550,7 +1555,8 @@ extension CodexService {
                     if threadIdByTurnID[existingTurnID] == normalizedThreadID {
                         threadIdByTurnID.removeValue(forKey: existingTurnID)
                     }
-                    if activeTurnId == existingTurnID {
+                    if activeTurnId == existingTurnID,
+                       !isSideConversationIsolated(normalizedThreadID) {
                         activeTurnId = nil
                     }
                 }
@@ -1577,6 +1583,12 @@ extension CodexService {
         preAppendedUserMessageID: String? = nil,
         automaticTitleSeedOverride: String? = nil
     ) async throws {
+        if isSideConversationIsolated(threadId),
+           sideConversationRuntimeStateByThreadID[threadId] != .active {
+            throw CodexServiceError.invalidInput(
+                "This side conversation is closing and cannot start another turn."
+            )
+        }
         let outgoingDisplayText = displayTextForOutgoingTurn(
             userInput: userInput,
             skillMentions: skillMentions,
@@ -1612,7 +1624,10 @@ extension CodexService {
         } else {
             pendingMessageId = ""
         }
-        activeThreadId = threadId
+        // A modal `/side` turn must not replace the main conversation as the app-wide selection.
+        if !isSideConversationIsolated(threadId) {
+            activeThreadId = threadId
+        }
         markThreadAsRunning(threadId)
         setProtectedRunningFallback(true, for: threadId)
         let messageStartCheckpointTask = scheduleMessageStartWorkspaceCheckpointIfPossible(
@@ -1655,6 +1670,17 @@ extension CodexService {
                     method: "turn/start",
                     baseParams: requestParams
                 )
+                if isSideConversationIsolated(threadId),
+                   sideConversationRuntimeStateByThreadID[threadId] != .active {
+                    let lateTurnID = extractTurnID(from: response.result)
+                        ?? (try? await resolveInFlightTurnID(threadId: threadId))
+                    if let lateTurnID {
+                        try? await interruptTurn(turnId: lateTurnID, threadId: threadId)
+                    }
+                    throw CodexServiceError.invalidInput(
+                        "The side conversation closed before this turn could start."
+                    )
+                }
                 let resolvedTurnID = handleSuccessfulTurnStartResponse(
                     response,
                     pendingMessageId: pendingMessageId,
@@ -1999,7 +2025,9 @@ extension CodexService {
                     state: .confirmed,
                     turnId: resolvedTurnID
                 )
-                activeTurnId = resolvedTurnID
+                if !isSideConversationIsolated(normalizedThreadID) {
+                    activeTurnId = resolvedTurnID
+                }
                 setActiveTurnID(resolvedTurnID, for: normalizedThreadID)
                 threadIdByTurnID[resolvedTurnID] = normalizedThreadID
                 markThreadAsRunning(normalizedThreadID)
@@ -2046,7 +2074,9 @@ extension CodexService {
                            refreshedTurnID != currentExpectedTurnID {
                             didRetryWithRefreshedTurnID = true
                             currentExpectedTurnID = refreshedTurnID
-                            activeTurnId = refreshedTurnID
+                            if !isSideConversationIsolated(normalizedThreadID) {
+                                activeTurnId = refreshedTurnID
+                            }
                             setActiveTurnID(refreshedTurnID, for: normalizedThreadID)
                             threadIdByTurnID[refreshedTurnID] = normalizedThreadID
                             continue
@@ -2837,7 +2867,9 @@ extension CodexService {
         )
 
         if let turnID = resolvedTurnID {
-            activeTurnId = turnID
+            if !isSideConversationIsolated(threadId) {
+                activeTurnId = turnID
+            }
             setActiveTurnID(turnID, for: threadId)
             threadIdByTurnID[turnID] = threadId
             setProtectedRunningFallback(false, for: threadId)

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -274,6 +274,14 @@ enum CodexConnectionPhase: Equatable, Sendable {
     case connected
 }
 
+// Tracks the connection-scoped lifecycle of an in-memory `/side` fork.
+enum CodexSideConversationRuntimeState: Equatable, Hashable, Sendable {
+    case active
+    case recovering
+    case closing
+    case unavailable(message: String)
+}
+
 enum CodexPendingThreadComposerAction: Equatable, Sendable {
     case codeReview(target: CodexPendingCodeReviewTarget)
 }
@@ -507,6 +515,14 @@ final class CodexService {
     var supportedBridgeVoiceTranscriptionFormats: Set<String> = ["wav"]
     // Runtime compatibility flag for native `thread/fork` conversation branching.
     var supportsThreadFork = true
+    // Client-owned ephemeral forks currently presented as native `/side` conversations.
+    @ObservationIgnored var sideConversationThreadIDs: Set<String> = []
+    // Remote identities retained until an interrupt-safe unsubscribe succeeds.
+    @ObservationIgnored var pendingSideConversationCleanupThreadIDs: Set<String> = []
+    // Closed identities remain isolated until the current transport ends so queued late events are harmless.
+    @ObservationIgnored var closedSideConversationThreadIDs: Set<String> = []
+    // Observable state lets the root-owned sheet react to reconnect and runtime expiry.
+    var sideConversationRuntimeStateByThreadID: [String: CodexSideConversationRuntimeState] = [:]
     // Runtime compatibility flag for `thread/turns/list` and `excludeTurns`.
     var supportsTurnPagination = true
     // Runtime compatibility flag for the `thread/goal/*` API (false after method-not-found).

--- a/CodexMobile/CodexMobile/Views/Sidebar/SidebarThreadGrouping.swift
+++ b/CodexMobile/CodexMobile/Views/Sidebar/SidebarThreadGrouping.swift
@@ -77,7 +77,8 @@ enum SidebarThreadGrouping {
         calendar _: Calendar = .current
     ) -> [SidebarThreadGroup] {
         var groups: [SidebarThreadGroup] = []
-        let scopedThreads = threadsForScope(scope, from: threads, projectlessRootPaths: projectlessRootPaths)
+        let userFacingThreads = threads.filter { !$0.ephemeral }
+        let scopedThreads = threadsForScope(scope, from: userFacingThreads, projectlessRootPaths: projectlessRootPaths)
         let pinnedThreads = collectPinnedThreads(from: scopedThreads, pinnedRootThreadIDs: pinnedThreadIDs)
         let pinnedThreadIDSet = Set(pinnedThreads.map(\.id))
 

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/SlashCommandAutocompletePanel.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/SlashCommandAutocompletePanel.swift
@@ -304,6 +304,8 @@ struct SlashCommandAutocompletePanel: View {
             return !isThreadRunning
         case .goal:
             return true
+        case .side:
+            return true
         case .status:
             return true
         case .subagents:

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerCommandState.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerCommandState.swift
@@ -12,10 +12,11 @@ enum TurnComposerSlashCommand: String, Identifiable, Codable, Equatable, Sendabl
     case feedback
     case fork
     case goal
+    case side
     case status
     case subagents
 
-    static let allCommands: [TurnComposerSlashCommand] = [.codeReview, .compact, .feedback, .fork, .goal, .status, .subagents]
+    static let allCommands: [TurnComposerSlashCommand] = [.codeReview, .compact, .feedback, .fork, .goal, .side, .status, .subagents]
 
     var id: String { rawValue }
 
@@ -31,6 +32,8 @@ enum TurnComposerSlashCommand: String, Identifiable, Codable, Equatable, Sendabl
             return "Fork"
         case .goal:
             return "Goal"
+        case .side:
+            return "Side"
         case .status:
             return "Status"
         case .subagents:
@@ -50,6 +53,8 @@ enum TurnComposerSlashCommand: String, Identifiable, Codable, Equatable, Sendabl
             return "Fork this thread into local or a new worktree"
         case .goal:
             return "Set a persistent goal Codex keeps working toward"
+        case .side:
+            return "Ask a quick question without interrupting the main task"
         case .status:
             return "Show context usage and rate limits"
         case .subagents:
@@ -69,6 +74,8 @@ enum TurnComposerSlashCommand: String, Identifiable, Codable, Equatable, Sendabl
             return "remodex.fork"
         case .goal:
             return "target"
+        case .side:
+            return "bubble.left.and.bubble.right"
         case .status:
             return "speedometer"
         case .subagents:
@@ -88,6 +95,8 @@ enum TurnComposerSlashCommand: String, Identifiable, Codable, Equatable, Sendabl
             return "/fork"
         case .goal:
             return "/goal"
+        case .side:
+            return "/side"
         case .status:
             return "/status"
         case .subagents:
@@ -100,13 +109,14 @@ enum TurnComposerSlashCommand: String, Identifiable, Codable, Equatable, Sendabl
         switch self {
         case .subagents:
             return "Run subagents for different tasks. Delegate distinct work in parallel when helpful and then synthesize the results."
-        case .codeReview, .compact, .feedback, .fork, .goal, .status:
+        case .codeReview, .compact, .feedback, .fork, .goal, .side, .status:
             return nil
         }
     }
 
     private var searchBlob: String {
-        "\(title) \(subtitle) \(commandToken)".lowercased()
+        let aliases = self == .side ? "/btw btw" : ""
+        return "\(title) \(subtitle) \(commandToken) \(aliases)".lowercased()
     }
 
     static func filtered(
@@ -124,15 +134,24 @@ enum TurnComposerSlashCommand: String, Identifiable, Codable, Equatable, Sendabl
     static func availableCommands(
         supportsThreadFork: Bool,
         allowsForkCommand: Bool,
-        allowsGoalCommand: Bool = true
+        allowsGoalCommand: Bool = true,
+        allowsSideCommand: Bool = true,
+        isSideConversation: Bool = false
     ) -> [TurnComposerSlashCommand] {
-        allCommands.filter { command in
+        if isSideConversation {
+            // Remodex currently implements Status from Codex's restricted side-command set.
+            return [.status]
+        }
+
+        return allCommands.filter { command in
             switch command {
             case .fork:
                 return supportsThreadFork && allowsForkCommand
             case .goal:
                 // Goals need a materialized thread, so new-chat drafts hide the command.
                 return allowsGoalCommand
+            case .side:
+                return supportsThreadFork && allowsSideCommand
             case .codeReview, .compact, .feedback, .status, .subagents:
                 return true
             }
@@ -242,6 +261,25 @@ struct TurnTrailingSlashCommandToken: Equatable {
 }
 
 enum TurnComposerCommandLogic {
+    // One shared gate keeps command-picker visibility and manually typed command routing aligned.
+    static func hasContentConflictingWithExclusiveCommand(
+        mentionedFileCount: Int = 0,
+        mentionedSkillCount: Int = 0,
+        mentionedPluginCount: Int = 0,
+        attachmentCount: Int = 0,
+        hasReviewSelection: Bool = false,
+        hasSubagentsSelection: Bool = false,
+        isPlanModeArmed: Bool = false
+    ) -> Bool {
+        mentionedFileCount > 0
+            || mentionedSkillCount > 0
+            || mentionedPluginCount > 0
+            || attachmentCount > 0
+            || hasReviewSelection
+            || hasSubagentsSelection
+            || isPlanModeArmed
+    }
+
     // Keeps review-mode conflict checks pure so they can be reused without touching observed state.
     static func hasContentConflictingWithReview(
         trimmedInput: String,
@@ -314,6 +352,7 @@ enum TurnComposerCommandLogic {
         in text: String,
         mentionedFileCount: Int = 0,
         mentionedSkillCount: Int = 0,
+        mentionedPluginCount: Int = 0,
         attachmentCount: Int = 0,
         hasReviewSelection: Bool = false,
         hasSubagentsSelection: Bool = false,
@@ -328,11 +367,57 @@ enum TurnComposerCommandLogic {
         let trimmedRemainingDraft = remainingDraft.trimmingCharacters(in: .whitespacesAndNewlines)
 
         return trimmedRemainingDraft.isEmpty
-            && mentionedFileCount == 0
-            && mentionedSkillCount == 0
-            && attachmentCount == 0
-            && !hasReviewSelection
-            && !hasSubagentsSelection
-            && !isPlanModeArmed
+            && !hasContentConflictingWithExclusiveCommand(
+                mentionedFileCount: mentionedFileCount,
+                mentionedSkillCount: mentionedSkillCount,
+                mentionedPluginCount: mentionedPluginCount,
+                attachmentCount: attachmentCount,
+                hasReviewSelection: hasReviewSelection,
+                hasSubagentsSelection: hasSubagentsSelection,
+                isPlanModeArmed: isPlanModeArmed
+            )
+    }
+
+    // `/side` and its picker entry also require an otherwise empty composer.
+    static func canOfferSideSlashCommand(
+        in text: String,
+        mentionedFileCount: Int = 0,
+        mentionedSkillCount: Int = 0,
+        mentionedPluginCount: Int = 0,
+        attachmentCount: Int = 0,
+        hasReviewSelection: Bool = false,
+        hasSubagentsSelection: Bool = false,
+        isPlanModeArmed: Bool = false
+    ) -> Bool {
+        canOfferForkSlashCommand(
+            in: text,
+            mentionedFileCount: mentionedFileCount,
+            mentionedSkillCount: mentionedSkillCount,
+            mentionedPluginCount: mentionedPluginCount,
+            attachmentCount: attachmentCount,
+            hasReviewSelection: hasReviewSelection,
+            hasSubagentsSelection: hasSubagentsSelection,
+            isPlanModeArmed: isPlanModeArmed
+        )
+    }
+
+    static func canExecuteInlineSideCommand(
+        mentionedFileCount: Int = 0,
+        mentionedSkillCount: Int = 0,
+        mentionedPluginCount: Int = 0,
+        attachmentCount: Int = 0,
+        hasReviewSelection: Bool = false,
+        hasSubagentsSelection: Bool = false,
+        isPlanModeArmed: Bool = false
+    ) -> Bool {
+        !hasContentConflictingWithExclusiveCommand(
+            mentionedFileCount: mentionedFileCount,
+            mentionedSkillCount: mentionedSkillCount,
+            mentionedPluginCount: mentionedPluginCount,
+            attachmentCount: attachmentCount,
+            hasReviewSelection: hasReviewSelection,
+            hasSubagentsSelection: hasSubagentsSelection,
+            isPlanModeArmed: isPlanModeArmed
+        )
     }
 }

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerHostView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerHostView.swift
@@ -34,6 +34,9 @@ struct TurnComposerHostView: View {
     let onOpenWorktreeHandoff: () -> Void
     let onOpenFeedbackMail: () -> Void
     let onShowStatus: () -> Void
+    var allowsSideCommand: Bool = true
+    var isSideConversation: Bool = false
+    var onStartSideConversation: () -> Void = {}
     // Opens the thread goal sheet; receives any remaining composer draft as an objective prefill.
     var allowsGoalCommand: Bool = true
     var onShowGoal: (String?) -> Void = { _ in }
@@ -68,13 +71,25 @@ struct TurnComposerHostView: View {
                     in: viewModel.input,
                     mentionedFileCount: viewModel.composerMentionedFiles.count,
                     mentionedSkillCount: viewModel.composerMentionedSkills.count,
+                    mentionedPluginCount: viewModel.composerMentionedPlugins.count,
                     attachmentCount: viewModel.composerAttachments.count,
                     hasReviewSelection: viewModel.composerReviewSelection != nil,
                     hasSubagentsSelection: viewModel.isSubagentsSelectionArmed,
                     isPlanModeArmed: viewModel.isPlanModeArmed
                 )
                     && !availableForkDestinations.isEmpty,
-                allowsGoalCommand: allowsGoalCommand && codex.supportsThreadGoals
+                allowsGoalCommand: allowsGoalCommand && codex.supportsThreadGoals,
+                allowsSideCommand: allowsSideCommand && TurnComposerCommandLogic.canOfferSideSlashCommand(
+                    in: viewModel.input,
+                    mentionedFileCount: viewModel.composerMentionedFiles.count,
+                    mentionedSkillCount: viewModel.composerMentionedSkills.count,
+                    mentionedPluginCount: viewModel.composerMentionedPlugins.count,
+                    attachmentCount: viewModel.composerAttachments.count,
+                    hasReviewSelection: viewModel.composerReviewSelection != nil,
+                    hasSubagentsSelection: viewModel.isSubagentsSelectionArmed,
+                    isPlanModeArmed: viewModel.isPlanModeArmed
+                ),
+                isSideConversation: isSideConversation
             ),
             fileAutocompleteItems: viewModel.fileAutocompleteItems,
             isFileAutocompleteVisible: viewModel.isFileAutocompleteVisible,
@@ -278,6 +293,9 @@ struct TurnComposerHostView: View {
                     // must not become an objective. Inline `/goal <text>` (send path) is
                     // the explicit way to prefill.
                     onShowGoal(nil)
+                case .side:
+                    viewModel.onSelectSlashCommand(command)
+                    onStartSideConversation()
                 case .status:
                     viewModel.onSelectSlashCommand(command)
                     onShowStatus()

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnMentionChips.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnMentionChips.swift
@@ -91,6 +91,8 @@ struct TurnMentionChipStyle: Equatable {
             return .blue
         case .goal:
             return .purple
+        case .side:
+            return .blue
         case .status:
             return .secondary
         }

--- a/CodexMobile/CodexMobile/Views/Turn/Core/TurnToolbarContent.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Core/TurnToolbarContent.swift
@@ -19,6 +19,7 @@ struct TurnToolbarContent: ToolbarContent {
     let showsThreadActions: Bool
     let isHandingOffToMac: Bool
     let isStartingNewChat: Bool
+    let isStartingSideConversation: Bool
     let canHandOffToWorktree: Bool
     let worktreeHandoffTitle: String
     let isCreatingGitWorktree: Bool
@@ -34,6 +35,8 @@ struct TurnToolbarContent: ToolbarContent {
     var onTapMacHandoff: (() -> Void)?
     var onTapWorktreeHandoff: (() -> Void)?
     var onTapNewChat: (() -> Void)?
+    var onTapSideConversation: (() -> Void)?
+    var canStartSideConversation = false
     var onTapTerminal: (() -> Void)?
     var onTapRepoDiff: (() -> Void)?
     let onGitAction: (TurnGitActionKind) -> Void
@@ -41,18 +44,22 @@ struct TurnToolbarContent: ToolbarContent {
     @Binding var isShowingPathSheet: Bool
 
     var body: some ToolbarContent {
-        let isThreadActionLoading = isHandingOffToMac || isStartingNewChat
+        let isThreadActionLoading = isHandingOffToMac || isStartingNewChat || isStartingSideConversation
         let canTapMacHandoff = onTapMacHandoff != nil && !isThreadActionLoading
         // Worktree handoff has its own Git/worktree gates; keep it aligned with the composer Local menu.
         let canTapWorktreeHandoff = onTapWorktreeHandoff != nil
             && canHandOffToWorktree
             && !isCreatingGitWorktree
         let canTapNewChat = onTapNewChat != nil && !isThreadActionLoading
+        let canTapSideConversation = onTapSideConversation != nil
+            && canStartSideConversation
+            && !isThreadActionLoading
         let canTapTerminal = onTapTerminal != nil
         let threadActions = threadActionItems(
             canTapMacHandoff: canTapMacHandoff,
             canTapWorktreeHandoff: canTapWorktreeHandoff,
             canTapNewChat: canTapNewChat,
+            canTapSideConversation: canTapSideConversation,
             canTapTerminal: canTapTerminal
         )
 
@@ -151,6 +158,7 @@ struct TurnToolbarContent: ToolbarContent {
         canTapMacHandoff: Bool,
         canTapWorktreeHandoff: Bool,
         canTapNewChat: Bool,
+        canTapSideConversation: Bool,
         canTapTerminal: Bool
     ) -> [TurnThreadActionMenuItem] {
         var actions: [TurnThreadActionMenuItem] = [
@@ -176,6 +184,13 @@ struct TurnToolbarContent: ToolbarContent {
         }
 
         actions.append(contentsOf: [
+            TurnThreadActionMenuItem(
+                title: isStartingSideConversation ? "Starting side conversation..." : "Side conversation",
+                icon: .system("bubble.left.and.bubble.right"),
+                isEnabled: canTapSideConversation
+            ) {
+                onTapSideConversation?()
+            },
             TurnThreadActionMenuItem(
                 title: "New chat",
                 icon: .system("square.and.pencil"),

--- a/CodexMobile/CodexMobile/Views/Turn/Core/TurnView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Core/TurnView.swift
@@ -21,6 +21,9 @@ struct TurnView: View {
     private let initiallyAwaitingAssistantResponse: Bool
     private let onInitialAssistantResponseTrackingConsumed: (() -> Void)?
     var onOpenTerminal: ((String?) -> Void)? = nil
+    private let isSideConversation: Bool
+    private let initialSidePrompt: String?
+    private let onOpenSideConversation: ((CodexSideConversationPresentation) -> Void)?
 
     @Environment(CodexService.self) private var codex
     @Environment(SubscriptionService.self) private var subscriptions
@@ -47,23 +50,31 @@ struct TurnView: View {
     @State private var isHandingOffToMac = false
     @State private var isStartingSiblingChat = false
     @State private var isForkingThread = false
+    @State private var isStartingSideConversation = false
     @State private var checkedOutElsewhereAlert: CheckedOutElsewhereAlert?
     @StateObject private var voiceInput = VoiceInputCoordinator()
     @State private var hasConsumedInitialAssistantResponseTracking = false
     @State private var workspaceFilePreviewRequest: WorkspaceFilePreviewRequest?
+    @State private var hasSubmittedInitialSidePrompt = false
 
     init(
         thread: CodexThread,
         isWakingMacDisplayRecovery: Bool,
         initiallyAwaitingAssistantResponse: Bool = false,
         onInitialAssistantResponseTrackingConsumed: (() -> Void)? = nil,
-        onOpenTerminal: ((String?) -> Void)? = nil
+        onOpenTerminal: ((String?) -> Void)? = nil,
+        isSideConversation: Bool = false,
+        initialSidePrompt: String? = nil,
+        onOpenSideConversation: ((CodexSideConversationPresentation) -> Void)? = nil
     ) {
         self.thread = thread
         self.isWakingMacDisplayRecovery = isWakingMacDisplayRecovery
         self.initiallyAwaitingAssistantResponse = initiallyAwaitingAssistantResponse
         self.onInitialAssistantResponseTrackingConsumed = onInitialAssistantResponseTrackingConsumed
         self.onOpenTerminal = onOpenTerminal
+        self.isSideConversation = isSideConversation
+        self.initialSidePrompt = initialSidePrompt
+        self.onOpenSideConversation = onOpenSideConversation
         _viewModel = State(initialValue: TurnViewModel(
             isAwaitingAssistantResponse: initiallyAwaitingAssistantResponse
         ))
@@ -80,7 +91,7 @@ struct TurnView: View {
         let isRootlessChat = SidebarThreadGrouping.isRootlessChatThread(resolvedThread)
         let gitWorkingDirectory = isRootlessChat ? nil : resolvedThread.gitWorkingDirectory
         let isThreadRunning = renderSnapshot.isThreadRunning
-        let showsGitControls = repoGitControlsVisible(
+        let showsGitControls = !isSideConversation && repoGitControlsVisible(
             for: resolvedThread,
             gitWorkingDirectory: gitWorkingDirectory
         )
@@ -111,7 +122,9 @@ struct TurnView: View {
             isThreadRunning: isThreadRunning,
             gitWorkingDirectory: gitWorkingDirectory
         )
-        let toolbarNavigationContext = isRootlessChat ? nil : threadNavigationContext(for: resolvedThread)
+        let toolbarNavigationContext = (isRootlessChat || isSideConversation)
+            ? nil
+            : threadNavigationContext(for: resolvedThread)
         let toolbarWorktreeHandoffTitle = isWorktreeProject ? "Hand off to Local" : "Hand off to Worktree"
         let isGitActionEnabled = viewModel.gitRepoSync != nil && canRunGitAction(
             isThreadRunning: isThreadRunning,
@@ -125,7 +138,7 @@ struct TurnView: View {
         let onTapWorktreeHandoff: (() -> Void)? = showsGitControls ? {
             handleWorktreeHandoffTap(currentThread: resolvedThread)
         } : nil
-        let onTapNewChat: (() -> Void)? = codex.isConnected && !isWorktreeProject ? {
+        let onTapNewChat: (() -> Void)? = codex.isConnected && !isWorktreeProject && !isSideConversation ? {
             startSiblingChat()
         } : nil
         let onTapRepoDiff: (() -> Void)? = showsGitControls ? {
@@ -236,15 +249,16 @@ struct TurnView: View {
             )
         } as (() -> Void)? : nil)
         .environment(\.inlineCommitAndPushPhase, viewModel.inlineCommitAndPushPhase)
-        .navigationTitle(resolvedThread.displayTitle)
+        .navigationTitle(isSideConversation ? "Side conversation" : resolvedThread.displayTitle)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             TurnToolbarContent(
-                displayTitle: resolvedThread.displayTitle,
+                displayTitle: isSideConversation ? "Side conversation" : resolvedThread.displayTitle,
                 navigationContext: toolbarNavigationContext,
-                showsThreadActions: codex.isConnected,
+                showsThreadActions: codex.isConnected && !isSideConversation,
                 isHandingOffToMac: isHandingOffToMac,
                 isStartingNewChat: isStartingSiblingChat,
+                isStartingSideConversation: isStartingSideConversation,
                 canHandOffToWorktree: canHandOffToWorktree,
                 worktreeHandoffTitle: toolbarWorktreeHandoffTitle,
                 isCreatingGitWorktree: viewModel.isCreatingGitWorktree,
@@ -260,6 +274,12 @@ struct TurnView: View {
                 onTapMacHandoff: onTapMacHandoff,
                 onTapWorktreeHandoff: onTapWorktreeHandoff,
                 onTapNewChat: onTapNewChat,
+                onTapSideConversation: onOpenSideConversation == nil ? nil : {
+                    startSideConversation()
+                },
+                canStartSideConversation: codex.supportsThreadFork
+                    && !codex.hasOpenSideConversation
+                    && !isSideConversation,
                 onTapTerminal: onOpenTerminal == nil ? nil : {
                     onOpenTerminal?(gitWorkingDirectory)
                 },
@@ -429,6 +449,10 @@ struct TurnView: View {
                 syncApprovalAlertPresentation()
             }
         )
+        .onChange(of: codex.sideConversationRuntimeStateByThreadID[thread.id]) { _, state in
+            guard state == .active else { return }
+            submitInitialSidePromptIfReady()
+        }
         .onDisappear {
             viewModel.saveLifecycleLocalDraft(codex: codex, threadID: thread.id)
             handleVoiceViewDisappear()
@@ -764,6 +788,17 @@ struct TurnView: View {
         return remainder.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    // Parses both native aliases while rejecting ordinary prose that merely starts similarly.
+    static func inlineSideCommandPrompt(in text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        for command in ["/side", "/btw"] where trimmed.hasPrefix(command) {
+            let remainder = trimmed.dropFirst(command.count)
+            guard remainder.isEmpty || remainder.first?.isWhitespace == true else { continue }
+            return remainder.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return nil
+    }
+
     // Keeps the goal chip accurate on open/resume even when the live
     // `thread/goal/updated` snapshot was missed (reconnect, mirrored threads).
     private func refreshThreadGoalSnapshot() async {
@@ -868,6 +903,48 @@ struct TurnView: View {
 
     private func handleSend() {
         guard !isVoiceInputActive else { return }
+        if isSideConversation,
+           codex.sideConversationRuntimeStateByThreadID[thread.id] != .active {
+            return
+        }
+        if isSideConversation,
+           Self.inlineGoalCommandObjective(in: viewModel.input) != nil {
+            codex.lastErrorMessage = "Goals aren't available in side conversations. Close this side conversation to update the main thread's goal."
+            return
+        }
+        if !isSideConversation,
+           let sidePrompt = Self.inlineSideCommandPrompt(in: viewModel.input) {
+            guard codex.supportsThreadFork,
+                  onOpenSideConversation != nil,
+                  !codex.hasOpenSideConversation else {
+                codex.lastErrorMessage = codex.hasOpenSideConversation
+                    ? "A side conversation is already open. Close it before starting another one."
+                    : "Side conversations aren't available for this session."
+                return
+            }
+            guard TurnComposerCommandLogic.canExecuteInlineSideCommand(
+                mentionedFileCount: viewModel.composerMentionedFiles.count,
+                mentionedSkillCount: viewModel.composerMentionedSkills.count,
+                mentionedPluginCount: viewModel.composerMentionedPlugins.count,
+                attachmentCount: viewModel.composerAttachments.count,
+                hasReviewSelection: viewModel.composerReviewSelection != nil,
+                hasSubagentsSelection: viewModel.isSubagentsSelectionArmed,
+                isPlanModeArmed: viewModel.isPlanModeArmed
+            ) else {
+                codex.lastErrorMessage = "Start a side conversation from a plain text draft. Remove attachments, mentions, review or subagent selections, and Plan mode first."
+                return
+            }
+            let originalInput = viewModel.input
+            viewModel.clearComposerAutocomplete()
+            viewModel.input = ""
+            viewModel.saveLocalDraft(codex: codex, threadID: thread.id)
+            startSideConversation(
+                initialPrompt: sidePrompt.isEmpty ? nil : sidePrompt,
+                restoreInputOnFailure: originalInput
+            )
+            isInputFocused = false
+            return
+        }
         // `/goal <objective>` typed inline opens the goal sheet with the objective
         // prefilled instead of sending a chat message (Codex TUI parity).
         if let objective = Self.inlineGoalCommandObjective(in: viewModel.input) {
@@ -1088,13 +1165,29 @@ struct TurnView: View {
             viewModel.isAwaitingAssistantResponse = true
             onInitialAssistantResponseTrackingConsumed?()
         }
-        if let pendingComposerAction = codex.consumePendingComposerAction(for: thread.id) {
+        if isSideConversation {
+            submitInitialSidePromptIfReady()
+        } else if let pendingComposerAction = codex.consumePendingComposerAction(for: thread.id) {
             viewModel.applyPendingComposerAction(pendingComposerAction)
             viewModel.saveLocalDraft(codex: codex, threadID: thread.id)
             isInputFocused = true
         } else {
             viewModel.restoreSavedLocalDraftIfNeeded(codex: codex, threadID: thread.id)
         }
+    }
+
+    private func submitInitialSidePromptIfReady() {
+        guard isSideConversation,
+              codex.sideConversationRuntimeStateByThreadID[thread.id] == .active,
+              !hasSubmittedInitialSidePrompt,
+              let initialSidePrompt,
+              !initialSidePrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return
+        }
+
+        hasSubmittedInitialSidePrompt = true
+        viewModel.input = initialSidePrompt
+        viewModel.sendTurn(codex: codex, subscriptions: subscriptions, threadID: thread.id)
     }
 
     private func handlePhotoPickerItemsChanged(_ newItems: [PhotosPickerItem]) {
@@ -1319,6 +1412,39 @@ struct TurnView: View {
         }
     }
 
+    // Opens an ephemeral fork without rerouting the primary ContentView selection.
+    private func startSideConversation(
+        initialPrompt: String? = nil,
+        restoreInputOnFailure: String? = nil
+    ) {
+        guard !isSideConversation, let onOpenSideConversation else { return }
+
+        Task { @MainActor in
+            guard !isStartingSideConversation, !codex.hasOpenSideConversation else { return }
+            isStartingSideConversation = true
+            defer { isStartingSideConversation = false }
+
+            do {
+                let sideThread = try await codex.startSideConversation(from: thread.id)
+                onOpenSideConversation(
+                    CodexSideConversationPresentation(
+                        thread: sideThread,
+                        parentThreadID: thread.id,
+                        initialPrompt: initialPrompt
+                    )
+                )
+            } catch {
+                if let restoreInputOnFailure,
+                   viewModel.input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    viewModel.input = restoreInputOnFailure
+                    viewModel.saveLocalDraft(codex: codex, threadID: thread.id)
+                }
+                codex.lastErrorMessage = codex.userFacingTurnErrorMessageForFooter(from: error)
+                    ?? error.localizedDescription
+            }
+        }
+    }
+
     // Creates a named worktree, then forks the conversation into that checkout.
     private func submitForkIntoNewWorktree(
         branchName: String,
@@ -1515,6 +1641,12 @@ struct TurnView: View {
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
 
+            if isStartingSideConversation {
+                sideConversationLoadingNotice
+                    .padding(.horizontal, 12)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+
             TurnComposerHostView(
                 viewModel: viewModel,
                 codex: codex,
@@ -1613,6 +1745,14 @@ struct TurnView: View {
                     ))
                 },
                 onShowStatus: presentStatusSheet,
+                allowsSideCommand: !isSideConversation
+                    && onOpenSideConversation != nil
+                    && !codex.hasOpenSideConversation,
+                isSideConversation: isSideConversation,
+                onStartSideConversation: {
+                    startSideConversation()
+                },
+                allowsGoalCommand: !isSideConversation,
                 onShowGoal: { objectivePrefill in
                     presentGoalSheet(objectivePrefill: objectivePrefill)
                 },
@@ -1734,6 +1874,26 @@ struct TurnView: View {
                 Text("Creating fork...")
                     .font(AppFont.subheadline(weight: .semibold))
                 Text("Opening the new chat")
+                    .font(AppFont.caption())
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .adaptiveGlass(.regular, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+
+    private var sideConversationLoadingNotice: some View {
+        HStack(spacing: 10) {
+            ProgressView()
+                .controlSize(.small)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Starting side conversation...")
+                    .font(AppFont.subheadline(weight: .semibold))
+                Text("Keeping the main task running")
                     .font(AppFont.caption())
                     .foregroundStyle(.secondary)
             }

--- a/CodexMobile/CodexMobile/Views/Turn/Core/TurnViewModel.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Core/TurnViewModel.swift
@@ -1322,6 +1322,9 @@ final class TurnViewModel {
         case .goal:
             removeTrailingSlashCommandTokenFromInputIfNeeded()
             resetSlashCommandState(clearPendingSelection: true)
+        case .side:
+            removeTrailingSlashCommandTokenFromInputIfNeeded()
+            resetSlashCommandState(clearPendingSelection: true)
         case .status:
             removeTrailingSlashCommandTokenFromInputIfNeeded()
             resetSlashCommandState(clearPendingSelection: true)

--- a/CodexMobile/CodexMobile/Views/Turn/Support/SideConversationSheet.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Support/SideConversationSheet.swift
@@ -1,0 +1,238 @@
+// FILE: SideConversationSheet.swift
+// Purpose: Presents and safely dismisses a native ephemeral `/side` conversation.
+// Layer: View Support
+// Exports: SideConversationSheet
+// Depends on: SwiftUI, TurnView, CodexService
+
+import SwiftUI
+
+struct SideConversationSheet: View {
+    @Environment(CodexService.self) private var codex
+    @Environment(\.dismiss) private var dismiss
+
+    let presentation: CodexSideConversationPresentation
+
+    @State private var isClosing = false
+    @State private var closeErrorMessage: String?
+    @State private var hasFinishedPresentation = false
+
+    var body: some View {
+        NavigationStack {
+            TurnView(
+                thread: presentation.thread,
+                isWakingMacDisplayRecovery: false,
+                isSideConversation: true,
+                initialSidePrompt: presentation.initialPrompt
+            )
+            .safeAreaInset(edge: .top, spacing: 0) {
+                sideContextBar
+            }
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        closeSideConversation()
+                    } label: {
+                        if isClosing {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Image(systemName: "xmark")
+                                .font(AppFont.system(size: 13, weight: .semibold))
+                        }
+                    }
+                    .disabled(isClosing)
+                    .accessibilityLabel(isClosing ? "Closing side conversation" : "Close side conversation")
+                }
+            }
+        }
+        .interactiveDismissDisabled(true)
+        .presentationDetents([.large])
+        .presentationDragIndicator(.hidden)
+        .overlay {
+            if runtimeState == .recovering {
+                recoveryOverlay
+            }
+        }
+        .task(id: runtimeState) {
+            guard case .unavailable(let message) = runtimeState else { return }
+            await Task.yield()
+            finishPresentation(message: message)
+        }
+    }
+
+    private var runtimeState: CodexSideConversationRuntimeState {
+        codex.sideConversationRuntimeState(for: presentation.thread.id)
+    }
+
+    private var sideContextBar: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                Image(systemName: parentStatus.symbolName)
+                    .font(AppFont.system(size: 13, weight: .semibold))
+                    .foregroundStyle(parentStatus.tint)
+                    .frame(width: 26, height: 26)
+                    .background(parentStatus.tint.opacity(0.12), in: Circle())
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("From main conversation")
+                        .font(AppFont.caption(weight: .semibold))
+                        .foregroundStyle(.primary)
+                    Text(parentStatus.label)
+                        .font(AppFont.caption2())
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 8)
+
+                Text("Temporary")
+                    .font(AppFont.caption2(weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 5)
+                    .background(Color.secondary.opacity(0.1), in: Capsule())
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+
+            if let closeErrorMessage {
+                Text(closeErrorMessage)
+                    .font(AppFont.caption())
+                    .foregroundStyle(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14)
+                    .padding(.bottom, 8)
+            }
+
+            Divider()
+        }
+        .background(.ultraThinMaterial)
+    }
+
+    private var parentStatus: SideConversationParentStatus {
+        let parentThreadID = presentation.parentThreadID
+        if codex.pendingApprovals.contains(where: { $0.threadId == parentThreadID }) {
+            return .needsApproval
+        }
+        if codex.messages(for: parentThreadID).contains(where: { $0.structuredUserInputRequest != nil }) {
+            return .needsInput
+        }
+        if codex.threadHasActiveOrRunningTurn(parentThreadID) {
+            return .working
+        }
+        if let terminalState = codex.latestTurnTerminalState(for: parentThreadID) {
+            switch terminalState {
+            case .completed:
+                return .finished
+            case .failed:
+                return .failed
+            case .stopped:
+                return .stopped
+            }
+        }
+        if codex.goalByThreadID[parentThreadID]?.status == .active {
+            return .working
+        }
+        return codex.isConnected ? .available : .disconnected
+    }
+
+    private func closeSideConversation() {
+        guard !isClosing else { return }
+        isClosing = true
+        closeErrorMessage = nil
+
+        Task { @MainActor in
+            do {
+                try await codex.closeSideConversation(threadID: presentation.thread.id)
+                finishPresentation()
+            } catch {
+                closeErrorMessage = codex.userFacingTurnErrorMessageForFooter(from: error)
+                    ?? error.localizedDescription
+                isClosing = false
+            }
+        }
+    }
+
+    private var recoveryOverlay: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text("Reconnecting side conversation...")
+                .font(AppFont.subheadline(weight: .semibold))
+            Text("The main conversation is still safe.")
+                .font(AppFont.caption())
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 22)
+        .padding(.vertical, 18)
+        .adaptiveGlass(.regular, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black.opacity(0.08))
+        .contentShape(Rectangle())
+    }
+
+    private func finishPresentation(message: String? = nil) {
+        guard !hasFinishedPresentation else { return }
+        hasFinishedPresentation = true
+
+        if let message {
+            codex.lastErrorMessage = message
+        }
+        codex.acknowledgeSideConversationDismissal(threadID: presentation.thread.id)
+        codex.activeThreadId = presentation.parentThreadID
+        codex.activeTurnId = codex.activeTurnID(for: presentation.parentThreadID)
+        codex.markThreadAsViewed(presentation.parentThreadID)
+        if codex.isConnected {
+            codex.requestImmediateActiveThreadSync(
+                threadId: presentation.parentThreadID,
+                forceHistoryRefresh: true
+            )
+        }
+        dismiss()
+    }
+}
+
+private enum SideConversationParentStatus {
+    case working
+    case needsInput
+    case needsApproval
+    case finished
+    case failed
+    case stopped
+    case available
+    case disconnected
+
+    var label: String {
+        switch self {
+        case .working: "Main is working"
+        case .needsInput: "Main needs input"
+        case .needsApproval: "Main needs approval"
+        case .finished: "Main finished"
+        case .failed: "Main failed"
+        case .stopped: "Main stopped"
+        case .available: "Main is available"
+        case .disconnected: "Main is disconnected"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .working: "sparkles"
+        case .needsInput: "questionmark.bubble"
+        case .needsApproval: "exclamationmark.shield"
+        case .finished: "checkmark"
+        case .failed: "xmark"
+        case .stopped: "stop.fill"
+        case .available: "circle.fill"
+        case .disconnected: "wifi.slash"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .working: .blue
+        case .needsInput, .needsApproval: .orange
+        case .finished, .available: .green
+        case .failed: .red
+        case .stopped, .disconnected: .secondary
+        }
+    }
+}

--- a/CodexMobile/CodexMobileTests/CodexServiceIncomingRunIndicatorTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceIncomingRunIndicatorTests.swift
@@ -700,6 +700,44 @@ final class CodexServiceIncomingRunIndicatorTests: XCTestCase {
         XCTAssertFalse(service.protectedRunningFallbackThreadIDs.contains(threadID))
     }
 
+    func testSideAssistantEventsKeepRuntimeStateThreadScoped() {
+        let service = makeService()
+        let parentThreadID = "parent-\(UUID().uuidString)"
+        let parentTurnID = "parent-turn-\(UUID().uuidString)"
+        let sideThreadID = "side-\(UUID().uuidString)"
+        let sideTurnID = "side-turn-\(UUID().uuidString)"
+        service.activeThreadId = parentThreadID
+        service.activeTurnId = parentTurnID
+        service.threads = [CodexThread(id: sideThreadID, ephemeral: true)]
+        service.sideConversationThreadIDs.insert(sideThreadID)
+
+        sendTurnStarted(service: service, threadID: sideThreadID, turnID: sideTurnID)
+        service.handleNotification(
+            method: "item/agentMessage/delta",
+            params: .object([
+                "threadId": .string(sideThreadID),
+                "turnId": .string(sideTurnID),
+                "itemId": .string("side-agent"),
+                "delta": .string("Side response"),
+            ])
+        )
+
+        XCTAssertEqual(service.activeThreadId, parentThreadID)
+        XCTAssertEqual(service.activeTurnId, parentTurnID)
+        XCTAssertEqual(service.activeTurnID(for: sideThreadID), sideTurnID)
+        XCTAssertTrue(service.runningThreadIDs.contains(sideThreadID))
+        XCTAssertFalse(service.threadsPendingCompletionHaptic.contains(sideThreadID))
+
+        sendTurnCompletedSuccess(service: service, threadID: sideThreadID, turnID: sideTurnID)
+
+        XCTAssertEqual(service.activeThreadId, parentThreadID)
+        XCTAssertEqual(service.activeTurnId, parentTurnID)
+        XCTAssertNil(service.activeTurnID(for: sideThreadID))
+        XCTAssertFalse(service.readyThreadIDs.contains(sideThreadID))
+        XCTAssertFalse(service.failedThreadIDs.contains(sideThreadID))
+        XCTAssertFalse(service.threadsPendingCompletionHaptic.contains(sideThreadID))
+    }
+
     func testDesktopMirrorActivityHeartbeatRestoresRunningAfterStaleClear() {
         let service = makeService()
         let threadID = "thread-\(UUID().uuidString)"

--- a/CodexMobile/CodexMobileTests/CodexSideConversationTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexSideConversationTests.swift
@@ -1,0 +1,412 @@
+// FILE: CodexSideConversationTests.swift
+// Purpose: Verifies native `/side` fork, boundary injection, and cleanup payloads.
+// Layer: Unit Test
+// Exports: CodexSideConversationTests
+// Depends on: XCTest, CodexMobile
+
+import XCTest
+@testable import CodexMobile
+
+@MainActor
+final class CodexSideConversationTests: XCTestCase {
+    private static var retainedServices: [CodexService] = []
+
+    func testStartSideConversationCreatesEphemeralForkAndInjectsBoundaryWithoutActivatingIt() async throws {
+        let service = makeService()
+        service.isConnected = true
+        service.isInitialized = true
+        service.threads = [makeSourceThread()]
+        service.activeThreadId = "source-thread"
+
+        var forkParams: RPCObject = [:]
+        var injectedItems: [JSONValue] = []
+        service.requestTransportOverride = { method, params in
+            switch method {
+            case "thread/fork":
+                forkParams = params?.objectValue ?? [:]
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([
+                        "thread": .object([
+                            "id": .string("side-thread"),
+                            "ephemeral": .bool(true),
+                        ]),
+                    ]),
+                    includeJSONRPC: false
+                )
+            case "thread/inject_items":
+                injectedItems = params?.objectValue?["items"]?.arrayValue ?? []
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([:]),
+                    includeJSONRPC: false
+                )
+            default:
+                XCTFail("Unexpected method: \(method)")
+                throw CodexServiceError.invalidInput("Unexpected method")
+            }
+        }
+
+        let sideThread = try await service.startSideConversation(from: "source-thread")
+
+        XCTAssertEqual(forkParams["threadId"]?.stringValue, "source-thread")
+        XCTAssertEqual(forkParams["ephemeral"]?.boolValue, true)
+        XCTAssertNotNil(forkParams["developerInstructions"]?.stringValue)
+        XCTAssertEqual(injectedItems.first?.objectValue?["type"]?.stringValue, "message")
+        XCTAssertEqual(injectedItems.first?.objectValue?["role"]?.stringValue, "user")
+        XCTAssertEqual(sideThread.id, "side-thread")
+        XCTAssertTrue(sideThread.ephemeral)
+        XCTAssertEqual(service.activeThreadId, "source-thread")
+        XCTAssertTrue(service.messages(for: "side-thread").isEmpty)
+        XCTAssertTrue(service.sideConversationThreadIDs.contains("side-thread"))
+        XCTAssertEqual(service.sideConversationRuntimeState(for: "side-thread"), .active)
+
+        _ = await service.prepareThreadForDisplay(threadId: "side-thread")
+
+        XCTAssertEqual(service.activeThreadId, "source-thread")
+    }
+
+    func testCloseSideConversationInterruptsBeforeUnsubscribeAndDropsLocalState() async throws {
+        let service = makeService()
+        service.isConnected = true
+        service.isInitialized = true
+        service.threads = [
+            makeSourceThread(),
+            CodexThread(id: "side-thread", ephemeral: true),
+        ]
+        service.sideConversationThreadIDs.insert("side-thread")
+        service.setActiveTurnID("turn-side", for: "side-thread")
+        service.markThreadAsRunning("side-thread")
+
+        var methods: [String] = []
+        service.requestTransportOverride = { method, _ in
+            methods.append(method)
+            if method == "thread/turns/list" {
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object(["data": .array([
+                        .object([
+                            "id": .string("turn-side"),
+                            "status": .string("in_progress"),
+                        ]),
+                    ])]),
+                    includeJSONRPC: false
+                )
+            }
+            return RPCMessage(
+                id: .string(UUID().uuidString),
+                result: .object(method == "thread/unsubscribe"
+                    ? ["status": .string("unsubscribed")]
+                    : [:]),
+                includeJSONRPC: false
+            )
+        }
+
+        try await service.closeSideConversation(threadID: "side-thread")
+
+        XCTAssertEqual(methods, ["thread/turns/list", "turn/interrupt", "thread/unsubscribe"])
+        XCTAssertNil(service.thread(for: "side-thread"))
+        XCTAssertFalse(service.sideConversationThreadIDs.contains("side-thread"))
+        XCTAssertEqual(service.sideConversationRuntimeState(for: "side-thread"), .closing)
+    }
+
+    func testReconnectResumesSideWithoutHydratingTurnsOrChangingPrimarySelection() async throws {
+        let service = makeService()
+        service.isConnected = true
+        service.isInitialized = true
+        service.threads = [
+            makeSourceThread(),
+            CodexThread(id: "side-thread", ephemeral: true),
+        ]
+        service.activeThreadId = "source-thread"
+        service.sideConversationThreadIDs.insert("side-thread")
+        service.sideConversationRuntimeStateByThreadID["side-thread"] = .recovering
+        service.messagesByThread["side-thread"] = [
+            CodexMessage(threadId: "side-thread", role: .user, text: "local-only question"),
+        ]
+
+        var resumeParams: RPCObject = [:]
+        service.requestTransportOverride = { method, params in
+            switch method {
+            case "thread/resume":
+                resumeParams = params?.objectValue ?? [:]
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([
+                        "thread": .object([
+                            "id": .string("side-thread"),
+                            "ephemeral": .bool(true),
+                        ]),
+                    ]),
+                    includeJSONRPC: false
+                )
+            case "thread/turns/list":
+                XCTAssertEqual(
+                    service.sideConversationRuntimeState(for: "side-thread"),
+                    .recovering
+                )
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object(["data": .array([])]),
+                    includeJSONRPC: false
+                )
+            default:
+                XCTFail("Unexpected method: \(method)")
+                throw CodexServiceError.invalidInput("Unexpected method")
+            }
+        }
+
+        await service.recoverSideConversationsAfterReconnect()
+
+        XCTAssertEqual(resumeParams["threadId"]?.stringValue, "side-thread")
+        XCTAssertEqual(resumeParams["excludeTurns"]?.boolValue, true)
+        XCTAssertEqual(service.sideConversationRuntimeState(for: "side-thread"), .active)
+        XCTAssertEqual(service.activeThreadId, "source-thread")
+        XCTAssertEqual(service.messages(for: "side-thread").map(\.text), ["local-only question"])
+    }
+
+    func testCloseFailureOnLiveConnectionRestoresActiveState() async {
+        let service = makeService()
+        service.isConnected = true
+        service.isInitialized = true
+        service.threads = [makeSourceThread(), CodexThread(id: "side-thread", ephemeral: true)]
+        service.sideConversationThreadIDs.insert("side-thread")
+        service.sideConversationRuntimeStateByThreadID["side-thread"] = .active
+        service.requestTransportOverride = { method, _ in
+            XCTAssertEqual(method, "thread/turns/list")
+            throw CodexServiceError.disconnected
+        }
+
+        do {
+            try await service.closeSideConversation(threadID: "side-thread")
+            XCTFail("Expected close to fail while turn state is ambiguous")
+        } catch {}
+
+        XCTAssertTrue(service.sideConversationThreadIDs.contains("side-thread"))
+        XCTAssertFalse(service.pendingSideConversationCleanupThreadIDs.contains("side-thread"))
+        XCTAssertEqual(service.sideConversationRuntimeState(for: "side-thread"), .active)
+        XCTAssertNotNil(service.thread(for: "side-thread"))
+    }
+
+    func testCloseFailureAfterDisconnectRetainsCleanupIntentInRecovery() async {
+        let service = makeService()
+        service.isConnected = true
+        service.isInitialized = true
+        service.threads = [makeSourceThread(), CodexThread(id: "side-thread", ephemeral: true)]
+        service.sideConversationThreadIDs.insert("side-thread")
+        service.sideConversationRuntimeStateByThreadID["side-thread"] = .active
+        service.requestTransportOverride = { method, _ in
+            XCTAssertEqual(method, "thread/turns/list")
+            service.isConnected = false
+            service.isInitialized = false
+            throw CodexServiceError.disconnected
+        }
+
+        do {
+            try await service.closeSideConversation(threadID: "side-thread")
+            XCTFail("Expected close to fail after disconnect")
+        } catch {}
+
+        XCTAssertTrue(service.pendingSideConversationCleanupThreadIDs.contains("side-thread"))
+        XCTAssertEqual(service.sideConversationRuntimeState(for: "side-thread"), .recovering)
+        guard let pauseState = service.queuePauseStateByThread["side-thread"],
+              case .paused = pauseState else {
+            return XCTFail("Expected the side queue to stay paused during recovery cleanup")
+        }
+    }
+
+    func testReconnectCleanupPublishesUnavailableStateForPresentedSide() async {
+        let service = makeService()
+        service.isConnected = true
+        service.isInitialized = true
+        service.threads = [makeSourceThread(), CodexThread(id: "side-thread", ephemeral: true)]
+        service.sideConversationThreadIDs.insert("side-thread")
+        service.pendingSideConversationCleanupThreadIDs.insert("side-thread")
+        service.sideConversationRuntimeStateByThreadID["side-thread"] = .recovering
+        service.requestTransportOverride = { method, _ in
+            if method == "thread/turns/list" {
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object(["data": .array([])]),
+                    includeJSONRPC: false
+                )
+            }
+            XCTAssertEqual(method, "thread/unsubscribe")
+            return RPCMessage(id: .string(UUID().uuidString), result: .object([:]), includeJSONRPC: false)
+        }
+
+        await service.recoverSideConversationsAfterReconnect()
+
+        guard case .unavailable = service.sideConversationRuntimeState(for: "side-thread") else {
+            return XCTFail("Expected reconnect cleanup to dismiss the presented side")
+        }
+        XCTAssertFalse(service.hasOpenSideConversation)
+        XCTAssertTrue(service.closedSideConversationThreadIDs.contains("side-thread"))
+    }
+
+    func testClosingSideRejectsQueuedTurnStartBeforeTransport() async {
+        let service = makeService()
+        service.isConnected = true
+        service.isInitialized = true
+        service.sideConversationThreadIDs.insert("side-thread")
+        service.sideConversationRuntimeStateByThreadID["side-thread"] = .closing
+        var requestedMethods: [String] = []
+        service.requestTransportOverride = { method, _ in
+            requestedMethods.append(method)
+            throw CodexServiceError.invalidInput("Unexpected transport request")
+        }
+
+        do {
+            try await service.sendTurnStart("queued question", to: "side-thread")
+            XCTFail("Expected a closing side to reject a queued turn")
+        } catch {}
+
+        XCTAssertTrue(requestedMethods.isEmpty)
+    }
+
+    func testAbandonedSideRetriesInterruptSafeCleanupAfterReconnect() async {
+        let service = makeService()
+        service.threads = [makeSourceThread(), CodexThread(id: "side-thread", ephemeral: true)]
+        service.sideConversationThreadIDs.insert("side-thread")
+        service.abandonSideConversationLocally(threadID: "side-thread")
+
+        XCTAssertTrue(service.pendingSideConversationCleanupThreadIDs.contains("side-thread"))
+
+        service.isConnected = true
+        service.isInitialized = true
+        var methods: [String] = []
+        service.requestTransportOverride = { method, _ in
+            methods.append(method)
+            if method == "thread/turns/list" {
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object(["data": .array([])]),
+                    includeJSONRPC: false
+                )
+            }
+            return RPCMessage(
+                id: .string(UUID().uuidString),
+                result: .object([:]),
+                includeJSONRPC: false
+            )
+        }
+
+        await service.recoverSideConversationsAfterReconnect()
+
+        XCTAssertEqual(methods, ["thread/turns/list", "thread/unsubscribe"])
+        XCTAssertFalse(service.pendingSideConversationCleanupThreadIDs.contains("side-thread"))
+    }
+
+    func testReconnectDropsExpiredSideButPreservesParent() async {
+        let service = makeService()
+        service.isConnected = true
+        service.isInitialized = true
+        service.threads = [
+            makeSourceThread(),
+            CodexThread(id: "side-thread", ephemeral: true),
+        ]
+        service.activeThreadId = "source-thread"
+        service.sideConversationThreadIDs.insert("side-thread")
+        service.sideConversationRuntimeStateByThreadID["side-thread"] = .recovering
+        service.requestTransportOverride = { method, _ in
+            XCTAssertEqual(method, "thread/resume")
+            throw CodexServiceError.rpcError(RPCError(code: -32000, message: "thread not found"))
+        }
+
+        await service.recoverSideConversationsAfterReconnect()
+
+        guard case .unavailable(let message) = service.sideConversationRuntimeState(for: "side-thread") else {
+            return XCTFail("Expected unavailable side state")
+        }
+        XCTAssertTrue(message.contains("main conversation is unchanged"))
+        XCTAssertEqual(service.activeThreadId, "source-thread")
+        XCTAssertNotNil(service.thread(for: "source-thread"))
+        XCTAssertNil(service.thread(for: "side-thread"))
+        XCTAssertFalse(service.sideConversationThreadIDs.contains("side-thread"))
+    }
+
+    func testSideMessagesAreExcludedFromLocalPersistencePayload() {
+        let service = makeService()
+        service.threads = [
+            makeSourceThread(),
+            CodexThread(id: "side-thread", ephemeral: true),
+        ]
+        service.sideConversationThreadIDs.insert("side-thread")
+        service.messagesByThread = [
+            "source-thread": [CodexMessage(threadId: "source-thread", role: .user, text: "keep")],
+            "side-thread": [CodexMessage(threadId: "side-thread", role: .user, text: "discard")],
+        ]
+
+        XCTAssertEqual(Set(service.messagesEligibleForPersistence.keys), ["source-thread"])
+    }
+
+    func testAbandonedCleanupTombstoneKeepsLateEventsOutOfPersistence() {
+        let service = makeService()
+        service.threads = [makeSourceThread(), CodexThread(id: "side-thread", ephemeral: true)]
+        service.sideConversationThreadIDs.insert("side-thread")
+
+        service.abandonSideConversationLocally(threadID: "side-thread")
+        service.messagesByThread["side-thread"] = [
+            CodexMessage(threadId: "side-thread", role: .assistant, text: "late side event"),
+        ]
+
+        XCTAssertTrue(service.hasOpenSideConversation)
+        XCTAssertTrue(service.isSideConversationIsolated("side-thread"))
+        XCTAssertNil(service.messagesEligibleForPersistence["side-thread"])
+    }
+
+    func testSuccessfulCloseKeepsLateNotificationsIsolatedWithoutBlockingNewSide() async throws {
+        let service = makeService()
+        service.isConnected = true
+        service.isInitialized = true
+        service.threads = [makeSourceThread(), CodexThread(id: "side-thread", ephemeral: true)]
+        service.sideConversationThreadIDs.insert("side-thread")
+        service.sideConversationRuntimeStateByThreadID["side-thread"] = .active
+        service.requestTransportOverride = { method, _ in
+            if method == "thread/turns/list" {
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object(["data": .array([])]),
+                    includeJSONRPC: false
+                )
+            }
+            XCTAssertEqual(method, "thread/unsubscribe")
+            return RPCMessage(id: .string(UUID().uuidString), result: .object([:]), includeJSONRPC: false)
+        }
+
+        try await service.closeSideConversation(threadID: "side-thread")
+        service.handleNotification(
+            method: "item/agentMessage/delta",
+            params: .object([
+                "threadId": .string("side-thread"),
+                "turnId": .string("late-turn"),
+                "itemId": .string("late-item"),
+                "delta": .string("late response"),
+            ])
+        )
+
+        XCTAssertFalse(service.hasOpenSideConversation)
+        XCTAssertTrue(service.isSideConversationIsolated("side-thread"))
+        XCTAssertTrue(service.messages(for: "side-thread").isEmpty)
+        XCTAssertNil(service.messagesEligibleForPersistence["side-thread"])
+    }
+
+    private func makeService() -> CodexService {
+        let suiteName = "CodexSideConversationTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+        let service = CodexService(defaults: defaults)
+        Self.retainedServices.append(service)
+        return service
+    }
+
+    private func makeSourceThread() -> CodexThread {
+        CodexThread(
+            id: "source-thread",
+            title: "Source",
+            cwd: "/tmp/remodex",
+            model: "gpt-5.4",
+            modelProvider: "openai"
+        )
+    }
+}

--- a/CodexMobile/CodexMobileTests/CodexSideConversationTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexSideConversationTests.swift
@@ -165,6 +165,27 @@ final class CodexSideConversationTests: XCTestCase {
         XCTAssertEqual(service.messages(for: "side-thread").map(\.text), ["local-only question"])
     }
 
+    func testReconnectKeepsClosedSideTombstonesForBufferedReplay() {
+        let service = makeService()
+        service.closedSideConversationThreadIDs.insert("closed-side")
+
+        service.markSideConversationsForReconnect()
+
+        XCTAssertTrue(service.closedSideConversationThreadIDs.contains("closed-side"))
+        XCTAssertTrue(service.isSideConversationIsolated("closed-side"))
+    }
+
+    func testRuntimeInvalidationPromotesPendingCleanupToClosedTombstone() {
+        let service = makeService()
+        service.pendingSideConversationCleanupThreadIDs.insert("pending-side")
+
+        service.invalidateAllSideConversations(message: "Runtime changed")
+
+        XCTAssertFalse(service.pendingSideConversationCleanupThreadIDs.contains("pending-side"))
+        XCTAssertTrue(service.closedSideConversationThreadIDs.contains("pending-side"))
+        XCTAssertTrue(service.shouldDropRetiredSideConversationEvent("pending-side"))
+    }
+
     func testCloseFailureOnLiveConnectionRestoresActiveState() async {
         let service = makeService()
         service.isConnected = true
@@ -340,19 +361,36 @@ final class CodexSideConversationTests: XCTestCase {
         XCTAssertEqual(Set(service.messagesEligibleForPersistence.keys), ["source-thread"])
     }
 
-    func testAbandonedCleanupTombstoneKeepsLateEventsOutOfPersistence() {
+    func testAbandonedCleanupTombstoneDropsLateEventsWithoutBlockingNewSide() {
         let service = makeService()
         service.threads = [makeSourceThread(), CodexThread(id: "side-thread", ephemeral: true)]
         service.sideConversationThreadIDs.insert("side-thread")
 
         service.abandonSideConversationLocally(threadID: "side-thread")
-        service.messagesByThread["side-thread"] = [
-            CodexMessage(threadId: "side-thread", role: .assistant, text: "late side event"),
-        ]
+        service.handleNotification(
+            method: "item/agentMessage/delta",
+            params: .object([
+                "threadId": .string("side-thread"),
+                "turnId": .string("late-turn"),
+                "itemId": .string("late-item"),
+                "delta": .string("late side event"),
+            ])
+        )
 
-        XCTAssertTrue(service.hasOpenSideConversation)
+        XCTAssertFalse(service.hasOpenSideConversation)
         XCTAssertTrue(service.isSideConversationIsolated("side-thread"))
+        XCTAssertTrue(service.messages(for: "side-thread").isEmpty)
         XCTAssertNil(service.messagesEligibleForPersistence["side-thread"])
+    }
+
+    func testSideRunningStateNeverArmsCompletionHaptic() {
+        let service = makeService()
+        service.sideConversationThreadIDs.insert("side-thread")
+
+        service.markThreadAsRunning("side-thread")
+
+        XCTAssertTrue(service.runningThreadIDs.contains("side-thread"))
+        XCTAssertFalse(service.threadsPendingCompletionHaptic.contains("side-thread"))
     }
 
     func testSuccessfulCloseKeepsLateNotificationsIsolatedWithoutBlockingNewSide() async throws {

--- a/CodexMobile/CodexMobileTests/TurnComposerReviewModeTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnComposerReviewModeTests.swift
@@ -147,7 +147,7 @@ final class TurnComposerReviewModeTests: XCTestCase {
                     allowsForkCommand: true
                 )
             ).map(\.commandToken),
-            ["/review", "/compact", "/feedback", "/fork", "/status", "/subagents"]
+            ["/review", "/compact", "/feedback", "/fork", "/goal", "/side", "/status", "/subagents"]
         )
     }
 
@@ -157,7 +157,7 @@ final class TurnComposerReviewModeTests: XCTestCase {
                 supportsThreadFork: true,
                 allowsForkCommand: false
             ).map(\.commandToken),
-            ["/review", "/compact", "/feedback", "/status", "/subagents"]
+            ["/review", "/compact", "/feedback", "/goal", "/side", "/status", "/subagents"]
         )
     }
 
@@ -170,6 +170,17 @@ final class TurnComposerReviewModeTests: XCTestCase {
             viewModel.slashCommandPanelState,
             .forkDestinations([.newWorktree, .local])
         )
+    }
+
+    func testSelectingSideClearsTokenWithoutOpeningForkDestinations() {
+        let viewModel = makeViewModel()
+        viewModel.input = "/side"
+        viewModel.slashCommandPanelState = .commands(query: "side")
+
+        viewModel.onSelectSlashCommand(.side)
+
+        XCTAssertEqual(viewModel.input, "")
+        XCTAssertEqual(viewModel.slashCommandPanelState, .hidden)
     }
 
     func testSelectingForkDestinationClearsSlashTokenAndClosesPanel() {

--- a/CodexMobile/CodexMobileTests/TurnSlashCommandTokenTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnSlashCommandTokenTests.swift
@@ -92,4 +92,34 @@ final class TurnSlashCommandTokenTests: XCTestCase {
             )
         )
     }
+
+    func testSideCommandMatchesCanonicalNameAndBtwAlias() {
+        XCTAssertEqual(TurnComposerSlashCommand.filtered(matching: "si"), [.side])
+        XCTAssertEqual(TurnComposerSlashCommand.filtered(matching: "btw"), [.side])
+    }
+
+    func testSideCommandRequiresOtherwiseEmptyComposerState() {
+        XCTAssertTrue(TurnComposerCommandLogic.canOfferSideSlashCommand(in: "/side"))
+        XCTAssertFalse(TurnComposerCommandLogic.canOfferSideSlashCommand(in: "explain /side"))
+        XCTAssertFalse(TurnComposerCommandLogic.canOfferSideSlashCommand(in: "/side", attachmentCount: 1))
+        XCTAssertFalse(TurnComposerCommandLogic.canOfferSideSlashCommand(in: "/side", mentionedPluginCount: 1))
+    }
+
+    func testTypedSideCommandUsesSameNonTextEligibilityAsAutocomplete() {
+        XCTAssertTrue(TurnComposerCommandLogic.canExecuteInlineSideCommand())
+        XCTAssertFalse(TurnComposerCommandLogic.canExecuteInlineSideCommand(attachmentCount: 1))
+        XCTAssertFalse(TurnComposerCommandLogic.canExecuteInlineSideCommand(mentionedFileCount: 1))
+        XCTAssertFalse(TurnComposerCommandLogic.canExecuteInlineSideCommand(mentionedSkillCount: 1))
+        XCTAssertFalse(TurnComposerCommandLogic.canExecuteInlineSideCommand(mentionedPluginCount: 1))
+        XCTAssertFalse(TurnComposerCommandLogic.canExecuteInlineSideCommand(hasReviewSelection: true))
+        XCTAssertFalse(TurnComposerCommandLogic.canExecuteInlineSideCommand(hasSubagentsSelection: true))
+        XCTAssertFalse(TurnComposerCommandLogic.canExecuteInlineSideCommand(isPlanModeArmed: true))
+    }
+
+    func testInlineSideCommandSupportsPromptAndAlias() {
+        XCTAssertEqual(TurnView.inlineSideCommandPrompt(in: "/side explain this"), "explain this")
+        XCTAssertEqual(TurnView.inlineSideCommandPrompt(in: "/btw status?"), "status?")
+        XCTAssertEqual(TurnView.inlineSideCommandPrompt(in: "/side"), "")
+        XCTAssertNil(TurnView.inlineSideCommandPrompt(in: "/sidebar"))
+    }
 }


### PR DESCRIPTION
## Summary
- Introduce ephemeral thread tracking so `/side` conversations stay out of cold-start persistence, quick actions, and primary thread selection.
- Route side conversation presentation through the root sheet while keeping the parent thread selected underneath.
- Isolate runtime events, notifications, and completion state so closed or reconnecting side forks do not leak into the main chat experience.

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad changes to connection lifecycle, active-thread routing, and persistence filtering; mistakes could affect main-chat selection or leak ephemeral state, though behavior is heavily unit-tested.
> 
> **Overview**
> Adds **native `/side` (and `/btw`) side conversations**: ephemeral forks via `thread/fork`, a model-only history boundary, and a root-owned **Side conversation** sheet so the **main thread stays selected** underneath.
> 
> **Service layer:** `CodexThread.ephemeral` marks in-memory forks; `CodexService+SideConversation` owns start/close, reconnect resume (`excludeTurns`), interrupt + unsubscribe cleanup, and tombstones so late events don’t leak. Side threads are **excluded from local persistence**, sidebar/quick actions, completion badges/haptics, and background notifications; `activeThreadId` / streaming state stay scoped to the parent unless the side sheet owns the fork.
> 
> **UI:** `/side` in the composer (empty-draft rules), toolbar action, inline typed commands with optional initial prompt, and a restricted command set inside the side sheet. Dismissal coordinates with root sheet priority (bridge update, What’s New) and queued presentations.
> 
> **Tests:** `CodexSideConversationTests` and run-indicator coverage for parent vs side isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 976ce27c6c7a2b17a578c86ac2164ab8646e8e1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->