### PR TITLE
Reconcile closed chats after reconnect

### DIFF
--- a/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
@@ -578,7 +578,7 @@ extension CodexService {
                         .first(where: { $0.role == .assistant && !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })?
                         .text ?? ""
                 }
-            } else {
+            } else if !shouldShowImmediateEmptyPlaceholder(threadId: threadId) {
                 // A bridge reconnect can miss terminal Desktop IPC deltas even when the
                 // cached closed thread is already hydrated. One canonical page makes the
                 // selected timeline converge without adding closed-chat polling.

--- a/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
@@ -578,7 +578,10 @@ extension CodexService {
                         .first(where: { $0.role == .assistant && !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })?
                         .text ?? ""
                 }
-            } else if shouldDeferHeavyDisplayHydration(threadId: threadId) {
+            } else {
+                // A bridge reconnect can miss terminal Desktop IPC deltas even when the
+                // cached closed thread is already hydrated. One canonical page makes the
+                // selected timeline converge without adding closed-chat polling.
                 markThreadNeedingCanonicalHistoryReconcile(
                     threadId,
                     requestImmediateSync: activeThreadId == threadId

--- a/CodexMobile/CodexMobile/Services/CodexService+Messages.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Messages.swift
@@ -708,7 +708,7 @@ extension CodexService {
         return CanonicalHistoryReconcileRetryPolicy.delayNanoseconds(forAttempt: nextAttempt)
     }
 
-    // Marks a large chat as "local-first for now, but still needs one authoritative server merge".
+    // Marks a cached chat as needing one authoritative server merge.
     func markThreadNeedingCanonicalHistoryReconcile(
         _ threadId: String,
         requestImmediateSync: Bool = false

--- a/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
@@ -107,7 +107,9 @@ extension CodexService {
                 startSyncLoop()
                 // A suspended app can miss terminal Desktop IPC deltas while its cached
                 // closed thread still looks hydrated. Reconcile the visible thread once.
-                if let activeThreadId, !threadHasActiveOrRunningTurn(activeThreadId) {
+                if let activeThreadId,
+                   !threadHasActiveOrRunningTurn(activeThreadId),
+                   !shouldShowImmediateEmptyPlaceholder(threadId: activeThreadId) {
                     markThreadNeedingCanonicalHistoryReconcile(activeThreadId)
                 }
                 requestImmediateSync(threadId: activeThreadId)

--- a/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Sync.swift
@@ -105,6 +105,11 @@ extension CodexService {
             if isConnected && isInitialized {
                 startWebSocketKeepAliveLoop()
                 startSyncLoop()
+                // A suspended app can miss terminal Desktop IPC deltas while its cached
+                // closed thread still looks hydrated. Reconcile the visible thread once.
+                if let activeThreadId, !threadHasActiveOrRunningTurn(activeThreadId) {
+                    markThreadNeedingCanonicalHistoryReconcile(activeThreadId)
+                }
                 requestImmediateSync(threadId: activeThreadId)
                 // Re-check bridge-managed state when the app becomes active again.
                 Task { @MainActor [weak self] in

--- a/CodexMobile/CodexMobileTests/CodexServiceCatchupRecoveryTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceCatchupRecoveryTests.swift
@@ -755,6 +755,78 @@ final class CodexServiceCatchupRecoveryTests: XCTestCase {
         XCTAssertLessThanOrEqual(canonicalHistoryReadCount, 1)
     }
 
+    func testPostConnectReconcilesAnAlreadyHydratedClosedActiveThread() async {
+        let service = makeService()
+        let threadID = "thread-post-connect-closed"
+        let turnID = "turn-post-connect-closed"
+        service.isConnected = true
+        service.isInitialized = true
+        service.supportsTurnPagination = true
+        service.activeThreadId = threadID
+        service.hydratedThreadIDs.insert(threadID)
+        service.initialTurnsLoadedByThreadID.insert(threadID)
+        service.upsertThread(CodexThread(id: threadID, title: "Closed"))
+
+        var canonicalHistoryReadCount = 0
+        service.requestTransportOverride = { method, params in
+            switch method {
+            case "thread/list":
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([
+                        "threads": .array([
+                            .object([
+                                "id": .string(threadID),
+                                "title": .string("Closed"),
+                            ]),
+                        ]),
+                    ]),
+                    includeJSONRPC: false
+                )
+            case "thread/turns/list":
+                let limit = params?.objectValue?["limit"]?.intValue
+                if limit == ThreadHistoryHydrationPolicy.initialTurnPageSize {
+                    canonicalHistoryReadCount += 1
+                }
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([
+                        "data": .array([
+                            .object([
+                                "id": .string(turnID),
+                                "status": .string("completed"),
+                                "items": .array([
+                                    .object([
+                                        "id": .string("assistant-post-connect-closed"),
+                                        "type": .string("agentMessage"),
+                                        "text": .string("Recovered after reconnect"),
+                                    ]),
+                                ]),
+                            ]),
+                        ]),
+                        "nextCursor": .null,
+                    ]),
+                    includeJSONRPC: false
+                )
+            default:
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([:]),
+                    includeJSONRPC: false
+                )
+            }
+        }
+
+        await service.performPostConnectSyncPass(preferredThreadId: threadID)
+        for _ in 0..<100 where canonicalHistoryReadCount == 0 {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(canonicalHistoryReadCount, 1)
+        XCTAssertEqual(service.messages(for: threadID).last?.text, "Recovered after reconnect")
+        XCTAssertFalse(service.threadsNeedingCanonicalHistoryReconcile.contains(threadID))
+    }
+
     private func makeService() -> CodexService {
         let suiteName = "CodexServiceCatchupRecoveryTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName) ?? .standard

--- a/CodexMobile/CodexMobileTests/CodexServiceCatchupRecoveryTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceCatchupRecoveryTests.swift
@@ -818,12 +818,60 @@ final class CodexServiceCatchupRecoveryTests: XCTestCase {
         }
 
         await service.performPostConnectSyncPass(preferredThreadId: threadID)
-        for _ in 0..<100 where canonicalHistoryReadCount == 0 {
-            await Task.yield()
+        for _ in 0..<100 where service.messages(for: threadID).last?.text != "Recovered after reconnect" {
+            try? await Task.sleep(nanoseconds: 10_000_000)
         }
 
         XCTAssertEqual(canonicalHistoryReadCount, 1)
         XCTAssertEqual(service.messages(for: threadID).last?.text, "Recovered after reconnect")
+        XCTAssertFalse(service.threadsNeedingCanonicalHistoryReconcile.contains(threadID))
+    }
+
+    func testPostConnectSkipsCanonicalReconcileForNewEmptyActiveThread() async {
+        let service = makeService()
+        let threadID = "thread-post-connect-empty"
+        service.isConnected = true
+        service.isInitialized = true
+        service.supportsTurnPagination = true
+        service.activeThreadId = threadID
+        service.upsertThread(CodexThread(id: threadID))
+
+        var canonicalHistoryReadCount = 0
+        service.requestTransportOverride = { method, params in
+            switch method {
+            case "thread/list":
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([
+                        "threads": .array([
+                            .object([
+                                "id": .string(threadID),
+                                "title": .string(CodexThread.defaultDisplayTitle),
+                            ]),
+                        ]),
+                    ]),
+                    includeJSONRPC: false
+                )
+            case "thread/turns/list":
+                canonicalHistoryReadCount += 1
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object(["data": .array([]), "nextCursor": .null]),
+                    includeJSONRPC: false
+                )
+            default:
+                return RPCMessage(
+                    id: .string(UUID().uuidString),
+                    result: .object([:]),
+                    includeJSONRPC: false
+                )
+            }
+        }
+
+        await service.performPostConnectSyncPass(preferredThreadId: threadID)
+        await Task.yield()
+
+        XCTAssertEqual(canonicalHistoryReadCount, 0)
         XCTAssertFalse(service.threadsNeedingCanonicalHistoryReconcile.contains(threadID))
     }
 


### PR DESCRIPTION
## Summary

Reconcile the selected closed thread once after reconnecting or returning to the foreground.

## Root cause

Desktop IPC can miss a terminal update while a suspended iOS app retains a hydrated local cache. The existing reconnect path only scheduled canonical reconciliation for deferred heavy hydration, leaving an already-hydrated closed thread stale.

## Changes

- Mark the selected inactive thread for one canonical history reconciliation after post-connect recovery.
- Do the same during foreground recovery.
- Retain the existing one-shot reconcile mechanism; no polling is introduced.
- Add a regression case covering an already-hydrated closed active thread.

## Validation

- `git diff --check upstream/main...HEAD`

No Xcode tests were run; this repository requests that they only run when explicitly requested.
