### PR TITLE
Avoid rendering oversized diffs in detail

### DIFF
--- a/CodexMobile/CodexMobile/Views/Turn/Diff/TurnDiffSheet.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Diff/TurnDiffSheet.swift
@@ -25,18 +25,92 @@ enum TurnDiffRenderingMode: Equatable {
 enum TurnDiffRenderingPolicy {
     static let maximumDetailedChangedLines = 2_000
     static let maximumDetailedBytes = 256_000
+    static let maximumDetailedLineBytes = 16_000
     static let maximumSummaryFileEntries = 200
 
     static func mode(
         entries: [TurnFileChangeSummaryEntry],
         bodyText: String
     ) -> TurnDiffRenderingMode {
-        let changedLineCount = entries.reduce(0) { $0 + $1.additions + $1.deletions }
+        let entryChangedLineCount = entries.reduce(0) { $0 + $1.additions + $1.deletions }
+        guard bodyText.utf8.count <= maximumDetailedBytes else {
+            return .summaryOnly(changedLineCount: entryChangedLineCount)
+        }
+
+        let bodyMetrics = diffBodyMetrics(in: bodyText)
+        let changedLineCount = max(entryChangedLineCount, bodyMetrics.changedLineCount)
         guard changedLineCount <= maximumDetailedChangedLines,
-              bodyText.utf8.count <= maximumDetailedBytes else {
+              bodyMetrics.longestLineByteCount <= maximumDetailedLineBytes else {
             return .summaryOnly(changedLineCount: changedLineCount)
         }
         return .detailed
+    }
+
+    private static func diffBodyMetrics(in bodyText: String) -> (
+        changedLineCount: Int,
+        longestLineByteCount: Int
+    ) {
+        var changedLineCount = 0
+        var longestLineByteCount = 0
+
+        bodyText.enumerateSubstrings(
+            in: bodyText.startIndex..<bodyText.endIndex,
+            options: .byLines
+        ) { line, _, _, stop in
+            guard let line else { return }
+            let lineByteCount = line.utf8.count
+            longestLineByteCount = max(longestLineByteCount, lineByteCount)
+
+            if (line.hasPrefix("+") && !line.hasPrefix("+++"))
+                || (line.hasPrefix("-") && !line.hasPrefix("---")) {
+                changedLineCount += 1
+            }
+
+            if changedLineCount > maximumDetailedChangedLines
+                || longestLineByteCount > maximumDetailedLineBytes {
+                stop = true
+            }
+        }
+
+        return (changedLineCount, longestLineByteCount)
+    }
+}
+
+// A file row can be opened from a multi-file recap. Extract its section away from the
+// main actor before the diff parser runs so one small file remains inspectable even when
+// the aggregate turn exceeds the detailed-rendering limit.
+enum TurnDiffBodyTextScope {
+    static func bodyText(for path: String, in bodyText: String) -> String {
+        let separator = "\n\n---\n\n"
+        var sectionStart = bodyText.startIndex
+
+        while sectionStart < bodyText.endIndex {
+            let sectionEnd = bodyText.range(
+                of: separator,
+                range: sectionStart..<bodyText.endIndex
+            )?.lowerBound ?? bodyText.endIndex
+            let section = bodyText[sectionStart..<sectionEnd]
+            if let lineEnd = section.firstIndex(of: "\n") {
+                let firstLine = section[..<lineEnd]
+                if firstLine.hasPrefix("Path:") {
+                    let candidatePath = String(firstLine.dropFirst("Path:".count))
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    if FileChangePathIdentity.representsSameFile(candidatePath, path) {
+                        return String(section)
+                    }
+                }
+            }
+
+            guard let separatorRange = bodyText.range(
+                of: separator,
+                range: sectionStart..<bodyText.endIndex
+            ) else {
+                break
+            }
+            sectionStart = separatorRange.upperBound
+        }
+
+        return bodyText
     }
 }
 
@@ -209,6 +283,7 @@ struct TurnDiffSheet: View {
     @Environment(\.dismiss) private var dismiss
     @State private var allHunksCollapsed = false
     @State private var presentationDetent: PresentationDetent = .large
+    @State private var restrictedBodyText: String?
 
     init(
         title: String,
@@ -225,9 +300,22 @@ struct TurnDiffSheet: View {
     }
 
     private var chunks: [PerFileDiffChunk] {
-        let all = PerFileDiffChunkCache.chunks(messageID: messageID, bodyText: bodyText, entries: entries)
+        let all = PerFileDiffChunkCache.chunks(
+            messageID: scopedMessageID,
+            bodyText: scopedBodyText,
+            entries: visibleEntries
+        )
         guard let restrictToPath else { return all }
         return all.filter { FileChangePathIdentity.representsSameFile($0.path, restrictToPath) }
+    }
+
+    private var scopedMessageID: String {
+        guard let restrictToPath else { return messageID }
+        return "\(messageID)|\(restrictToPath)"
+    }
+
+    private var scopedBodyText: String {
+        restrictToPath == nil ? bodyText : (restrictedBodyText ?? "")
     }
 
     private var visibleEntries: [TurnFileChangeSummaryEntry] {
@@ -236,7 +324,7 @@ struct TurnDiffSheet: View {
     }
 
     private var renderingMode: TurnDiffRenderingMode {
-        TurnDiffRenderingPolicy.mode(entries: visibleEntries, bodyText: bodyText)
+        TurnDiffRenderingPolicy.mode(entries: visibleEntries, bodyText: scopedBodyText)
     }
 
     private var entryTotals: (additions: Int, deletions: Int) {
@@ -282,15 +370,29 @@ struct TurnDiffSheet: View {
             }
         }
         .presentationDetents([.medium, .large], selection: $presentationDetent)
+        .task(id: scopedMessageID) {
+            guard let restrictToPath else { return }
+            let scopedText = await Task.detached(priority: .userInitiated) {
+                TurnDiffBodyTextScope.bodyText(for: restrictToPath, in: bodyText)
+            }
+            .value
+            guard !Task.isCancelled else { return }
+            restrictedBodyText = scopedText
+        }
     }
 
     @ViewBuilder
     private var sheetContent: some View {
-        switch renderingMode {
-        case .detailed:
-            detailedContent
-        case .summaryOnly(let changedLineCount):
-            summaryOnlyContent(changedLineCount: changedLineCount)
+        if restrictToPath != nil, restrictedBodyText == nil {
+            ProgressView()
+                .frame(maxWidth: .infinity, minHeight: 120)
+        } else {
+            switch renderingMode {
+            case .detailed:
+                detailedContent
+            case .summaryOnly(let changedLineCount):
+                summaryOnlyContent(changedLineCount: changedLineCount)
+            }
         }
     }
 

--- a/CodexMobile/CodexMobile/Views/Turn/Diff/TurnDiffSheet.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Diff/TurnDiffSheet.swift
@@ -15,6 +15,31 @@ struct TurnDiffPresentation: Identifiable, Equatable {
     let messageID: String
 }
 
+enum TurnDiffRenderingMode: Equatable {
+    case detailed
+    case summaryOnly(changedLineCount: Int)
+}
+
+// Detailed diffs are built entirely on the main actor. Keep an oversized patch out of the
+// parser and SwiftUI line renderer so opening the change sheet can never stall the app.
+enum TurnDiffRenderingPolicy {
+    static let maximumDetailedChangedLines = 2_000
+    static let maximumDetailedBytes = 256_000
+    static let maximumSummaryFileEntries = 200
+
+    static func mode(
+        entries: [TurnFileChangeSummaryEntry],
+        bodyText: String
+    ) -> TurnDiffRenderingMode {
+        let changedLineCount = entries.reduce(0) { $0 + $1.additions + $1.deletions }
+        guard changedLineCount <= maximumDetailedChangedLines,
+              bodyText.utf8.count <= maximumDetailedBytes else {
+            return .summaryOnly(changedLineCount: changedLineCount)
+        }
+        return .detailed
+    }
+}
+
 enum TurnDiffPresentationBuilder {
     // Converts a raw unified repo patch into the same sectioned shape the existing diff sheet already renders.
     static func repositoryPresentation(from rawPatch: String, title: String = "Repository Changes") -> TurnDiffPresentation? {
@@ -205,7 +230,31 @@ struct TurnDiffSheet: View {
         return all.filter { FileChangePathIdentity.representsSameFile($0.path, restrictToPath) }
     }
 
-    private var totals: (additions: Int, deletions: Int) {
+    private var visibleEntries: [TurnFileChangeSummaryEntry] {
+        guard let restrictToPath else { return entries }
+        return entries.filter { FileChangePathIdentity.representsSameFile($0.path, restrictToPath) }
+    }
+
+    private var renderingMode: TurnDiffRenderingMode {
+        TurnDiffRenderingPolicy.mode(entries: visibleEntries, bodyText: bodyText)
+    }
+
+    private var entryTotals: (additions: Int, deletions: Int) {
+        visibleEntries.reduce(into: (0, 0)) { totals, entry in
+            totals.0 += entry.additions
+            totals.1 += entry.deletions
+        }
+    }
+
+    private var summaryEntries: ArraySlice<TurnFileChangeSummaryEntry> {
+        visibleEntries.prefix(TurnDiffRenderingPolicy.maximumSummaryFileEntries)
+    }
+
+    private var hiddenSummaryEntryCount: Int {
+        visibleEntries.count - summaryEntries.count
+    }
+
+    private func totals(for chunks: [PerFileDiffChunk]) -> (additions: Int, deletions: Int) {
         chunks.reduce(into: (0, 0)) { totals, chunk in
             totals.0 += chunk.additions
             totals.1 += chunk.deletions
@@ -219,16 +268,7 @@ struct TurnDiffSheet: View {
     var body: some View {
         NavigationStack {
             ScrollView {
-                VStack(alignment: .leading, spacing: 12) {
-                    summaryHeader
-
-                    ForEach(chunks) { chunk in
-                        TurnDiffFileCard(
-                            chunk: chunk,
-                            collapseAllHunks: allHunksCollapsed
-                        )
-                    }
-                }
+                sheetContent
                 .padding(.vertical)
                 .padding(.horizontal, 12)
             }
@@ -244,11 +284,97 @@ struct TurnDiffSheet: View {
         .presentationDetents([.medium, .large], selection: $presentationDetent)
     }
 
-    private var summaryHeader: some View {
-        let totals = totals
+    @ViewBuilder
+    private var sheetContent: some View {
+        switch renderingMode {
+        case .detailed:
+            detailedContent
+        case .summaryOnly(let changedLineCount):
+            summaryOnlyContent(changedLineCount: changedLineCount)
+        }
+    }
+
+    private var detailedContent: some View {
+        let chunks = chunks
+        return LazyVStack(alignment: .leading, spacing: 12) {
+            summaryHeader(
+                fileCount: chunks.count,
+                totals: totals(for: chunks),
+                showsCollapseControl: !chunks.isEmpty
+            )
+
+            ForEach(chunks) { chunk in
+                TurnDiffFileCard(
+                    chunk: chunk,
+                    collapseAllHunks: allHunksCollapsed
+                )
+            }
+        }
+    }
+
+    private func summaryOnlyContent(changedLineCount: Int) -> some View {
+        LazyVStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Large diff")
+                    .font(AppFont.subheadline(weight: .semibold))
+                    .foregroundStyle(.primary)
+
+                Text(
+                    "\(changedLineCount) changed lines. Full patch rendering is disabled to keep Remodex responsive."
+                )
+                .font(AppFont.footnote())
+                .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(Color(.secondarySystemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+
+            summaryHeader(
+                fileCount: visibleEntries.count,
+                totals: entryTotals,
+                showsCollapseControl: false
+            )
+
+            ForEach(summaryEntries) { entry in
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(entry.compactPath)
+                        .font(AppFont.subheadline(weight: .medium))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .foregroundStyle(.primary)
+
+                    Spacer(minLength: 8)
+
+                    if entry.additions > 0 || entry.deletions > 0 {
+                        DiffCountsLabel(additions: entry.additions, deletions: entry.deletions)
+                            .font(AppFont.mono(.caption))
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(Color(.secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            }
+
+            if hiddenSummaryEntryCount > 0 {
+                Text("Showing the first \(summaryEntries.count) files; \(hiddenSummaryEntryCount) more are omitted.")
+                    .font(AppFont.footnote())
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private func summaryHeader(
+        fileCount: Int,
+        totals: (additions: Int, deletions: Int),
+        showsCollapseControl: Bool
+    ) -> some View {
         return HStack(alignment: .top) {
             VStack(alignment: .leading, spacing: 2) {
-                Text("\(chunks.count) file\(chunks.count == 1 ? "" : "s") changed")
+                Text("\(fileCount) file\(fileCount == 1 ? "" : "s") changed")
                     .font(AppFont.subheadline(weight: .semibold))
                     .foregroundStyle(.primary)
 
@@ -260,7 +386,7 @@ struct TurnDiffSheet: View {
 
             Spacer(minLength: 8)
 
-            if !chunks.isEmpty {
+            if showsCollapseControl {
                 Button {
                     withAnimation(.easeInOut(duration: 0.18)) {
                         allHunksCollapsed.toggle()

--- a/CodexMobile/CodexMobile/Views/Turn/Diff/TurnUnifiedDiffView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Diff/TurnUnifiedDiffView.swift
@@ -280,7 +280,7 @@ struct UnifiedDiffView: View {
             if diff.hunks.isEmpty {
                 rawFallback
             } else {
-                VStack(alignment: .leading, spacing: 0) {
+                LazyVStack(alignment: .leading, spacing: 0) {
                     ForEach(Array(diff.hunks.enumerated()), id: \.element.id) { index, hunk in
                         if index > 0 {
                             Rectangle()
@@ -342,7 +342,7 @@ struct UnifiedDiffView: View {
     // code is still non-empty (e.g. plain `+`/`-` snippets without `@@` markers).
     private var rawFallback: some View {
         let lines = rawDiffCode.components(separatedBy: "\n")
-        return VStack(alignment: .leading, spacing: 0) {
+        return LazyVStack(alignment: .leading, spacing: 0) {
             ForEach(Array(lines.enumerated()), id: \.offset) { _, raw in
                 UnifiedDiffRawRow(rawLine: raw)
             }
@@ -391,7 +391,7 @@ private struct UnifiedDiffHunkSection: View {
             .buttonStyle(.plain)
 
             if !isCollapsed {
-                VStack(alignment: .leading, spacing: 0) {
+                LazyVStack(alignment: .leading, spacing: 0) {
                     ForEach(hunk.lines) { line in
                         UnifiedDiffRow(line: line, gutterWidth: gutterWidth)
                     }

--- a/CodexMobile/CodexMobileTests/TurnMessageCachesTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnMessageCachesTests.swift
@@ -308,6 +308,57 @@ final class TurnMessageCachesTests: XCTestCase {
         XCTAssertFalse(second.fileChangeState?.detailBodyText.contains("FIRST-DETAIL") == true)
     }
 
+    func testTurnDiffRenderingPolicyUsesSummaryForLargeChangeCount() {
+        let entries = [
+            TurnFileChangeSummaryEntry(
+                path: "Tests/test_execution_summary.py",
+                additions: 34_477,
+                deletions: 0,
+                action: .edited
+            ),
+        ]
+
+        XCTAssertEqual(
+            TurnDiffRenderingPolicy.mode(entries: entries, bodyText: "small detail body"),
+            .summaryOnly(changedLineCount: 34_477)
+        )
+    }
+
+    func testTurnDiffRenderingPolicyUsesSummaryForLargeDetailBody() {
+        let entries = [
+            TurnFileChangeSummaryEntry(
+                path: "Sources/App.swift",
+                additions: 1,
+                deletions: 0,
+                action: .edited
+            ),
+        ]
+
+        XCTAssertEqual(
+            TurnDiffRenderingPolicy.mode(
+                entries: entries,
+                bodyText: String(repeating: "x", count: TurnDiffRenderingPolicy.maximumDetailedBytes + 1)
+            ),
+            .summaryOnly(changedLineCount: 1)
+        )
+    }
+
+    func testTurnDiffRenderingPolicyKeepsSmallDiffDetailed() {
+        let entries = [
+            TurnFileChangeSummaryEntry(
+                path: "Sources/App.swift",
+                additions: 12,
+                deletions: 3,
+                action: .edited
+            ),
+        ]
+
+        XCTAssertEqual(
+            TurnDiffRenderingPolicy.mode(entries: entries, bodyText: "@@ -1 +1 @@\n+let value = true"),
+            .detailed
+        )
+    }
+
     func testCommandOutputImageReferenceParserCombinesLsDirectoryAndOutputFile() {
         let reference = CommandOutputImageReferenceParser.firstReference(
             command: "/bin/zsh -lc 'ls -1 /Users/example/.codex/generated_images/turn-123'",

--- a/CodexMobile/CodexMobileTests/TurnMessageCachesTests.swift
+++ b/CodexMobile/CodexMobileTests/TurnMessageCachesTests.swift
@@ -359,6 +359,75 @@ final class TurnMessageCachesTests: XCTestCase {
         )
     }
 
+    func testTurnDiffRenderingPolicyUsesSummaryWhenDiffBodyExceedsInlineTotals() {
+        let entries = [
+            TurnFileChangeSummaryEntry(
+                path: "Sources/App.swift",
+                additions: 1,
+                deletions: 0,
+                action: .edited
+            ),
+        ]
+        let changedLines = String(repeating: "+let value = true\n", count: 2_001)
+        let bodyText = """
+        Path: Sources/App.swift
+        Totals: +1 -0
+
+        ```diff
+        \(changedLines)```
+        """
+
+        XCTAssertEqual(
+            TurnDiffRenderingPolicy.mode(entries: entries, bodyText: bodyText),
+            .summaryOnly(changedLineCount: 2_001)
+        )
+    }
+
+    func testTurnDiffRenderingPolicyUsesSummaryForOversizedDiffLine() {
+        let entries = [
+            TurnFileChangeSummaryEntry(
+                path: "Sources/App.swift",
+                additions: 1,
+                deletions: 0,
+                action: .edited
+            ),
+        ]
+        let bodyText = "+" + String(
+            repeating: "x",
+            count: TurnDiffRenderingPolicy.maximumDetailedLineBytes + 1
+        )
+
+        XCTAssertEqual(
+            TurnDiffRenderingPolicy.mode(entries: entries, bodyText: bodyText),
+            .summaryOnly(changedLineCount: 1)
+        )
+    }
+
+    func testTurnDiffBodyTextScopeExtractsSelectedFileWithoutParsingOtherSections() {
+        let bodyText = """
+        Path: Sources/Large.swift
+        Totals: +3000 -0
+
+        ```diff
+        +large change
+        ```
+
+        ---
+
+        Path: Sources/Small.swift
+        Totals: +1 -0
+
+        ```diff
+        +small change
+        ```
+        """
+
+        let scoped = TurnDiffBodyTextScope.bodyText(for: "Sources/Small.swift", in: bodyText)
+
+        XCTAssertTrue(scoped.contains("+small change"))
+        XCTAssertFalse(scoped.contains("+large change"))
+    }
+
     func testCommandOutputImageReferenceParserCombinesLsDirectoryAndOutputFile() {
         let reference = CommandOutputImageReferenceParser.firstReference(
             command: "/bin/zsh -lc 'ls -1 /Users/example/.codex/generated_images/turn-123'",


### PR DESCRIPTION
## Summary

Avoid parsing and rendering oversized file-change patches in the detailed SwiftUI diff view. Large patches now show a bounded file-summary view instead.

## Root cause

The detailed diff path parses and builds every hunk and line on the main actor. A very large patch can therefore stall the app while opening the changes sheet.

## Changes

- Add a size policy based on changed-line count and raw patch bytes.
- Keep normal-sized patches in the existing detailed view.
- Show a bounded, per-file summary for oversized patches.
- Use lazy stacks in detailed diff rendering.
- Add regression coverage for large line count, large body size, and normal detailed rendering.

## Validation

- `git diff --check upstream/main...HEAD`

No Xcode tests were run; this repository requests that they only run when explicitly requested.
