### PR TITLE
Normalize phone sandbox policies across Desktop IPC ownership

### DIFF
--- a/phodex-bridge/src/desktop-ipc-action-follower.js
+++ b/phodex-bridge/src/desktop-ipc-action-follower.js
@@ -21,6 +21,7 @@ const {
   cloneJSON,
   createFrameReader,
   isThreadTurnStateProbeRequest,
+  normalizeDesktopTurnStartSandboxPolicy,
   normalizeToken,
   readString,
   requestIdKey,
@@ -2034,9 +2035,10 @@ function createDesktopIpcActionFollower({
     const normalized = await Promise.resolve(
       normalizeTurnStartParams(cloneJSON(route.params.turnStartParams))
     );
-    const turnStartParams = normalized && typeof normalized === "object" && !Array.isArray(normalized)
+    const normalizedTurnStartParams = normalized && typeof normalized === "object" && !Array.isArray(normalized)
       ? normalized
       : route.params.turnStartParams;
+    const turnStartParams = normalizeDesktopTurnStartSandboxPolicy(normalizedTurnStartParams);
     return {
       ...route.params,
       turnStartParams,

--- a/phodex-bridge/src/desktop-ipc-live-owner.js
+++ b/phodex-bridge/src/desktop-ipc-live-owner.js
@@ -13,6 +13,7 @@ const {
   cloneJSON,
   conversationSnapshotShowsActiveTurn,
   isPlainJSONObject,
+  normalizeDesktopTurnStartSandboxPolicy,
   normalizeToken,
   readString,
   requestIdKey,
@@ -463,7 +464,9 @@ function createDesktopIpcLiveOwner({
     if (input.length === 0) {
       return null;
     }
-    const sanitizedParams = sanitizeTurnStartParams(cloneJSON(params));
+    const sanitizedParams = normalizeDesktopTurnStartSandboxPolicy(
+      sanitizeTurnStartParams(cloneJSON(params))
+    );
     sanitizedParams.input = normalizeInputEntriesForDesktop(sanitizedParams.input);
     const entry = { params: sanitizedParams, requestId: normalizedRequestId || null };
     const queue = pendingTurnStartParamsByThreadId.get(normalizedThreadId) || [];

--- a/phodex-bridge/src/desktop-ipc-shared.js
+++ b/phodex-bridge/src/desktop-ipc-shared.js
@@ -11,6 +11,7 @@ const { createHash } = require("crypto");
 
 const FRAME_HEADER_BYTES = 4;
 const MAX_FRAME_BYTES = 256 * 1024 * 1024;
+const WORKSPACE_WRITE_SANDBOX_TYPE = "workspaceWrite";
 
 const CLIENT_STATUS_CHANGED = "client-status-changed";
 
@@ -450,6 +451,24 @@ function isPlainJSONObject(value) {
   return value != null && typeof value === "object" && !Array.isArray(value);
 }
 
+// Desktop treats writableRoots as iterable for workspace-write turns, while
+// app-server and older mobile clients allow the field to be omitted.
+function normalizeDesktopTurnStartSandboxPolicy(turnStartParams) {
+  const sandboxPolicy = turnStartParams?.sandboxPolicy;
+  if (!isPlainJSONObject(sandboxPolicy)
+    || sandboxPolicy.type !== WORKSPACE_WRITE_SANDBOX_TYPE
+    || Array.isArray(sandboxPolicy.writableRoots)) {
+    return turnStartParams;
+  }
+  return {
+    ...turnStartParams,
+    sandboxPolicy: {
+      ...sandboxPolicy,
+      writableRoots: [],
+    },
+  };
+}
+
 // Single predicate for "this timeline item is a user message", shared by the
 // relay sanitizer, the JSONL history parser, and the Desktop-bound adapter so
 // context filters can never drift apart across paths again.
@@ -681,6 +700,7 @@ module.exports = {
   isPlainJSONObject,
   isThreadTurnStateProbeRequest,
   isUserRoleItem,
+  normalizeDesktopTurnStartSandboxPolicy,
   normalizeToken,
   readString,
   readText,

--- a/phodex-bridge/test/desktop-ipc-action-follower.test.js
+++ b/phodex-bridge/test/desktop-ipc-action-follower.test.js
@@ -1890,11 +1890,15 @@ test("desktop IPC follower routes phone turns to Desktop-owned threads", async (
     method: "turn/start",
     params: {
       threadId: "thread-desktop-owned",
-      input: [{ type: "input_text", text: "continue from phone" }],
+      input: [{ type: "text", text: "continue from phone" }],
       cwd: "/repo",
       model: "gpt-test",
       effort: "low",
       serviceTier: "fast",
+      sandboxPolicy: {
+        type: "workspaceWrite",
+        networkAccess: true,
+      },
     },
   }));
   assert.equal(handled, true);
@@ -1921,11 +1925,16 @@ test("desktop IPC follower routes phone turns to Desktop-owned threads", async (
     senderRequestId: "phone-turn-start-1",
     turnStartParams: {
       threadId: "thread-desktop-owned",
-      input: [{ type: "input_text", text: "continue from phone" }],
+      input: [{ type: "text", text: "continue from phone" }],
       cwd: "/repo",
       model: "gpt-test",
       effort: "low",
       serviceTier: "fast",
+      sandboxPolicy: {
+        type: "workspaceWrite",
+        networkAccess: true,
+        writableRoots: [],
+      },
     },
   });
 
@@ -1938,11 +1947,16 @@ test("desktop IPC follower routes phone turns to Desktop-owned threads", async (
     threadId: "thread-desktop-owned",
     params: {
       threadId: "thread-desktop-owned",
-      input: [{ type: "input_text", text: "continue from phone" }],
+      input: [{ type: "text", text: "continue from phone" }],
       cwd: "/repo",
       model: "gpt-test",
       effort: "low",
       serviceTier: "fast",
+      sandboxPolicy: {
+        type: "workspaceWrite",
+        networkAccess: true,
+        writableRoots: [],
+      },
     },
     metadata: {
       source: "phone",

--- a/phodex-bridge/test/desktop-ipc-live-owner.test.js
+++ b/phodex-bridge/test/desktop-ipc-live-owner.test.js
@@ -853,7 +853,7 @@ test("live owner does not rewind live state from a stale cached thread on later 
   );
 });
 
-test("live owner keeps phone turn input in snapshots when turn/started has no items", async (t) => {
+test("live owner keeps phone input and normalizes sandbox policy in Desktop snapshots", async (t) => {
   const { tempDir, socketPath } = createIpcTestSocket("remodex-live-owner-user-input-");
   const frames = [];
   let serverSocket = null;
@@ -907,8 +907,30 @@ test("live owner keeps phone turn input in snapshots when turn/started has no it
       threadId: "thread-user-input",
       cwd: "/tmp/user-input",
       input: [{ type: "input_text", text: "build the feature" }],
+      sandboxPolicy: {
+        type: "workspaceWrite",
+        networkAccess: true,
+      },
     },
   }));
+
+  const pendingBroadcast = await waitForMessage(
+    frames,
+    (frame) => frame.type === "broadcast"
+      && frame.method === "thread-stream-state-changed"
+      && frame.params?.conversationId === "thread-user-input"
+      && frame.params?.change?.type === "snapshot"
+      && frame.params.change.conversationState.turns?.[0]?.remodexOptimisticPendingTurn === true
+  );
+  assert.deepEqual(
+    pendingBroadcast.params.change.conversationState.turns[0].params.sandboxPolicy,
+    {
+      type: "workspaceWrite",
+      networkAccess: true,
+      writableRoots: [],
+    }
+  );
+
   owner.observeOutbound(JSON.stringify({
     method: "turn/started",
     params: {
@@ -925,19 +947,19 @@ test("live owner keeps phone turn input in snapshots when turn/started has no it
     },
   }));
 
-  const broadcast = await waitForMessage(
-    frames,
-    (frame) => frame.type === "broadcast"
-      && frame.method === "thread-stream-state-changed"
-      && frame.params?.conversationId === "thread-user-input"
-      && frame.params?.change?.type === "snapshot"
-      && frame.params.change.conversationState.turns?.[0]?.turnId === "turn-user-input"
-  );
-  const turn = broadcast.params.change.conversationState.turns[0];
+  await waitFor(() => (
+    owner._debugSnapshot("thread-user-input")?.turns?.[0]?.turnId === "turn-user-input"
+  ));
+  const turn = owner._debugSnapshot("thread-user-input").turns[0];
   assert.equal(turn.turnId, "turn-user-input");
   // Desktop renders the user bubble from params.input; a duplicate userMessage
   // item would be labelled "Steered conversation", so items must stay empty.
   assert.deepEqual(turn.params.input, [{ type: "input_text", text: "build the feature" }]);
+  assert.deepEqual(turn.params.sandboxPolicy, {
+    type: "workspaceWrite",
+    networkAccess: true,
+    writableRoots: [],
+  });
   assert.deepEqual(turn.items, []);
 });
 

--- a/phodex-bridge/test/desktop-ipc-shared.test.js
+++ b/phodex-bridge/test/desktop-ipc-shared.test.js
@@ -13,6 +13,7 @@ const path = require("node:path");
 const {
   isContextualUserText,
   isThreadTurnStateProbeRequest,
+  normalizeDesktopTurnStartSandboxPolicy,
   resolveDefaultIpcSocketPath,
   resolveIpcSocketPathCandidates,
   responseItemMessageText,
@@ -29,6 +30,32 @@ test("response item text preserves nested data text parts", () => {
     }),
     "Nested assistant text"
   );
+});
+
+test("normalizes writable roots only for malformed Desktop workspace-write policies", () => {
+  const missingRoots = {
+    input: [],
+    sandboxPolicy: { type: "workspaceWrite", networkAccess: true },
+  };
+  assert.deepEqual(normalizeDesktopTurnStartSandboxPolicy(missingRoots), {
+    input: [],
+    sandboxPolicy: { type: "workspaceWrite", networkAccess: true, writableRoots: [] },
+  });
+
+  const malformedRoots = {
+    sandboxPolicy: { type: "workspaceWrite", writableRoots: "/tmp/project" },
+  };
+  assert.deepEqual(normalizeDesktopTurnStartSandboxPolicy(malformedRoots), {
+    sandboxPolicy: { type: "workspaceWrite", writableRoots: [] },
+  });
+
+  const validRoots = {
+    sandboxPolicy: { type: "workspaceWrite", writableRoots: ["/tmp/project"] },
+  };
+  assert.equal(normalizeDesktopTurnStartSandboxPolicy(validRoots), validRoots);
+
+  const fullAccess = { sandboxPolicy: { type: "dangerFullAccess" } };
+  assert.equal(normalizeDesktopTurnStartSandboxPolicy(fullAccess), fullAccess);
 });
 
 // Payload shapes below are lifted verbatim from real rollout files, so these


### PR DESCRIPTION
## Summary

- centralize Desktop-bound workspace-write sandbox normalization
- provide an empty writableRoots array only when the field is missing or malformed
- apply the same compatibility rule to Desktop-owned follower turns and Bridge-owned optimistic snapshots
- preserve existing valid writable-root arrays and leave other sandbox policies unchanged

## Why

Remodex iOS omits writableRoots when no additional roots are selected. Codex Desktop treats that field as iterable, so the malformed policy can throw e is not iterable.

The original version of this PR fixed only phone turns forwarded into Desktop-owned threads. The same phone payload also enters desktop-ipc-live-owner for Bridge-owned threads and is published in the first optimistic Desktop snapshot. Normalizing both Desktop IPC boundaries fixes the renderer crash while keeping direct app-server behavior unchanged and remaining compatible with older mobile clients.

Fixes #171

## Testing

- targeted Desktop IPC tests: 152 passed
- Bridge Desktop IPC integration tests: 6 passed
- full Bridge suite: 702 passed; 3 unchanged workspace-image/sips preview tests failed locally
- git diff --check
- Xcode tests not run; this PR does not change iOS code
