### PR TITLE
Add selectable Mac wake modes

### DIFF
--- a/CodexMobile/CodexMobile/Services/CodexService+Account.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Account.swift
@@ -124,6 +124,7 @@ struct CodexBridgeHostCapabilities: Codable, Equatable, Sendable {
         case desktopHandoff
         case displayWake
         case keepAwake
+        case keepAwakeModes
         case hostBrowserLogin
         case terminal
         case bridgeUpdate
@@ -132,6 +133,7 @@ struct CodexBridgeHostCapabilities: Codable, Equatable, Sendable {
     var desktopHandoff: Bool = false
     var displayWake: Bool = false
     var keepAwake: Bool = false
+    var keepAwakeModes: Bool = false
     var hostBrowserLogin: Bool = false
     var terminal: Bool = false
     var bridgeUpdate: Bool = false
@@ -140,6 +142,7 @@ struct CodexBridgeHostCapabilities: Codable, Equatable, Sendable {
         desktopHandoff: Bool = false,
         displayWake: Bool = false,
         keepAwake: Bool = false,
+        keepAwakeModes: Bool = false,
         hostBrowserLogin: Bool = false,
         terminal: Bool = false,
         bridgeUpdate: Bool = false
@@ -147,6 +150,7 @@ struct CodexBridgeHostCapabilities: Codable, Equatable, Sendable {
         self.desktopHandoff = desktopHandoff
         self.displayWake = displayWake
         self.keepAwake = keepAwake
+        self.keepAwakeModes = keepAwakeModes
         self.hostBrowserLogin = hostBrowserLogin
         self.terminal = terminal
         self.bridgeUpdate = bridgeUpdate
@@ -157,6 +161,7 @@ struct CodexBridgeHostCapabilities: Codable, Equatable, Sendable {
         desktopHandoff = try container.decodeIfPresent(Bool.self, forKey: .desktopHandoff) ?? false
         displayWake = try container.decodeIfPresent(Bool.self, forKey: .displayWake) ?? false
         keepAwake = try container.decodeIfPresent(Bool.self, forKey: .keepAwake) ?? false
+        keepAwakeModes = try container.decodeIfPresent(Bool.self, forKey: .keepAwakeModes) ?? false
         hostBrowserLogin = try container.decodeIfPresent(Bool.self, forKey: .hostBrowserLogin) ?? false
         terminal = try container.decodeIfPresent(Bool.self, forKey: .terminal) ?? false
         bridgeUpdate = try container.decodeIfPresent(Bool.self, forKey: .bridgeUpdate) ?? false
@@ -1223,6 +1228,7 @@ extension CodexService {
             desktopHandoff: firstBoolValue(in: capabilitiesObject, keys: ["desktopHandoff", "desktop_handoff"]) ?? false,
             displayWake: firstBoolValue(in: capabilitiesObject, keys: ["displayWake", "display_wake"]) ?? false,
             keepAwake: firstBoolValue(in: capabilitiesObject, keys: ["keepAwake", "keep_awake"]) ?? false,
+            keepAwakeModes: firstBoolValue(in: capabilitiesObject, keys: ["keepAwakeModes", "keep_awake_modes"]) ?? false,
             hostBrowserLogin: firstBoolValue(in: capabilitiesObject, keys: ["hostBrowserLogin", "host_browser_login"]) ?? false,
             terminal: firstBoolValue(in: capabilitiesObject, keys: ["terminal", "sshTerminal", "ssh_terminal"]) ?? false,
             bridgeUpdate: firstBoolValue(in: capabilitiesObject, keys: ["bridgeUpdate", "bridge_update"]) ?? false

--- a/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService+Connection.swift
@@ -8,6 +8,12 @@ import Foundation
 import Network
 import UIKit
 
+enum CodexKeepAwakeMode: String, CaseIterable, Sendable {
+    case off
+    case acPower = "ac-power"
+    case always
+}
+
 extension CodexService {
     // Only close codes that prove the saved pairing/session can no longer be reused
     // should force a QR reset. A `4003` replaces an older mobile socket with a newer one,
@@ -209,9 +215,16 @@ extension CodexService {
         failAllPendingRequests(with: CodexServiceError.disconnected)
     }
 
+    func setKeepMacAwakeModePreference(_ mode: CodexKeepAwakeMode) {
+        keepMacAwakeMode = mode
+        defaults.set(mode.rawValue, forKey: Self.keepMacAwakeModeDefaultsKey)
+        // Preserve safe downgrade behavior for older app versions. AC-only
+        // becomes off rather than unexpectedly keeping a Mac awake on battery.
+        defaults.set(mode == .always, forKey: Self.keepMacAwakeWhileBridgeRunsDefaultsKey)
+    }
+
     func setKeepMacAwakeWhileBridgeRunsPreference(_ enabled: Bool) {
-        keepMacAwakeWhileBridgeRuns = enabled
-        defaults.set(enabled, forKey: Self.keepMacAwakeWhileBridgeRunsDefaultsKey)
+        setKeepMacAwakeModePreference(enabled ? .always : .off)
     }
 
     func updateBridgeKeepMacAwakePreference(_ enabled: Bool) async {
@@ -228,7 +241,7 @@ extension CodexService {
 
         do {
             try await handoffService.updateBridgeKeepMacAwakePreference(
-                enabled: keepMacAwakeWhileBridgeRuns
+                mode: keepMacAwakeMode
             )
         } catch {
             if showFailureInUI {

--- a/CodexMobile/CodexMobile/Services/CodexService.swift
+++ b/CodexMobile/CodexMobile/Services/CodexService.swift
@@ -467,7 +467,10 @@ final class CodexService {
     @ObservationIgnored var autoApprovalRetryTokensByReviewKey: [String: CodexAutoApprovalRetryToken] = [:]
     var lastRawMessage: String?
     var lastErrorMessage: String?
-    var keepMacAwakeWhileBridgeRuns = false
+    var keepMacAwakeMode: CodexKeepAwakeMode = .off
+    var keepMacAwakeWhileBridgeRuns: Bool {
+        keepMacAwakeMode != .off
+    }
     var runtimeDebugLogEntries: [String] = []
     @ObservationIgnored var compactRuntimeItemCompletedCount = 0
     @ObservationIgnored var compactRuntimeItemCompletedTypes: [String: Int] = [:]
@@ -743,6 +746,9 @@ final class CodexService {
     var supportsKeepAwakeWhileBridgeRuns: Bool {
         bridgeHostCapabilities.keepAwake
     }
+    var supportsKeepAwakeModes: Bool {
+        bridgeHostCapabilities.keepAwakeModes
+    }
     var supportsBridgePackageUpdate: Bool {
         bridgeHostCapabilities.bridgeUpdate
     }
@@ -854,6 +860,7 @@ final class CodexService {
     static let turnTerminalStatesDefaultsKey = "codex.turnTerminalStates"
     static let threadHistoryPaginationStateDefaultsKey = "codex.threadHistoryPaginationState"
     static let notificationsPromptedDefaultsKey = "codex.notifications.prompted"
+    static let keepMacAwakeModeDefaultsKey = "codex.keepMacAwakeMode"
     static let keepMacAwakeWhileBridgeRunsDefaultsKey = "codex.keepMacAwakeWhileBridgeRuns"
 
     init(
@@ -895,10 +902,15 @@ final class CodexService {
             ? savedReasoning
             : nil
 
-        if defaults.object(forKey: Self.keepMacAwakeWhileBridgeRunsDefaultsKey) != nil {
-            self.keepMacAwakeWhileBridgeRuns = defaults.bool(forKey: Self.keepMacAwakeWhileBridgeRunsDefaultsKey)
+        if let rawKeepAwakeMode = defaults.string(forKey: Self.keepMacAwakeModeDefaultsKey),
+           let savedKeepAwakeMode = CodexKeepAwakeMode(rawValue: rawKeepAwakeMode) {
+            self.keepMacAwakeMode = savedKeepAwakeMode
+        } else if defaults.object(forKey: Self.keepMacAwakeWhileBridgeRunsDefaultsKey) != nil {
+            self.keepMacAwakeMode = defaults.bool(forKey: Self.keepMacAwakeWhileBridgeRunsDefaultsKey)
+                ? .always
+                : .off
         } else {
-            self.keepMacAwakeWhileBridgeRuns = false
+            self.keepMacAwakeMode = .off
         }
         self.threadRuntimeOverridesByThreadID = [:]
 

--- a/CodexMobile/CodexMobile/Services/DesktopHandoffService.swift
+++ b/CodexMobile/CodexMobile/Services/DesktopHandoffService.swift
@@ -107,12 +107,15 @@ final class DesktopHandoffService {
         try await sendWakeDisplayRequest(using: codex)
     }
 
-    func updateBridgeKeepMacAwakePreference(enabled: Bool) async throws {
+    func updateBridgeKeepMacAwakePreference(mode: CodexKeepAwakeMode) async throws {
         do {
             let response = try await codex.sendRequest(
                 method: "desktop/preferences/update",
                 params: .object([
-                    "keepMacAwake": .bool(enabled),
+                    "keepMacAwakeMode": .string(mode.rawValue),
+                    // Older bridges require the boolean. AC-only intentionally
+                    // degrades to off instead of holding a battery wake assertion.
+                    "keepMacAwake": .bool(mode == .always),
                 ])
             )
             guard let resultObject = response.result?.objectValue,

--- a/CodexMobile/CodexMobile/Views/Settings/SettingsConnectionCard.swift
+++ b/CodexMobile/CodexMobile/Views/Settings/SettingsConnectionCard.swift
@@ -45,8 +45,17 @@ struct SettingsConnectionCard: View {
             }
 
             if codex.supportsKeepAwakeWhileBridgeRuns {
-                Toggle("Keep device reachable", isOn: keepMacAwakeWhileBridgeRunsBinding)
-                    .tint(settingsToggleTintColor)
+                if codex.supportsKeepAwakeModes {
+                    Picker("Keep device reachable", selection: keepMacAwakeModeBinding) {
+                        ForEach(CodexKeepAwakeMode.allCases, id: \.self) { mode in
+                            Text(keepAwakeModeLabel(mode)).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                } else {
+                    Toggle("Keep device reachable", isOn: keepMacAwakeWhileBridgeRunsBinding)
+                        .tint(settingsToggleTintColor)
+                }
             }
 
             if codex.isConnected {
@@ -66,8 +75,13 @@ struct SettingsConnectionCard: View {
     private var keepAwakeFooter: String? {
         guard codex.supportsKeepAwakeWhileBridgeRuns else { return nil }
 
-        if codex.keepMacAwakeWhileBridgeRuns {
-            return "Keeps your Mac reachable while the bridge is running. Best while charging."
+        switch codex.keepMacAwakeMode {
+        case .acPower:
+            return "Keeps your Mac reachable while it is plugged into power and the bridge is running."
+        case .always:
+            return "Keeps your Mac reachable on power and battery while the bridge is running."
+        case .off:
+            break
         }
 
         if !codex.isConnected {
@@ -77,9 +91,32 @@ struct SettingsConnectionCard: View {
         return nil
     }
 
+    private var keepMacAwakeModeBinding: Binding<CodexKeepAwakeMode> {
+        Binding(
+            get: { codex.keepMacAwakeMode },
+            set: { nextMode in
+                codex.setKeepMacAwakeModePreference(nextMode)
+                Task { @MainActor in
+                    await codex.syncBridgeKeepMacAwakePreferenceIfNeeded(showFailureInUI: true)
+                }
+            }
+        )
+    }
+
+    private func keepAwakeModeLabel(_ mode: CodexKeepAwakeMode) -> String {
+        switch mode {
+        case .off:
+            return "Off"
+        case .acPower:
+            return "While Plugged In"
+        case .always:
+            return "Always"
+        }
+    }
+
     private var keepMacAwakeWhileBridgeRunsBinding: Binding<Bool> {
         Binding(
-            get: { codex.keepMacAwakeWhileBridgeRuns },
+            get: { codex.keepMacAwakeMode == .always },
             set: { nextValue in
                 codex.setKeepMacAwakeWhileBridgeRunsPreference(nextValue)
                 Task { @MainActor in

--- a/CodexMobile/CodexMobileTests/CodexGPTAccountTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexGPTAccountTests.swift
@@ -29,6 +29,7 @@ final class CodexGPTAccountTests: XCTestCase {
         XCTAssertFalse(service.supportsDisplayWake)
         XCTAssertFalse(service.supportsDesktopAppHandoff)
         XCTAssertFalse(service.supportsKeepAwakeWhileBridgeRuns)
+        XCTAssertFalse(service.supportsKeepAwakeModes)
     }
 
     func testKnownMacBridgeKeepsLegacyDisplayWakeFallback() {
@@ -47,6 +48,19 @@ final class CodexGPTAccountTests: XCTestCase {
         XCTAssertTrue(service.supportsDisplayWake)
         XCTAssertTrue(service.supportsDesktopAppHandoff)
         XCTAssertTrue(service.supportsKeepAwakeWhileBridgeRuns)
+        XCTAssertFalse(service.supportsKeepAwakeModes)
+    }
+
+    func testCurrentMacBridgeAdvertisesSelectableKeepAwakeModes() {
+        let service = makeService()
+        service.gptAccountSnapshot.hostPlatform = .macOS
+        service.gptAccountSnapshot.hostCapabilities = CodexBridgeHostCapabilities(
+            keepAwake: true,
+            keepAwakeModes: true
+        )
+
+        XCTAssertTrue(service.supportsKeepAwakeWhileBridgeRuns)
+        XCTAssertTrue(service.supportsKeepAwakeModes)
     }
 
     func testRefreshGPTAccountStateDecodesSanitizedBridgeStatus() async {

--- a/CodexMobile/CodexMobileTests/CodexServiceConnectionErrorTests.swift
+++ b/CodexMobile/CodexMobileTests/CodexServiceConnectionErrorTests.swift
@@ -19,6 +19,49 @@ final class CodexServiceConnectionErrorTests: XCTestCase {
         let service = CodexService(defaults: defaults)
 
         XCTAssertFalse(service.keepMacAwakeWhileBridgeRuns)
+        XCTAssertEqual(service.keepMacAwakeMode, .off)
+    }
+
+    func testLegacyKeepAwakePreferenceMigratesToAlways() {
+        let suiteName = "CodexServiceConnectionErrorTests.legacyKeepMacAwake.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults.set(true, forKey: CodexService.keepMacAwakeWhileBridgeRunsDefaultsKey)
+
+        let service = CodexService(defaults: defaults)
+
+        XCTAssertEqual(service.keepMacAwakeMode, .always)
+        XCTAssertTrue(service.keepMacAwakeWhileBridgeRuns)
+    }
+
+    func testACOnlyKeepAwakePreferencePersistsWithoutEnablingLegacyBatteryWake() {
+        let suiteName = "CodexServiceConnectionErrorTests.acOnlyKeepMacAwake.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let service = CodexService(defaults: defaults)
+
+        service.setKeepMacAwakeModePreference(.acPower)
+
+        XCTAssertEqual(service.keepMacAwakeMode, .acPower)
+        XCTAssertEqual(defaults.string(forKey: CodexService.keepMacAwakeModeDefaultsKey), "ac-power")
+        XCTAssertFalse(defaults.bool(forKey: CodexService.keepMacAwakeWhileBridgeRunsDefaultsKey))
+    }
+
+    func testACOnlyKeepAwakePreferenceSendsModeWithSafeLegacyFallback() async throws {
+        let service = CodexService()
+        service.requestTransportOverride = { method, params in
+            XCTAssertEqual(method, "desktop/preferences/update")
+            XCTAssertEqual(params?.objectValue?["keepMacAwakeMode"]?.stringValue, "ac-power")
+            XCTAssertEqual(params?.objectValue?["keepMacAwake"]?.boolValue, false)
+            return RPCMessage(
+                id: .string(UUID().uuidString),
+                result: .object(["success": .bool(true)]),
+                includeJSONRPC: false
+            )
+        }
+
+        try await DesktopHandoffService(codex: service)
+            .updateBridgeKeepMacAwakePreference(mode: .acPower)
     }
 
     func testBenignBackgroundAbortIsSuppressedFromUserFacingErrors() {

--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ remodex watch
 | `REMODEX_DESKTOP_AUTO_FOLLOW` | `true` on macOS with local IPC | Open a newly materialized phone-driven thread once so Codex Desktop follows its live IPC stream |
 | `REMODEX_DESKTOP_IPC_SOCKET` | auto-detected | Override the local Codex IPC socket or Windows named pipe path |
 | `REMODEX_DESKTOP_IPC_SNAPSHOT_DEBOUNCE_MS` | `75` | Debounce window (ms) for IPC `conversationState` snapshot / patch broadcasts |
+| `REMODEX_KEEP_MAC_AWAKE_MODE` | `off` | macOS bridge wake policy: `off`, `ac-power`, or `always` |
 | `REMODEX_REFRESH_ENABLED` | `false` | Auto-refresh Codex.app when phone activity is detected (`true` enables it explicitly) |
 | `REMODEX_REFRESH_DEBOUNCE_MS` | `1200` | Debounce window (ms) for coalescing refresh events |
 | `REMODEX_REFRESH_COMMAND` | — | Custom shell command to run instead of the built-in AppleScript refresh |

--- a/phodex-bridge/src/account-status.js
+++ b/phodex-bridge/src/account-status.js
@@ -170,6 +170,7 @@ function deriveHostCapabilities(platform) {
     desktopHandoff: isMacOS,
     displayWake: isMacOS,
     keepAwake: isMacOS,
+    keepAwakeModes: isMacOS,
     hostBrowserLogin: isMacOS,
     bridgeUpdate: isMacOS,
   };

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -71,6 +71,12 @@ const { createThreadRuntimeSettingsStore } = require("./thread-runtime-settings-
 const { createThreadListProvenanceEnricher } = require("./thread-list-provenance");
 const { createWorktreeOriginEnricher } = require("./worktree-origin");
 const { forEachThreadRowInResponse } = require("./thread-row-enrichment");
+const {
+  KEEP_AWAKE_MODE_ALWAYS,
+  KEEP_AWAKE_MODE_OFF,
+  caffeinateFlagForKeepAwakeMode,
+  resolveKeepAwakeMode,
+} = require("./keep-awake-mode");
 const { version: bridgePackageVersion = "" } = require("../package.json");
 const {
   MINIMUM_SUPPORTED_IOS_APP_VERSION,
@@ -707,9 +713,13 @@ function startBridge({
   onBridgeStatus = null,
 } = {}) {
   const config = explicitConfig || readBridgeConfig();
-  config.keepMacAwakeEnabled = config.keepMacAwakeEnabled === true;
-  const bridgeWakeAssertion = createMacOSBridgeWakeAssertion({
+  config.keepMacAwakeMode = resolveKeepAwakeMode({
+    mode: config.keepMacAwakeMode,
     enabled: config.keepMacAwakeEnabled,
+  });
+  config.keepMacAwakeEnabled = config.keepMacAwakeMode !== KEEP_AWAKE_MODE_OFF;
+  const bridgeWakeAssertion = createMacOSBridgeWakeAssertion({
+    mode: config.keepMacAwakeMode,
   });
   const relayBaseUrl = config.relayUrl.replace(/\/+$/, "");
   if (!relayBaseUrl) {
@@ -2137,20 +2147,25 @@ function startBridge({
     return {
       success: true,
       preferences: {
-        keepMacAwake: config.keepMacAwakeEnabled !== false,
+        keepMacAwake: config.keepMacAwakeMode !== KEEP_AWAKE_MODE_OFF,
+        keepMacAwakeMode: config.keepMacAwakeMode,
       },
       applied: bridgeWakeAssertion.active,
     };
   }
 
   function updateBridgePreferences(preferences = {}) {
-    const nextKeepMacAwakeEnabled = preferences.keepMacAwake !== false;
-    config.keepMacAwakeEnabled = nextKeepMacAwakeEnabled;
-    bridgeWakeAssertion.setEnabled?.(nextKeepMacAwakeEnabled);
+    const nextKeepMacAwakeMode = resolveKeepAwakeMode({
+      mode: preferences.keepMacAwakeMode,
+      enabled: preferences.keepMacAwake,
+    });
+    config.keepMacAwakeMode = nextKeepMacAwakeMode;
+    config.keepMacAwakeEnabled = nextKeepMacAwakeMode !== KEEP_AWAKE_MODE_OFF;
+    bridgeWakeAssertion.setMode?.(nextKeepMacAwakeMode);
 
     try {
       persistBridgePreferences({
-        keepMacAwakeEnabled: nextKeepMacAwakeEnabled,
+        keepMacAwakeMode: nextKeepMacAwakeMode,
       });
     } catch (error) {
       const nextError = new Error("Could not save the bridge preference on this Mac.");
@@ -2225,26 +2240,35 @@ function startBridge({
   };
 }
 
-// Holds a single macOS idle-sleep assertion for as long as the bridge process stays alive.
+// Holds one macOS sleep assertion for as long as the bridge stays alive.
 function createMacOSBridgeWakeAssertion({
   platform = process.platform,
   pid = process.pid,
   spawnImpl = spawn,
   consoleImpl = console,
-  enabled = true,
+  mode = null,
+  enabled = undefined,
 } = {}) {
   if (platform !== "darwin") {
     return {
       active: false,
       enabled: false,
+      mode: KEEP_AWAKE_MODE_OFF,
+      setMode() {
+        return { active: false, enabled: false, mode: KEEP_AWAKE_MODE_OFF };
+      },
       setEnabled() {
-        return { active: false, enabled: false };
+        return { active: false, enabled: false, mode: KEEP_AWAKE_MODE_OFF };
       },
       stop() {},
     };
   }
 
-  let desiredEnabled = Boolean(enabled);
+  let desiredMode = resolveKeepAwakeMode({
+    mode,
+    enabled,
+    fallback: KEEP_AWAKE_MODE_ALWAYS,
+  });
   let child = null;
 
   function stop() {
@@ -2260,12 +2284,13 @@ function createMacOSBridgeWakeAssertion({
   }
 
   function start() {
-    if (!desiredEnabled || child) {
+    const caffeinateFlag = caffeinateFlagForKeepAwakeMode(desiredMode);
+    if (!caffeinateFlag || child) {
       return;
     }
 
     try {
-      const nextChild = spawnImpl("/usr/bin/caffeinate", ["-i", "-w", String(pid)], {
+      const nextChild = spawnImpl("/usr/bin/caffeinate", [caffeinateFlag, "-w", String(pid)], {
         stdio: "ignore",
       });
 
@@ -2287,18 +2312,27 @@ function createMacOSBridgeWakeAssertion({
     }
   }
 
-  function setEnabled(nextEnabled) {
-    desiredEnabled = Boolean(nextEnabled);
-    if (desiredEnabled) {
-      start();
-    } else {
-      stop();
-    }
-
+  function snapshot() {
     return {
       active: Boolean(child && !child.killed),
-      enabled: desiredEnabled,
+      enabled: desiredMode !== KEEP_AWAKE_MODE_OFF,
+      mode: desiredMode,
     };
+  }
+
+  function setMode(nextMode) {
+    const normalizedMode = resolveKeepAwakeMode({ mode: nextMode });
+    if (normalizedMode === desiredMode) {
+      return snapshot();
+    }
+    stop();
+    desiredMode = normalizedMode;
+    start();
+    return snapshot();
+  }
+
+  function setEnabled(nextEnabled) {
+    return setMode(nextEnabled ? KEEP_AWAKE_MODE_ALWAYS : KEEP_AWAKE_MODE_OFF);
   }
 
   start();
@@ -2308,8 +2342,12 @@ function createMacOSBridgeWakeAssertion({
       return Boolean(child && !child.killed);
     },
     get enabled() {
-      return desiredEnabled;
+      return desiredMode !== KEEP_AWAKE_MODE_OFF;
     },
+    get mode() {
+      return desiredMode;
+    },
+    setMode,
     setEnabled,
     stop,
   };
@@ -5019,16 +5057,20 @@ function truncateRelayTextTail(value, maxChars) {
 
 function persistBridgePreferences(
   {
-    keepMacAwakeEnabled,
+    keepMacAwakeMode,
   },
   {
     readDaemonConfigImpl = readDaemonConfig,
     writeDaemonConfigImpl = writeDaemonConfig,
   } = {}
 ) {
+  const normalizedMode = resolveKeepAwakeMode({ mode: keepMacAwakeMode });
   writeDaemonConfigImpl({
     ...(readDaemonConfigImpl() || {}),
-    keepMacAwakeEnabled,
+    keepMacAwakeMode: normalizedMode,
+    // Older bridge versions only understand this boolean. AC-only degrades to
+    // off on downgrade instead of unexpectedly preventing battery sleep.
+    keepMacAwakeEnabled: normalizedMode === KEEP_AWAKE_MODE_ALWAYS,
   });
 }
 

--- a/phodex-bridge/src/codex-desktop-refresher.js
+++ b/phodex-bridge/src/codex-desktop-refresher.js
@@ -8,6 +8,11 @@ const { execFile } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const { readDaemonConfig } = require("./daemon-state");
+const {
+  KEEP_AWAKE_MODE_ALWAYS,
+  KEEP_AWAKE_MODE_OFF,
+  normalizeKeepAwakeMode,
+} = require("./keep-awake-mode");
 const { createThreadRolloutActivityWatcher } = require("./rollout-watch");
 
 const DEFAULT_BUNDLE_ID = "com.openai.codex";
@@ -724,10 +729,20 @@ function readBridgeConfig({
   const explicitRefreshEnabled = readOptionalBooleanEnv(["REMODEX_REFRESH_ENABLED"], env);
   const explicitDesktopIpcLiveSyncEnabled = readOptionalBooleanEnv(["REMODEX_DESKTOP_IPC_LIVE_SYNC"], env);
   const explicitDesktopAutoFollowEnabled = readOptionalBooleanEnv(["REMODEX_DESKTOP_AUTO_FOLLOW"], env);
+  const explicitKeepMacAwakeMode = normalizeKeepAwakeMode(env.REMODEX_KEEP_MAC_AWAKE_MODE);
   const explicitKeepMacAwakeEnabled = readOptionalBooleanEnv(["REMODEX_KEEP_MAC_AWAKE"], env);
+  const persistedKeepMacAwakeMode = normalizeKeepAwakeMode(daemonConfig.keepMacAwakeMode);
   const persistedKeepMacAwakeEnabled = typeof daemonConfig.keepMacAwakeEnabled === "boolean"
     ? daemonConfig.keepMacAwakeEnabled
     : null;
+  const keepMacAwakeMode = explicitKeepMacAwakeMode
+    || (explicitKeepMacAwakeEnabled == null
+      ? null
+      : (explicitKeepMacAwakeEnabled ? KEEP_AWAKE_MODE_ALWAYS : KEEP_AWAKE_MODE_OFF))
+    || persistedKeepMacAwakeMode
+    || (persistedKeepMacAwakeEnabled == null
+      ? KEEP_AWAKE_MODE_OFF
+      : (persistedKeepMacAwakeEnabled ? KEEP_AWAKE_MODE_ALWAYS : KEEP_AWAKE_MODE_OFF));
   // The deep-link refresh workaround stays opt-in; local IPC live sync is the primary desktop path.
   // Once opted in, the persisted choice must survive restarts: `remodex restart`
   // rewrites daemon-config.json from this computed config, so ignoring the
@@ -762,9 +777,8 @@ function readBridgeConfig({
       readFirstDefinedEnv(["REMODEX_REFRESH_DEBOUNCE_MS"], String(DEFAULT_DEBOUNCE_MS), env),
       DEFAULT_DEBOUNCE_MS
     ),
-    keepMacAwakeEnabled: explicitKeepMacAwakeEnabled == null
-      ? (persistedKeepMacAwakeEnabled == null ? false : persistedKeepMacAwakeEnabled)
-      : explicitKeepMacAwakeEnabled,
+    keepMacAwakeMode,
+    keepMacAwakeEnabled: keepMacAwakeMode !== KEEP_AWAKE_MODE_OFF,
     codexEndpoint,
     desktopIpcSocketPath: readFirstDefinedEnv(["REMODEX_DESKTOP_IPC_SOCKET"], "", env),
     desktopIpcLiveSyncEnabled,

--- a/phodex-bridge/src/desktop-handler.js
+++ b/phodex-bridge/src/desktop-handler.js
@@ -8,6 +8,7 @@ const { execFile } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const { promisify } = require("util");
+const { resolveKeepAwakeMode } = require("./keep-awake-mode");
 const { findRolloutFileForThread, resolveSessionsRoot } = require("./rollout-watch");
 
 const execFileAsync = promisify(execFile);
@@ -350,7 +351,19 @@ async function updateBridgePreferences(params, options = {}) {
     );
   }
 
-  if (!params || typeof params !== "object" || typeof params.keepMacAwake !== "boolean") {
+  if (!params || typeof params !== "object") {
+    throw desktopError(
+      "invalid_bridge_preferences",
+      "The bridge preference payload is invalid."
+    );
+  }
+
+  const keepMacAwakeMode = resolveKeepAwakeMode({
+    mode: params.keepMacAwakeMode,
+    enabled: params.keepMacAwake,
+    fallback: null,
+  });
+  if (!keepMacAwakeMode) {
     throw desktopError(
       "invalid_bridge_preferences",
       "The bridge preference payload is invalid."
@@ -358,7 +371,7 @@ async function updateBridgePreferences(params, options = {}) {
   }
 
   return options.updateBridgePreferences({
-    keepMacAwake: params.keepMacAwake,
+    keepMacAwakeMode,
   });
 }
 

--- a/phodex-bridge/src/keep-awake-mode.js
+++ b/phodex-bridge/src/keep-awake-mode.js
@@ -1,0 +1,67 @@
+// FILE: keep-awake-mode.js
+// Purpose: Normalizes persisted and wire-level Mac wake preferences.
+// Layer: Bridge helper
+// Exports: wake mode constants plus normalization and caffeinate flag helpers
+
+const KEEP_AWAKE_MODE_OFF = "off";
+const KEEP_AWAKE_MODE_AC_POWER = "ac-power";
+const KEEP_AWAKE_MODE_ALWAYS = "always";
+
+function normalizeKeepAwakeMode(value, fallback = null) {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+
+  switch (value.trim().toLowerCase().replace(/[_\s]+/g, "-")) {
+    case "off":
+    case "disabled":
+    case "false":
+      return KEEP_AWAKE_MODE_OFF;
+    case "ac":
+    case "ac-power":
+    case "plugged-in":
+    case "charging":
+      return KEEP_AWAKE_MODE_AC_POWER;
+    case "always":
+    case "on":
+    case "enabled":
+    case "true":
+      return KEEP_AWAKE_MODE_ALWAYS;
+    default:
+      return fallback;
+  }
+}
+
+function resolveKeepAwakeMode({ mode, enabled, fallback = KEEP_AWAKE_MODE_OFF } = {}) {
+  const normalizedMode = normalizeKeepAwakeMode(mode);
+  if (normalizedMode) {
+    return normalizedMode;
+  }
+  if (typeof enabled === "boolean") {
+    return enabled ? KEEP_AWAKE_MODE_ALWAYS : KEEP_AWAKE_MODE_OFF;
+  }
+  if (fallback === null) {
+    return null;
+  }
+  return normalizeKeepAwakeMode(fallback, KEEP_AWAKE_MODE_OFF);
+}
+
+function caffeinateFlagForKeepAwakeMode(mode) {
+  switch (normalizeKeepAwakeMode(mode, KEEP_AWAKE_MODE_OFF)) {
+    case KEEP_AWAKE_MODE_AC_POWER:
+      return "-s";
+    case KEEP_AWAKE_MODE_ALWAYS:
+      return "-i";
+    default:
+      return null;
+  }
+}
+
+module.exports = {
+  KEEP_AWAKE_MODE_AC_POWER,
+  KEEP_AWAKE_MODE_ALWAYS,
+  KEEP_AWAKE_MODE_OFF,
+  caffeinateFlagForKeepAwakeMode,
+  normalizeKeepAwakeMode,
+  resolveKeepAwakeMode,
+};

--- a/phodex-bridge/test/account-status.test.js
+++ b/phodex-bridge/test/account-status.test.js
@@ -21,6 +21,7 @@ const macHostMetadata = {
     desktopHandoff: true,
     displayWake: true,
     keepAwake: true,
+    keepAwakeModes: true,
     hostBrowserLogin: true,
     bridgeUpdate: true,
   },

--- a/phodex-bridge/test/bridge.test.js
+++ b/phodex-bridge/test/bridge.test.js
@@ -3478,7 +3478,7 @@ test("sanitizeThreadHistoryImagesForRelay leaves unrelated RPC payloads unchange
   );
 });
 
-test("createMacOSBridgeWakeAssertion spawns a macOS caffeinate idle-sleep assertion tied to the bridge pid", () => {
+test("createMacOSBridgeWakeAssertion uses an always-on idle-sleep assertion by default", () => {
   const spawnCalls = [];
   const fakeChild = {
     killed: false,
@@ -3509,7 +3509,36 @@ test("createMacOSBridgeWakeAssertion spawns a macOS caffeinate idle-sleep assert
   assert.equal(fakeChild.killed, true);
 });
 
-test("createMacOSBridgeWakeAssertion can toggle the caffeinate assertion on and off live", () => {
+test("createMacOSBridgeWakeAssertion uses an AC-only system-sleep assertion when requested", () => {
+  const spawnCalls = [];
+  const assertion = createMacOSBridgeWakeAssertion({
+    platform: "darwin",
+    pid: 5150,
+    mode: "ac-power",
+    spawnImpl(command, args, options) {
+      spawnCalls.push({ command, args, options });
+      return {
+        killed: false,
+        on() {},
+        unref() {},
+        kill() {
+          this.killed = true;
+        },
+      };
+    },
+  });
+
+  assert.equal(assertion.mode, "ac-power");
+  assert.equal(assertion.active, true);
+  assert.deepEqual(spawnCalls, [{
+    command: "/usr/bin/caffeinate",
+    args: ["-s", "-w", "5150"],
+    options: { stdio: "ignore" },
+  }]);
+  assertion.stop();
+});
+
+test("createMacOSBridgeWakeAssertion can switch modes live", () => {
   const spawnCalls = [];
   const children = [];
 
@@ -3534,17 +3563,26 @@ test("createMacOSBridgeWakeAssertion can toggle the caffeinate assertion on and 
 
   assert.equal(assertion.active, false);
   assert.equal(assertion.enabled, false);
+  assert.equal(assertion.mode, "off");
   assert.deepEqual(spawnCalls, []);
 
-  assertion.setEnabled(true);
+  assertion.setMode("ac-power");
   assert.equal(assertion.enabled, true);
+  assert.equal(assertion.mode, "ac-power");
   assert.equal(assertion.active, true);
   assert.equal(spawnCalls.length, 1);
+  assert.deepEqual(spawnCalls[0].args, ["-s", "-w", "9001"]);
 
-  assertion.setEnabled(false);
+  assertion.setMode("always");
+  assert.equal(assertion.mode, "always");
+  assert.equal(assertion.active, true);
+  assert.equal(children[0].killed, true);
+  assert.deepEqual(spawnCalls[1].args, ["-i", "-w", "9001"]);
+
+  assertion.setMode("off");
   assert.equal(assertion.enabled, false);
   assert.equal(assertion.active, false);
-  assert.equal(children[0].killed, true);
+  assert.equal(children[1].killed, true);
 });
 
 test("createMacOSBridgeWakeAssertion is a no-op outside macOS", () => {
@@ -3558,6 +3596,7 @@ test("createMacOSBridgeWakeAssertion is a no-op outside macOS", () => {
   });
 
   assert.equal(assertion.active, false);
+  assert.equal(assertion.mode, "off");
   assertion.stop();
   assert.equal(didSpawn, false);
 });
@@ -3566,7 +3605,7 @@ test("persistBridgePreferences only saves the daemon preference field", () => {
   const writes = [];
 
   persistBridgePreferences(
-    { keepMacAwakeEnabled: false },
+    { keepMacAwakeMode: "ac-power" },
     {
       readDaemonConfigImpl() {
         return {
@@ -3583,6 +3622,7 @@ test("persistBridgePreferences only saves the daemon preference field", () => {
   assert.deepEqual(writes, [{
     relayUrl: "ws://127.0.0.1:9000/relay",
     refreshEnabled: true,
+    keepMacAwakeMode: "ac-power",
     keepMacAwakeEnabled: false,
   }]);
 });

--- a/phodex-bridge/test/codex-desktop-refresher.test.js
+++ b/phodex-bridge/test/codex-desktop-refresher.test.js
@@ -73,6 +73,38 @@ test("readBridgeConfig keeps safe defaults and explicit overrides", () => {
       },
     },
   });
+  const persistedLegacyKeepAwakeConfig = readBridgeConfig({
+    env: {
+      REMODEX_DEVICE_STATE_DIR: "/tmp/remodex-state",
+    },
+    platform: "darwin",
+    runtimeRoot: "/tmp/remodex-package",
+    fsImpl: {
+      existsSync(targetPath) {
+        return targetPath === "/tmp/remodex-state/daemon-config.json";
+      },
+      readFileSync(targetPath) {
+        if (targetPath === "/tmp/remodex-state/daemon-config.json") {
+          return JSON.stringify({ keepMacAwakeEnabled: true });
+        }
+        throw new Error("unexpected read");
+      },
+    },
+  });
+  const explicitAcPowerConfig = readBridgeConfig({
+    env: {
+      REMODEX_KEEP_MAC_AWAKE_MODE: "ac-power",
+      REMODEX_KEEP_MAC_AWAKE: "true",
+    },
+    platform: "darwin",
+    runtimeRoot: "/tmp/remodex-package",
+    fsImpl: {
+      existsSync: () => false,
+      readFileSync: () => {
+        throw new Error("unexpected read");
+      },
+    },
+  });
   const linuxConfig = readBridgeConfig({
     env: {},
     platform: "linux",
@@ -142,12 +174,18 @@ test("readBridgeConfig keeps safe defaults and explicit overrides", () => {
   });
   assert.equal(macConfig.refreshEnabled, false);
   assert.equal(macConfig.keepMacAwakeEnabled, false);
+  assert.equal(macConfig.keepMacAwakeMode, "off");
   assert.equal(macConfig.relayUrl, "");
   assert.equal(macConfig.pushServiceUrl, "");
   assert.equal(macConfig.desktopIpcLiveSyncEnabled, true);
   assert.equal(macConfig.desktopAutoFollowEnabled, true);
   assert.equal(macConfig.desktopIpcSnapshotDebounceMs, 75);
   assert.equal(persistedKeepAwakeConfig.keepMacAwakeEnabled, false);
+  assert.equal(persistedKeepAwakeConfig.keepMacAwakeMode, "off");
+  assert.equal(persistedLegacyKeepAwakeConfig.keepMacAwakeEnabled, true);
+  assert.equal(persistedLegacyKeepAwakeConfig.keepMacAwakeMode, "always");
+  assert.equal(explicitAcPowerConfig.keepMacAwakeEnabled, true);
+  assert.equal(explicitAcPowerConfig.keepMacAwakeMode, "ac-power");
   assert.equal(macEndpointConfig.refreshEnabled, false);
   assert.equal(linuxConfig.refreshEnabled, false);
   assert.equal(linuxConfig.desktopAutoFollowEnabled, false);

--- a/phodex-bridge/test/desktop-handler.test.js
+++ b/phodex-bridge/test/desktop-handler.test.js
@@ -403,6 +403,7 @@ test("desktop/preferences/update forwards bridge preference changes", async () =
     id: "request-5",
     method: "desktop/preferences/update",
     params: {
+      keepMacAwakeMode: "ac-power",
       keepMacAwake: false,
     },
   }), (response) => {
@@ -422,18 +423,40 @@ test("desktop/preferences/update forwards bridge preference changes", async () =
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   assert.deepEqual(updates, [{
-    keepMacAwake: false,
+    keepMacAwakeMode: "ac-power",
   }]);
   assert.deepEqual(responses, [{
     id: "request-5",
     result: {
       success: true,
       preferences: {
-        keepMacAwake: false,
+        keepMacAwakeMode: "ac-power",
       },
       applied: false,
     },
   }]);
+});
+
+test("desktop/preferences/update maps legacy booleans to wake modes", async () => {
+  const updates = [];
+
+  handleDesktopRequest(JSON.stringify({
+    id: "request-legacy-preference",
+    method: "desktop/preferences/update",
+    params: {
+      keepMacAwake: true,
+    },
+  }), () => {}, {
+    platform: "darwin",
+    updateBridgePreferences(nextPreferences) {
+      updates.push(nextPreferences);
+      return { success: true };
+    },
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(updates, [{ keepMacAwakeMode: "always" }]);
 });
 
 test("desktop/preferences/update rejects invalid bridge preference payloads", async () => {


### PR DESCRIPTION
## Summary

- replace the binary Mac wake preference with Off, While Plugged In, and Always modes
- use `caffeinate -s -w <bridge-pid>` for AC-only reachability and `caffeinate -i -w <bridge-pid>` for always-on reachability
- preserve compatibility with older app and bridge versions through the existing boolean preference
- expose the new mode capability and picker in iOS Settings

## Validation

- `npm test` in `phodex-bridge` (pass)
- Xcode build for iPhone 17 Pro / iOS 26.5 Simulator (pass)
- Swift parse check for all changed Swift sources and tests (pass)
- live macOS smoke check: `caffeinate -s` registered a `PreventSystemSleep` assertion while the Mac was on AC power

## Screenshot

A simulator screenshot of the new setting is attached below.

<img width="1206" height="2622" alt="Remodex Settings showing While Plugged In wake mode" src="https://github.com/user-attachments/assets/6b5b2cb5-76b7-4e68-b4d5-30bd749a76f0" />