### PR TITLE
Add GPT-5.6 model options

### DIFF
--- a/CodexMobile/CodexMobile/Models/CodexModelOption.swift
+++ b/CodexMobile/CodexMobile/Models/CodexModelOption.swift
@@ -26,13 +26,20 @@ struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
         supportedReasoningEfforts: [CodexReasoningEffortOption],
         defaultReasoningEffort: String?
     ) {
+        let normalizedEfforts = supportedReasoningEfforts.filter {
+            !$0.reasoningEffort.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
         self.id = id
         self.model = model
         self.displayName = displayName
         self.description = description
         self.isDefault = isDefault
         self.supportsFastMode = supportsFastMode
-        self.supportedReasoningEfforts = supportedReasoningEfforts
+        self.supportedReasoningEfforts = CodexModelCapabilityResolver.supportedReasoningEfforts(
+            model: model,
+            id: id,
+            advertised: normalizedEfforts
+        )
         self.defaultReasoningEffort = defaultReasoningEffort
     }
 
@@ -114,7 +121,11 @@ struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
             explicitFastMode: explicitFastMode,
             additionalSpeedTiers: additionalSpeedTiers
         )
-        supportedReasoningEfforts = normalizedEfforts
+        supportedReasoningEfforts = CodexModelCapabilityResolver.supportedReasoningEfforts(
+            model: normalizedModel,
+            id: normalizedID,
+            advertised: normalizedEfforts
+        )
 
         let normalizedDefault = defaultEffort?.trimmingCharacters(in: .whitespacesAndNewlines)
         defaultReasoningEffort = (normalizedDefault?.isEmpty == true) ? nil : normalizedDefault
@@ -173,11 +184,19 @@ struct CodexModelOption: Identifiable, Codable, Hashable, Sendable {
 private enum CodexModelCapabilityResolver {
     // Mirrors the desktop capability table only when older bridges omit explicit model speed metadata.
     private static let staticFastModeModelIdentifiers: Set<String> = [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
         "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5.2-codex",
         "gpt-5.2",
+    ]
+    private static let staticReasoningEffortsByModelIdentifier: [String: [String]] = [
+        "gpt-5.6-sol": ["low", "medium", "high", "xhigh", "max"],
+        "gpt-5.6-terra": ["low", "medium", "high", "xhigh", "max"],
+        "gpt-5.6-luna": ["low", "medium", "high", "xhigh", "max"],
     ]
 
     static func supportsFastMode(
@@ -193,6 +212,33 @@ private enum CodexModelCapabilityResolver {
             return true
         }
         return staticFastModeFallback(for: [model, id])
+    }
+
+    static func supportedReasoningEfforts(
+        model: String,
+        id: String,
+        advertised: [CodexReasoningEffortOption]
+    ) -> [CodexReasoningEffortOption] {
+        let identifiers = [model, id].map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        }
+        let fallbackEfforts = identifiers.compactMap {
+            staticReasoningEffortsByModelIdentifier[$0]
+        }.first
+        guard let fallbackEfforts else {
+            return advertised
+        }
+
+        var result = advertised
+        var seen = Set(
+            advertised.map {
+                $0.reasoningEffort.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            }
+        )
+        for effort in fallbackEfforts where seen.insert(effort).inserted {
+            result.append(CodexReasoningEffortOption(reasoningEffort: effort, description: ""))
+        }
+        return result
     }
 
     private static func supportsServiceTier(

--- a/CodexMobile/CodexMobile/Services/CodexService+RuntimeConfig.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+RuntimeConfig.swift
@@ -26,7 +26,8 @@ private enum RuntimeDebugLogPolicy {
 }
 
 private enum RuntimeSelectionDefaults {
-    static let modelId = "gpt-5.5"
+    static let modelId = "gpt-5.6-sol"
+    static let fallbackModelIds = [modelId, "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5"]
     static let reasoningEffort = "medium"
 
     static func reasoningEffort(for unresolvedModelId: String?) -> String? {
@@ -901,12 +902,14 @@ private extension CodexService {
     }
 
     func fallbackModel(from models: [CodexModelOption]) -> CodexModelOption? {
-        // Prefer GPT-5.5 when the bridge advertises it; the rest of the app treats
-        // it as the canonical default regardless of the bridge's `isDefault` flag.
-        if let preferred = models.first(where: {
-            $0.id.lowercased() == "gpt-5.5" || $0.model.lowercased() == "gpt-5.5"
-        }) {
-            return preferred
+        // Prefer the current 5.6 family when the bridge advertises it, while
+        // keeping GPT-5.5 as the compatibility fallback for older local runtimes.
+        for identifier in RuntimeSelectionDefaults.fallbackModelIds {
+            if let preferred = models.first(where: {
+                $0.id.lowercased() == identifier || $0.model.lowercased() == identifier
+            }) {
+                return preferred
+            }
         }
         if let defaultModel = models.first(where: { $0.isDefault }) {
             return defaultModel

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerMetaMapper.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerMetaMapper.swift
@@ -14,6 +14,9 @@ enum TurnComposerMetaMapper {
     // Returns models sorted using the explicit product order expected by the UI.
     static func orderedModels(from models: [CodexModelOption]) -> [CodexModelOption] {
         let preferredOrder: [String] = [
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
             "gpt-5.5",
             "gpt-5.4",
             "gpt-5.3-codex",
@@ -46,6 +49,12 @@ enum TurnComposerMetaMapper {
     static func modelTitle(forIdentifier identifier: String?, fallback: String? = nil) -> String {
         let normalizedIdentifier = identifier?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         switch normalizedIdentifier.lowercased() {
+        case "gpt-5.6-sol":
+            return "GPT-5.6-Sol"
+        case "gpt-5.6-terra":
+            return "GPT-5.6-Terra"
+        case "gpt-5.6-luna":
+            return "GPT-5.6-Luna"
         case "gpt-5.5":
             return "GPT-5.5"
         case "gpt-5.3-codex":
@@ -70,7 +79,7 @@ enum TurnComposerMetaMapper {
             if normalizedIdentifier.lowercased().hasPrefix("gpt-") {
                 return "GPT-" + String(normalizedIdentifier.dropFirst("gpt-".count))
             }
-            return normalizedIdentifier.isEmpty ? "GPT-5.5" : normalizedIdentifier
+            return normalizedIdentifier.isEmpty ? "GPT-5.6-Sol" : normalizedIdentifier
         }
     }
 
@@ -148,6 +157,8 @@ enum TurnComposerMetaMapper {
             return "High"
         case "xhigh", "extra_high", "extra-high", "very_high", "very-high":
             return "Extra High"
+        case "max", "maximum":
+            return "Max"
         default:
             return normalized.split(separator: "_")
                 .map { $0.capitalized }
@@ -178,8 +189,12 @@ struct TurnComposerReasoningDisplayOption: Identifiable, Equatable {
             return 1
         case "High":
             return 2
-        case "Exceptional":
+        case "Extra High":
             return 3
+        case "Exceptional":
+            return 4
+        case "Max":
+            return 5
         default:
             return 4
         }

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerRuntimeUIKitMenu.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerRuntimeUIKitMenu.swift
@@ -31,6 +31,9 @@ enum TurnComposerRuntimeUIKitMenuBuilder {
     // Identifiers pinned to the top of the model menu; the rest are reachable
     // via "Other models…" so the menu stays glanceable as the list grows.
     private static let featuredModelIdentifiers: Set<String> = [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
         "gpt-5.5",
         "gpt-5.4",
     ]

--- a/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerView.swift
+++ b/CodexMobile/CodexMobile/Views/Turn/Composer/TurnComposerView.swift
@@ -681,10 +681,58 @@ private struct ComposerPreviewContent: View {
     let isThreadRunning: Bool
 
     private let reasoningOptions = TurnComposerMetaMapper.reasoningDisplayOptions(
-        from: ["low", "medium", "high", "xhigh"]
+        from: ["low", "medium", "high", "xhigh", "max"]
     )
 
     private let modelOptions: [CodexModelOption] = [
+        CodexModelOption(
+            id: "gpt-5.6-sol",
+            model: "gpt-5.6-sol",
+            displayName: "GPT-5.6-Sol",
+            description: "Preview model",
+            isDefault: true,
+            supportsFastMode: true,
+            supportedReasoningEfforts: [
+                CodexReasoningEffortOption(reasoningEffort: "low", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "medium", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "high", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "xhigh", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "max", description: ""),
+            ],
+            defaultReasoningEffort: "high"
+        ),
+        CodexModelOption(
+            id: "gpt-5.6-terra",
+            model: "gpt-5.6-terra",
+            displayName: "GPT-5.6-Terra",
+            description: "Preview model",
+            isDefault: false,
+            supportsFastMode: true,
+            supportedReasoningEfforts: [
+                CodexReasoningEffortOption(reasoningEffort: "low", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "medium", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "high", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "xhigh", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "max", description: ""),
+            ],
+            defaultReasoningEffort: "medium"
+        ),
+        CodexModelOption(
+            id: "gpt-5.6-luna",
+            model: "gpt-5.6-luna",
+            displayName: "GPT-5.6-Luna",
+            description: "Preview model",
+            isDefault: false,
+            supportsFastMode: true,
+            supportedReasoningEfforts: [
+                CodexReasoningEffortOption(reasoningEffort: "low", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "medium", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "high", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "xhigh", description: ""),
+                CodexReasoningEffortOption(reasoningEffort: "max", description: ""),
+            ],
+            defaultReasoningEffort: "medium"
+        ),
         CodexModelOption(
             id: "gpt-5.5",
             model: "gpt-5.5",
@@ -835,14 +883,14 @@ private struct ComposerPreviewContent: View {
             hasWorkingDirectory: true,
             isWorktreeProject: false,
             orderedModelOptions: modelOptions,
-            selectedModelID: "gpt-5.5",
-            selectedModelTitle: "GPT-5.5",
+            selectedModelID: "gpt-5.6-sol",
+            selectedModelTitle: "GPT-5.6-Sol",
             isLoadingModels: false,
             isRuntimeSelectionLoading: false,
             runtimeState: TurnComposerRuntimeState(
                 reasoningDisplayOptions: reasoningOptions,
-                effectiveReasoningEffort: "high",
-                selectedReasoningEffort: "high",
+                effectiveReasoningEffort: "max",
+                selectedReasoningEffort: "max",
                 reasoningMenuDisabled: false,
                 selectedServiceTier: .fast,
                 supportsFastMode: true

--- a/CodexMobile/CodexMobileTests/CodexServiceTierTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceTierTests.swift
@@ -81,6 +81,21 @@ final class CodexServiceTierTests: XCTestCase {
         let payload = """
         [
           {
+            "slug": "gpt-5.6-sol",
+            "name": "GPT-5.6 Sol",
+            "supportedReasoningEfforts": ["medium"]
+          },
+          {
+            "slug": "gpt-5.6-terra",
+            "name": "GPT-5.6 Terra",
+            "supportedReasoningEfforts": ["medium"]
+          },
+          {
+            "slug": "gpt-5.6-luna",
+            "name": "GPT-5.6 Luna",
+            "supportedReasoningEfforts": ["medium"]
+          },
+          {
             "slug": "gpt-5.4",
             "name": "GPT-5.4",
             "supportedReasoningEfforts": ["medium"]
@@ -112,9 +127,18 @@ final class CodexServiceTierTests: XCTestCase {
 
         XCTAssertTrue(models[0].supportsFastMode)
         XCTAssertTrue(models[1].supportsFastMode)
-        XCTAssertFalse(models[2].supportsFastMode)
-        XCTAssertFalse(models[3].supportsFastMode)
-        XCTAssertFalse(models[4].supportsFastMode)
+        XCTAssertTrue(models[2].supportsFastMode)
+        XCTAssertTrue(models[3].supportsFastMode)
+        XCTAssertTrue(models[4].supportsFastMode)
+        XCTAssertFalse(models[5].supportsFastMode)
+        XCTAssertFalse(models[6].supportsFastMode)
+        XCTAssertFalse(models[7].supportsFastMode)
+        for index in 0...2 {
+            XCTAssertEqual(
+                models[index].supportedReasoningEfforts.map(\.reasoningEffort),
+                ["medium", "low", "high", "xhigh", "max"]
+            )
+        }
     }
 
     func testSwitchingBetweenFastCapableModelsKeepsSelectedServiceTier() {

--- a/CodexMobile/CodexMobileTests/CodexThreadRuntimeOverrideTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexThreadRuntimeOverrideTests.swift
@@ -147,17 +147,17 @@ final class CodexThreadRuntimeOverrideTests: XCTestCase {
         XCTAssertNil(service.effectiveServiceTier(for: "thread-phone-authority"))
     }
 
-    func testClearingSelectedModelFallsBackToGPT55Medium() {
+    func testClearingSelectedModelFallsBackToGPT56SolMedium() {
         let service = makeService()
-        service.availableModels = [makeGPT55Model(), makeModel()]
+        service.availableModels = [makeGPT55Model(), makeGPT56Model(id: "gpt-5.6-sol"), makeModel()]
         service.setSelectedModelId("gpt-5.4")
         service.setSelectedReasoningEffort("high")
 
         service.setSelectedModelId(nil)
 
-        XCTAssertEqual(service.selectedModelId, "gpt-5.5")
+        XCTAssertEqual(service.selectedModelId, "gpt-5.6-sol")
         XCTAssertEqual(service.selectedReasoningEffort, "medium")
-        XCTAssertEqual(service.runtimeModelIdentifierForTurn(), "gpt-5.5")
+        XCTAssertEqual(service.runtimeModelIdentifierForTurn(), "gpt-5.6-sol")
         XCTAssertEqual(service.selectedReasoningEffortForSelectedModel(), "medium")
     }
 
@@ -185,7 +185,7 @@ final class CodexThreadRuntimeOverrideTests: XCTestCase {
         let suiteName = "CodexThreadRuntimeOverrideTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName) ?? .standard
         defaults.removePersistentDomain(forName: suiteName)
-        defaults.set("gpt-5.5", forKey: CodexService.selectedModelIdDefaultsKey)
+        defaults.set("gpt-5.6-sol", forKey: CodexService.selectedModelIdDefaultsKey)
 
         let service = CodexService(defaults: defaults)
         Self.retainedServices.append(service)
@@ -194,7 +194,7 @@ final class CodexThreadRuntimeOverrideTests: XCTestCase {
         XCTAssertTrue(service.availableModels.isEmpty)
         XCTAssertNil(service.visibleSelectedModelIDForComposer())
         XCTAssertTrue(service.isRuntimeSelectionLoadingForComposer())
-        XCTAssertEqual(service.runtimeModelIdentifierForTurn(), "gpt-5.5")
+        XCTAssertEqual(service.runtimeModelIdentifierForTurn(), "gpt-5.6-sol")
     }
 
     func testComposerKeepsCustomPersistedModelVisibleDuringBootstrap() {
@@ -223,7 +223,7 @@ final class CodexThreadRuntimeOverrideTests: XCTestCase {
         XCTAssertFalse(service.hasPersistedSelectedModelId)
         XCTAssertNil(service.selectedModelId)
         XCTAssertNil(service.selectedReasoningEffort)
-        XCTAssertEqual(service.runtimeModelIdentifierForTurn(), "gpt-5.5")
+        XCTAssertEqual(service.runtimeModelIdentifierForTurn(), "gpt-5.6-sol")
         XCTAssertNil(defaults.string(forKey: CodexService.selectedModelIdDefaultsKey))
     }
 
@@ -234,18 +234,78 @@ final class CodexThreadRuntimeOverrideTests: XCTestCase {
 
         let firstService = CodexService(defaults: defaults)
         Self.retainedServices.append(firstService)
-        firstService.availableModels = [makeGPT55Model(), makeModel()]
+        firstService.availableModels = [
+            makeGPT55Model(),
+            makeGPT56Model(id: "gpt-5.6-luna"),
+            makeGPT56Model(id: "gpt-5.6-terra"),
+            makeGPT56Model(id: "gpt-5.6-sol"),
+            makeModel(),
+        ]
         firstService.normalizeRuntimeSelectionsAfterModelsUpdate()
 
         XCTAssertTrue(firstService.hasPersistedSelectedModelId)
-        XCTAssertEqual(firstService.selectedModelId, "gpt-5.5")
-        XCTAssertEqual(defaults.string(forKey: CodexService.selectedModelIdDefaultsKey), "gpt-5.5")
+        XCTAssertEqual(firstService.selectedModelId, "gpt-5.6-sol")
+        XCTAssertEqual(defaults.string(forKey: CodexService.selectedModelIdDefaultsKey), "gpt-5.6-sol")
 
         let secondService = CodexService(defaults: defaults)
         Self.retainedServices.append(secondService)
 
         XCTAssertTrue(secondService.hasPersistedSelectedModelId)
-        XCTAssertEqual(secondService.selectedModelId, "gpt-5.5")
+        XCTAssertEqual(secondService.selectedModelId, "gpt-5.6-sol")
+    }
+
+    func testModelListRefreshFallsBackThroughGPT56FamilyBeforeGPT55() {
+        let service = makeService()
+        service.availableModels = [
+            makeGPT55Model(),
+            makeGPT56Model(id: "gpt-5.6-luna"),
+            makeGPT56Model(id: "gpt-5.6-terra"),
+            makeModel(),
+        ]
+        service.normalizeRuntimeSelectionsAfterModelsUpdate()
+
+        XCTAssertEqual(service.selectedModelId, "gpt-5.6-terra")
+        XCTAssertEqual(service.runtimeModelIdentifierForTurn(), "gpt-5.6-terra")
+    }
+
+    func testModelListRefreshUsesGPT55WhenGPT56FamilyIsUnavailable() {
+        let service = makeService()
+        service.availableModels = [makeGPT55Model(), makeModel()]
+        service.normalizeRuntimeSelectionsAfterModelsUpdate()
+
+        XCTAssertEqual(service.selectedModelId, "gpt-5.5")
+        XCTAssertEqual(service.runtimeModelIdentifierForTurn(), "gpt-5.5")
+    }
+
+    func testGPT56ModelsAreFirstClassRuntimeMenuModels() {
+        let orderedModels = TurnComposerMetaMapper.orderedModels(
+            from: [
+                makeModel(),
+                makeGPT55Model(),
+                makeGPT56Model(id: "gpt-5.6-luna"),
+                makeGPT56Model(id: "gpt-5.6-terra"),
+                makeGPT56Model(id: "gpt-5.6-sol"),
+            ]
+        )
+
+        XCTAssertEqual(
+            orderedModels.prefix(3).map(\.id),
+            ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]
+        )
+        XCTAssertEqual(TurnComposerMetaMapper.modelTitle(forIdentifier: "gpt-5.6-sol"), "GPT-5.6-Sol")
+        XCTAssertEqual(TurnComposerMetaMapper.modelTitle(forIdentifier: "gpt-5.6-terra"), "GPT-5.6-Terra")
+        XCTAssertEqual(TurnComposerMetaMapper.modelTitle(forIdentifier: "gpt-5.6-luna"), "GPT-5.6-Luna")
+    }
+
+    func testGPT56ReasoningDisplayIncludesMaxAboveExtraHigh() {
+        let options = TurnComposerMetaMapper.reasoningDisplayOptions(
+            from: ["low", "medium", "high", "xhigh", "max"]
+        )
+
+        XCTAssertEqual(
+            options.map(\.title),
+            ["Max", "Extra High", "High", "Medium", "Low"]
+        )
     }
 
     func testContinuationInheritsThreadRuntimeOverrides() {
@@ -391,6 +451,25 @@ final class CodexThreadRuntimeOverrideTests: XCTestCase {
             supportedReasoningEfforts: [
                 CodexReasoningEffortOption(reasoningEffort: "medium", description: "Medium"),
                 CodexReasoningEffortOption(reasoningEffort: "high", description: "High"),
+            ],
+            defaultReasoningEffort: "medium"
+        )
+    }
+
+    private func makeGPT56Model(id: String) -> CodexModelOption {
+        CodexModelOption(
+            id: id,
+            model: id,
+            displayName: id.uppercased(),
+            description: "Test model",
+            isDefault: true,
+            supportsFastMode: true,
+            supportedReasoningEfforts: [
+                CodexReasoningEffortOption(reasoningEffort: "low", description: "Low"),
+                CodexReasoningEffortOption(reasoningEffort: "medium", description: "Medium"),
+                CodexReasoningEffortOption(reasoningEffort: "high", description: "High"),
+                CodexReasoningEffortOption(reasoningEffort: "xhigh", description: "Extra High"),
+                CodexReasoningEffortOption(reasoningEffort: "max", description: "Max"),
             ],
             defaultReasoningEffort: "medium"
         )


### PR DESCRIPTION
## Summary
- Add GPT-5.6-Sol, GPT-5.6-Terra, and GPT-5.6-Luna to the iOS model picker and runtime fallback order.
- Provide Low, Medium, High, Extra High, and Max reasoning options when runtime metadata is incomplete.
- Cover the new model family, fallback behavior, ordering, and labels with focused tests.

## Verification
- `git diff --check upstream/main...HEAD`
- `swiftc -parse` on the changed production and test Swift files

## Notes
- Xcode tests were not run because this repository requires explicit user approval before running them.