### PR TITLE
Add configurable Codex Desktop targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,25 @@ npm uninstall -g remodex
 
 macOS only. Prints the current `launchd` / bridge status, including whether the service is loaded and whether a recent pairing payload exists.
 
+### `remodex target set` / `remodex target reset`
+
+macOS only. Selects the Codex-compatible desktop app and data home used by the bridge:
+
+```sh
+remodex target set \
+  --codex-home "$HOME/.codex-secondary" \
+  --bundle-id com.openai.codex.secondary \
+  --app-path "$HOME/Applications/ChatGPT Personal.app" \
+  --url-scheme codex-secondary \
+  --restart
+
+remodex target reset --restart
+```
+
+The target is persisted in `~/.remodex/daemon-config.json`. Remodex validates the app bundle identifier and registered URL scheme, and derives IPC only from the selected Codex home. A running service requires `--restart`; Remodex confirms the new app-server and target fingerprint, then restores the previous complete configuration if activation fails. Relay, trusted-phone, and pairing state are not reset by a target switch.
+
+Only one target is active per Remodex bridge. Omitting target commands keeps the existing primary ChatGPT defaults.
+
 ### `remodex run-service`
 
 macOS only. Internal service entrypoint used by `launchd`. You normally do not run this manually.
@@ -352,6 +371,8 @@ remodex watch
 | `REMODEX_REFRESH_DEBOUNCE_MS` | `1200` | Debounce window (ms) for coalescing refresh events |
 | `REMODEX_REFRESH_COMMAND` | — | Custom shell command to run instead of the built-in AppleScript refresh |
 | `REMODEX_CODEX_BUNDLE_ID` | `com.openai.codex` | macOS bundle ID of the Codex app |
+| `REMODEX_CODEX_APP_PATH` | `/Applications/ChatGPT.app` (legacy fallback: `/Applications/Codex.app`) | Absolute path to the selected desktop app bundle |
+| `REMODEX_CODEX_URL_SCHEME` | `codex` | URL scheme used for Resume, auto-follow, and Continue on Mac |
 | `CODEX_HOME` | `~/.codex` | Codex data directory (used here for `sessions/` rollout files) |
 
 ```sh

--- a/phodex-bridge/bin/remodex.js
+++ b/phodex-bridge/bin/remodex.js
@@ -11,10 +11,12 @@ const {
   printMacOSBridgeServiceStatus,
   readBridgeConfig,
   resetMacOSBridgePairing,
+  resetMacOSDesktopTarget,
   restartMacOSBridgeService,
   runMacOSBridgeService,
   startBridge,
   startMacOSBridgeService,
+  setMacOSDesktopTarget,
   stopMacOSBridgeService,
   uninstallMacOSBridgeService,
   resetBridgePairing,
@@ -29,10 +31,12 @@ const defaultDeps = {
   printMacOSBridgeServiceStatus,
   readBridgeConfig,
   resetMacOSBridgePairing,
+  resetMacOSDesktopTarget,
   restartMacOSBridgeService,
   runMacOSBridgeService,
   startBridge,
   startMacOSBridgeService,
+  setMacOSDesktopTarget,
   stopMacOSBridgeService,
   uninstallMacOSBridgeService,
   resetBridgePairing,
@@ -229,6 +233,40 @@ async function main({
     return;
   }
 
+  if (command === "target") {
+    assertMacOSCommand(command, { platform, consoleImpl, exitImpl });
+    const targetCommand = parseTargetCommand(argv.slice(2));
+    let result;
+    if (targetCommand.action === "set") {
+      result = await deps.setMacOSDesktopTarget({
+        target: {
+          codexHome: targetCommand.codexHome,
+          codexBundleId: targetCommand.bundleId,
+          codexAppPath: targetCommand.appPath,
+          codexUrlScheme: targetCommand.urlScheme,
+        },
+        restart: targetCommand.restart,
+      });
+    } else if (targetCommand.action === "reset") {
+      result = await deps.resetMacOSDesktopTarget({ restart: targetCommand.restart });
+    } else {
+      throw new Error("Usage: remodex target set --codex-home <path> --bundle-id <id> --app-path <path> --url-scheme <scheme> [--restart] | remodex target reset [--restart]");
+    }
+    emitResult({
+      payload: {
+        ok: true,
+        currentVersion: version,
+        target: result.target,
+        restarted: result.restarted,
+        rolledBack: result.rolledBack,
+      },
+      message: `[remodex] Desktop target ${targetCommand.action === "reset" ? "reset" : "updated"}${result.restarted ? " and service restarted" : ""}.`,
+      jsonOutput,
+      consoleImpl,
+    });
+    return;
+  }
+
   if (command === "reset-pairing") {
     try {
       if (platform === "darwin") {
@@ -265,7 +303,12 @@ async function main({
 
   if (command === "resume") {
     try {
-      const state = deps.openLastActiveThread();
+      const config = deps.readBridgeConfig();
+      const state = deps.openLastActiveThread({
+        bundleId: config.codexBundleId,
+        appPath: config.codexAppPath,
+        urlScheme: config.codexUrlScheme,
+      });
       emitResult({
         payload: {
           ok: true,
@@ -296,7 +339,7 @@ async function main({
 
   consoleImpl.error(`Unknown command: ${command}`);
   consoleImpl.error(
-    "Usage: remodex up | remodex run | remodex start | remodex restart | remodex qr | remodex pair | remodex stop | remodex uninstall-service | remodex status | "
+    "Usage: remodex up | remodex run | remodex start | remodex restart | remodex qr | remodex pair | remodex stop | remodex uninstall-service | remodex status | remodex target ... | "
     + "remodex reset-pairing | remodex resume | remodex watch [threadId] | remodex --version | "
     + "append --json to start/restart/qr/pair/stop/uninstall-service/status/reset-pairing/resume for machine-readable output"
   );
@@ -321,6 +364,51 @@ function parseCliArgs(rawArgs) {
     jsonOutput,
     watchThreadId: positionals[1] || "",
   };
+}
+
+function parseTargetCommand(rawArgs) {
+  const args = rawArgs.filter((arg) => arg !== "--json");
+  const action = args[1] || "";
+  const result = {
+    action,
+    restart: false,
+    codexHome: "",
+    bundleId: "",
+    appPath: "",
+    urlScheme: "",
+  };
+  const valueFlags = new Map([
+    ["--codex-home", "codexHome"],
+    ["--bundle-id", "bundleId"],
+    ["--app-path", "appPath"],
+    ["--url-scheme", "urlScheme"],
+  ]);
+  for (let index = 2; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--restart") {
+      result.restart = true;
+      continue;
+    }
+    const field = valueFlags.get(argument);
+    if (!field || index + 1 >= args.length) {
+      throw new Error(`Unknown or incomplete target option: ${argument}`);
+    }
+    result[field] = args[index + 1];
+    index += 1;
+  }
+  if (action === "set") {
+    for (const [field, label] of [
+      ["codexHome", "--codex-home"],
+      ["bundleId", "--bundle-id"],
+      ["appPath", "--app-path"],
+      ["urlScheme", "--url-scheme"],
+    ]) {
+      if (!result[field]) {
+        throw new Error(`remodex target set requires ${label}.`);
+      }
+    }
+  }
+  return result;
 }
 
 function emitVersion({

--- a/phodex-bridge/src/bridge.js
+++ b/phodex-bridge/src/bridge.js
@@ -22,6 +22,7 @@ const {
   hasRelayConnectionGoneStale,
 } = require("./bridge-status");
 const { createCodexTransport } = require("./codex-transport");
+const { activateCodexHome } = require("./desktop-target");
 const {
   createThreadRolloutActivityWatcher,
   findRecentRolloutFileForContextRead,
@@ -707,6 +708,10 @@ function startBridge({
   onBridgeStatus = null,
 } = {}) {
   const config = explicitConfig || readBridgeConfig();
+  // A bridge process owns exactly one runtime target. Applying its persisted
+  // home process-wide keeps every existing rollout/worktree/IPC helper aligned
+  // with the app-server spawned below, including helpers that predate config DI.
+  activateCodexHome(config);
   config.keepMacAwakeEnabled = config.keepMacAwakeEnabled === true;
   const bridgeWakeAssertion = createMacOSBridgeWakeAssertion({
     enabled: config.keepMacAwakeEnabled,
@@ -748,6 +753,7 @@ function startBridge({
     refreshCommand: config.refreshCommand,
     bundleId: config.codexBundleId,
     appPath: config.codexAppPath,
+    urlScheme: config.codexUrlScheme,
   });
   const pushServiceClient = createPushNotificationServiceClient({
     baseUrl: config.pushServiceUrl,
@@ -1236,6 +1242,8 @@ function startBridge({
     if (handleDesktopRequest(rawMessage, sendApplicationResponse, {
       bundleId: config.codexBundleId,
       appPath: config.codexAppPath,
+      urlScheme: config.codexUrlScheme,
+      env: process.env,
       readBridgePreferences,
       updateBridgePreferences,
       updateBridgePackageAndRestart,

--- a/phodex-bridge/src/codex-desktop-refresher.js
+++ b/phodex-bridge/src/codex-desktop-refresher.js
@@ -8,10 +8,16 @@ const { execFile } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const { readDaemonConfig } = require("./daemon-state");
+const {
+  DEFAULT_CODEX_BUNDLE_ID,
+  DEFAULT_CODEX_URL_SCHEME,
+  buildCodexDeepLink,
+  defaultCodexAppPath,
+  defaultCodexHome,
+  desktopTargetFingerprint,
+} = require("./desktop-target");
 const { createThreadRolloutActivityWatcher } = require("./rollout-watch");
 
-const DEFAULT_BUNDLE_ID = "com.openai.codex";
-const DEFAULT_APP_PATH = "/Applications/Codex.app";
 const DEFAULT_DEBOUNCE_MS = 1200;
 const DEFAULT_FALLBACK_NEW_THREAD_MS = 2_000;
 const DEFAULT_MID_RUN_REFRESH_THROTTLE_MS = 3_000;
@@ -21,7 +27,6 @@ const DEFAULT_CUSTOM_REFRESH_FAILURE_THRESHOLD = 3;
 const DEFAULT_FOLLOW_CONFIRM_TIMEOUT_MS = 1_500;
 const DEFAULT_FOLLOW_MAX_ATTEMPTS = 3;
 const REFRESH_SCRIPT_PATH = path.join(__dirname, "scripts", "codex-refresh.applescript");
-const NEW_THREAD_DEEP_LINK = "codex://threads/new";
 
 class CodexDesktopRefresher {
   constructor({
@@ -34,8 +39,9 @@ class CodexDesktopRefresher {
     navigationOnly = false,
     debounceMs = DEFAULT_DEBOUNCE_MS,
     refreshCommand = "",
-    bundleId = DEFAULT_BUNDLE_ID,
-    appPath = DEFAULT_APP_PATH,
+    bundleId = DEFAULT_CODEX_BUNDLE_ID,
+    appPath = defaultCodexAppPath(),
+    urlScheme = DEFAULT_CODEX_URL_SCHEME,
     logPrefix = "[remodex]",
     fallbackNewThreadMs = DEFAULT_FALLBACK_NEW_THREAD_MS,
     midRunRefreshThrottleMs = DEFAULT_MID_RUN_REFRESH_THROTTLE_MS,
@@ -55,6 +61,7 @@ class CodexDesktopRefresher {
     this.refreshCommand = refreshCommand;
     this.bundleId = bundleId;
     this.appPath = appPath;
+    this.urlScheme = urlScheme;
     this.logPrefix = logPrefix;
     this.fallbackNewThreadMs = fallbackNewThreadMs;
     this.midRunRefreshThrottleMs = midRunRefreshThrottleMs;
@@ -108,7 +115,7 @@ class CodexDesktopRefresher {
 
     const method = parsed.method;
     if (method === "thread/start") {
-      const target = resolveInboundTarget(method, parsed);
+      const target = resolveInboundTarget(method, parsed, this.urlScheme);
       if (target?.threadId) {
         this.queueRefresh("phone", target, `phone ${method}`);
         this.ensureWatcher(target.threadId);
@@ -123,7 +130,7 @@ class CodexDesktopRefresher {
     }
 
     if (method === "turn/start") {
-      const target = resolveInboundTarget(method, parsed);
+      const target = resolveInboundTarget(method, parsed, this.urlScheme);
       if (!target) {
         return;
       }
@@ -164,13 +171,13 @@ class CodexDesktopRefresher {
         return;
       }
 
-      const target = resolveOutboundTarget(method, parsed);
+      const target = resolveOutboundTarget(method, parsed, this.urlScheme);
       this.queueCompletionRefresh(target, turnId, `codex ${method}`);
       return;
     }
 
     if (method === "thread/started") {
-      const target = resolveOutboundTarget(method, parsed);
+      const target = resolveOutboundTarget(method, parsed, this.urlScheme);
       const shouldWaitForMaterialization = Boolean(
         this.navigationOnly
         && this.pendingNewThread
@@ -446,7 +453,7 @@ class CodexDesktopRefresher {
         return;
       }
 
-      this.noteRefreshTarget({ threadId: null, url: NEW_THREAD_DEEP_LINK });
+      this.noteRefreshTarget({ threadId: null, url: buildCodexDeepLink("threads/new", this.urlScheme) });
       this.pendingRefreshKinds.add("phone");
       this.scheduleRefresh("fallback thread/start");
     }, this.fallbackNewThreadMs);
@@ -527,14 +534,14 @@ class CodexDesktopRefresher {
     this.lastRolloutSize = event.size;
     this.noteRefreshTarget({
       threadId: event.threadId,
-      url: buildThreadDeepLink(event.threadId),
+      url: buildThreadDeepLink(event.threadId, this.urlScheme),
     });
 
     if (event.reason === "materialized") {
       this.materializationPendingThreadIds.delete(event.threadId);
       this.queueRefresh("rollout_materialized", {
         threadId: event.threadId,
-        url: buildThreadDeepLink(event.threadId),
+        url: buildThreadDeepLink(event.threadId, this.urlScheme),
       }, `rollout ${event.reason}`);
       if (this.navigationOnly) {
         this.stopWatcher();
@@ -554,7 +561,7 @@ class CodexDesktopRefresher {
     if (previousSize == null) {
       this.queueRefresh("rollout_growth", {
         threadId: event.threadId,
-        url: buildThreadDeepLink(event.threadId),
+        url: buildThreadDeepLink(event.threadId, this.urlScheme),
       }, "rollout first-growth");
       this.lastMidRunRefreshAt = this.now();
       return;
@@ -567,7 +574,7 @@ class CodexDesktopRefresher {
     this.lastMidRunRefreshAt = this.now();
     this.queueRefresh("rollout_growth", {
       threadId: event.threadId,
-      url: buildThreadDeepLink(event.threadId),
+      url: buildThreadDeepLink(event.threadId, this.urlScheme),
     }, "rollout mid-run");
   }
 
@@ -628,7 +635,7 @@ class CodexDesktopRefresher {
     }
     this.queueRefresh("materialization_fallback", {
       threadId,
-      url: buildThreadDeepLink(threadId),
+      url: buildThreadDeepLink(threadId, this.urlScheme),
     }, reason);
   }
 
@@ -640,7 +647,7 @@ class CodexDesktopRefresher {
     if (!this.navigationOnly || !threadId) {
       return targetUrl;
     }
-    const resolvedTargetUrl = targetUrl || buildThreadDeepLink(threadId);
+    const resolvedTargetUrl = targetUrl || buildThreadDeepLink(threadId, this.urlScheme);
     const separator = resolvedTargetUrl.includes("?") ? "&" : "?";
     this.followActivationSerial += 1;
     return `${resolvedTargetUrl}${separator}remodex-follow=${this.now()}-${this.followActivationSerial}`;
@@ -661,7 +668,7 @@ class CodexDesktopRefresher {
       }
       this.queueRefresh("follow_retry", {
         threadId,
-        url: targetUrl || buildThreadDeepLink(threadId),
+        url: targetUrl || buildThreadDeepLink(threadId, this.urlScheme),
       }, `desktop follow not confirmed (attempt ${attempts + 1})`);
     }, Math.max(0, this.followConfirmTimeoutMs));
     timer.unref?.();
@@ -744,7 +751,38 @@ function readBridgeConfig({
     && !codexEndpoint
     && desktopIpcLiveSyncEnabled
   );
-  return {
+  const codexHome = readFirstDefinedEnv(
+    ["CODEX_HOME"],
+    readString(daemonConfig.codexHome) || defaultCodexHome(),
+    env
+  );
+  const codexBundleId = readFirstDefinedEnv(
+    ["REMODEX_CODEX_BUNDLE_ID"],
+    readString(daemonConfig.codexBundleId) || DEFAULT_CODEX_BUNDLE_ID,
+    env
+  );
+  const codexAppPath = readFirstDefinedEnv(
+    ["REMODEX_CODEX_APP_PATH"],
+    readString(daemonConfig.codexAppPath) || defaultCodexAppPath({ fsImpl }),
+    env
+  );
+  const codexUrlScheme = readFirstDefinedEnv(
+    ["REMODEX_CODEX_URL_SCHEME"],
+    readString(daemonConfig.codexUrlScheme) || DEFAULT_CODEX_URL_SCHEME,
+    env
+  );
+  const configuredDesktopIpcSocketPath = readFirstDefinedEnv(
+    ["REMODEX_DESKTOP_IPC_SOCKET"],
+    readString(daemonConfig.desktopIpcSocketPath),
+    env
+  );
+  const explicitCodexHome = readString(env.CODEX_HOME)
+    || readString(daemonConfig.codexHome);
+  const customCodexHomeSelected = explicitCodexHome
+    && path.resolve(explicitCodexHome) !== path.resolve(defaultCodexHome());
+  const desktopIpcSocketPath = configuredDesktopIpcSocketPath
+    || (customCodexHomeSelected ? path.join(codexHome, "ipc", "ipc.sock") : "");
+  const config = {
     relayUrl,
     pushServiceUrl: readFirstDefinedEnv(
       ["REMODEX_PUSH_SERVICE_URL"],
@@ -766,7 +804,8 @@ function readBridgeConfig({
       ? (persistedKeepMacAwakeEnabled == null ? false : persistedKeepMacAwakeEnabled)
       : explicitKeepMacAwakeEnabled,
     codexEndpoint,
-    desktopIpcSocketPath: readFirstDefinedEnv(["REMODEX_DESKTOP_IPC_SOCKET"], "", env),
+    codexHome,
+    desktopIpcSocketPath,
     desktopIpcLiveSyncEnabled,
     desktopAutoFollowEnabled: explicitDesktopAutoFollowEnabled == null
       ? defaultDesktopAutoFollowEnabled
@@ -776,9 +815,12 @@ function readBridgeConfig({
       75
     ),
     refreshCommand,
-    codexBundleId: readFirstDefinedEnv(["REMODEX_CODEX_BUNDLE_ID"], DEFAULT_BUNDLE_ID, env),
-    codexAppPath: DEFAULT_APP_PATH,
+    codexBundleId,
+    codexAppPath,
+    codexUrlScheme,
   };
+  config.codexTargetFingerprint = desktopTargetFingerprint(config);
+  return config;
 }
 
 function readPrivatePackageDefaults({ runtimeRoot, fsImpl }) {
@@ -878,34 +920,34 @@ function extractThreadId(message) {
   return null;
 }
 
-function resolveInboundTarget(method, message) {
+function resolveInboundTarget(method, message, urlScheme = DEFAULT_CODEX_URL_SCHEME) {
   const threadId = extractThreadId(message);
   if (threadId) {
-    return { threadId, url: buildThreadDeepLink(threadId) };
+    return { threadId, url: buildThreadDeepLink(threadId, urlScheme) };
   }
 
   if (method === "thread/start" || method === "turn/start") {
-    return { threadId: null, url: NEW_THREAD_DEEP_LINK };
+    return { threadId: null, url: buildCodexDeepLink("threads/new", urlScheme) };
   }
 
   return null;
 }
 
-function resolveOutboundTarget(method, message) {
+function resolveOutboundTarget(method, message, urlScheme = DEFAULT_CODEX_URL_SCHEME) {
   const threadId = extractThreadId(message);
   if (threadId) {
-    return { threadId, url: buildThreadDeepLink(threadId) };
+    return { threadId, url: buildThreadDeepLink(threadId, urlScheme) };
   }
 
   if (method === "thread/started") {
-    return { threadId: null, url: NEW_THREAD_DEEP_LINK };
+    return { threadId: null, url: buildCodexDeepLink("threads/new", urlScheme) };
   }
 
   return null;
 }
 
-function buildThreadDeepLink(threadId) {
-  return `codex://threads/${threadId}`;
+function buildThreadDeepLink(threadId, urlScheme = DEFAULT_CODEX_URL_SCHEME) {
+  return buildCodexDeepLink(`threads/${threadId}`, urlScheme);
 }
 
 function readOptionalBooleanEnv(keys, env = process.env) {

--- a/phodex-bridge/src/daemon-state.js
+++ b/phodex-bridge/src/daemon-state.js
@@ -100,12 +100,14 @@ function ensureRemodexLogsDir({ fsImpl = fs, ...options } = {}) {
 function writeJsonFile(targetPath, value, { fsImpl = fs } = {}) {
   fsImpl.mkdirSync(path.dirname(targetPath), { recursive: true });
   const serialized = JSON.stringify(value, null, 2);
-  fsImpl.writeFileSync(targetPath, serialized, { mode: 0o600 });
+  const stagedPath = `${targetPath}.tmp-${process.pid}-${Date.now()}`;
+  fsImpl.writeFileSync(stagedPath, serialized, { mode: 0o600 });
   try {
-    fsImpl.chmodSync(targetPath, 0o600);
+    fsImpl.chmodSync(stagedPath, 0o600);
   } catch {
     // Best-effort only on filesystems without POSIX mode support.
   }
+  fsImpl.renameSync(stagedPath, targetPath);
 }
 
 function readJsonFile(targetPath, { fsImpl = fs } = {}) {

--- a/phodex-bridge/src/desktop-handler.js
+++ b/phodex-bridge/src/desktop-handler.js
@@ -8,11 +8,15 @@ const { execFile } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const { promisify } = require("util");
+const {
+  DEFAULT_CODEX_BUNDLE_ID,
+  DEFAULT_CODEX_URL_SCHEME,
+  buildCodexDeepLink,
+  defaultCodexAppPath,
+} = require("./desktop-target");
 const { findRolloutFileForThread, resolveSessionsRoot } = require("./rollout-watch");
 
 const execFileAsync = promisify(execFile);
-const DEFAULT_BUNDLE_ID = "com.openai.codex";
-const DEFAULT_APP_PATH = "/Applications/Codex.app";
 const DEFAULT_PLATFORM = process.platform;
 const HANDOFF_TIMEOUT_MS = 20_000;
 const DEFAULT_RELAUNCH_WAIT_MS = 300;
@@ -20,7 +24,6 @@ const DEFAULT_APP_BOOT_WAIT_MS = 1_200;
 const DEFAULT_THREAD_MATERIALIZE_WAIT_MS = 4_000;
 const DEFAULT_THREAD_MATERIALIZE_POLL_MS = 250;
 const DEFAULT_WAKE_DISPLAY_DURATION_SECONDS = 30;
-const WINDOWS_BOUNCE_URL = "codex://settings";
 const DESKTOP_THREAD_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$/;
 
 function handleDesktopRequest(rawMessage, sendResponse, options = {}) {
@@ -61,8 +64,9 @@ function handleDesktopRequest(rawMessage, sendResponse, options = {}) {
 
 async function handleDesktopMethod(method, params, options = {}) {
   const platform = options.platform || DEFAULT_PLATFORM;
-  const bundleId = options.bundleId || DEFAULT_BUNDLE_ID;
-  const appPath = options.appPath || DEFAULT_APP_PATH;
+  const bundleId = options.bundleId || DEFAULT_CODEX_BUNDLE_ID;
+  const appPath = options.appPath || defaultCodexAppPath();
+  const urlScheme = options.urlScheme || DEFAULT_CODEX_URL_SCHEME;
   const executor = options.executor || execFileAsync;
   const env = options.env || process.env;
   const fsModule = options.fsModule || fs;
@@ -86,6 +90,7 @@ async function handleDesktopMethod(method, params, options = {}) {
         platform,
         bundleId,
         appPath,
+        urlScheme,
         executor,
         env,
         fsModule,
@@ -108,6 +113,7 @@ async function handleDesktopMethod(method, params, options = {}) {
         platform,
         bundleId,
         appPath,
+        urlScheme,
         executor,
         env,
         fsModule,
@@ -140,6 +146,7 @@ async function continueOnDesktop(
     platform,
     bundleId,
     appPath,
+    urlScheme,
     executor,
     env,
     fsModule,
@@ -159,7 +166,7 @@ async function continueOnDesktop(
     throw desktopError("invalid_thread_id", "The requested desktop thread id is not valid.");
   }
 
-  const targetUrl = `codex://threads/${threadId}`;
+  const targetUrl = buildCodexDeepLink(`threads/${threadId}`, urlScheme);
   const desktopKnown = isThreadLikelyKnownOnDesktop(threadId, { env, fsModule });
 
   if (platform === "win32") {
@@ -170,9 +177,10 @@ async function continueOnDesktop(
           env,
           sleepFn,
           settleMs: relaunchWaitMs,
+          urlScheme,
         });
       } else {
-        await openWindowsDeepLink(WINDOWS_BOUNCE_URL, { executor, env });
+        await openWindowsDeepLink(buildCodexDeepLink("settings", urlScheme), { executor, env });
         await sleepFn(appBootWaitMs);
         await waitForThreadMaterialization(threadId, {
           env,
@@ -202,7 +210,7 @@ async function continueOnDesktop(
 
   const appRunning = typeof isAppRunning === "function"
     ? await isAppRunning(appPath)
-    : await detectRunningCodexApp(appPath, executor);
+    : await detectRunningCodexApp(bundleId, executor);
 
   // If Codex.app is already open, explicit handoff should still feel like a
   // real device switch: close, reopen, then focus the requested thread.
@@ -421,14 +429,12 @@ function resolveSessionsRootForEnv(env) {
   return resolveSessionsRoot();
 }
 
-async function detectRunningCodexApp(appPath, executor) {
-  const appName = path.basename(appPath, ".app");
-
+async function detectRunningCodexApp(bundleId, executor) {
   try {
-    await executor("pgrep", ["-x", appName], {
+    const result = await executor("/usr/bin/lsappinfo", ["find", `bundleid=${bundleId}`], {
       timeout: HANDOFF_TIMEOUT_MS,
     });
-    return true;
+    return Boolean(String(result?.stdout || "").trim());
   } catch {
     return false;
   }
@@ -468,8 +474,8 @@ async function openWindowsDeepLink(targetUrl, { executor, env }) {
   });
 }
 
-async function refreshWindowsCodex(targetUrl, { executor, env, sleepFn, settleMs }) {
-  await openWindowsDeepLink(WINDOWS_BOUNCE_URL, { executor, env });
+async function refreshWindowsCodex(targetUrl, { executor, env, sleepFn, settleMs, urlScheme }) {
+  await openWindowsDeepLink(buildCodexDeepLink("settings", urlScheme), { executor, env });
   await sleepFn(settleMs);
   await openWindowsDeepLink(targetUrl, { executor, env });
 }
@@ -499,31 +505,31 @@ async function forceRelaunchCodexApp({
   relaunchWaitMs,
   appBootWaitMs,
 }) {
-  const appName = path.basename(appPath, ".app");
+  await executor("/usr/bin/osascript", [
+    "-e",
+    "on run argv",
+    "-e",
+    "tell application id (item 1 of argv) to quit",
+    "-e",
+    "end run",
+    bundleId,
+  ], {
+    timeout: HANDOFF_TIMEOUT_MS,
+  });
 
-  try {
-    await executor("pkill", ["-x", appName], {
-      timeout: HANDOFF_TIMEOUT_MS,
-    });
-  } catch (error) {
-    if (error?.code !== 1) {
-      throw error;
-    }
-  }
-
-  await waitForAppExit(appPath, executor, isAppRunning);
+  await waitForAppExit(bundleId, appPath, executor, isAppRunning);
   await sleepFn(relaunchWaitMs);
   await openCodexApp({ bundleId, appPath, executor });
   await sleepFn(appBootWaitMs);
 }
 
-async function waitForAppExit(appPath, executor, isAppRunning) {
+async function waitForAppExit(bundleId, appPath, executor, isAppRunning) {
   const deadline = Date.now() + HANDOFF_TIMEOUT_MS;
 
   while (Date.now() < deadline) {
     const isRunning = typeof isAppRunning === "function"
       ? await isAppRunning(appPath)
-      : await detectRunningCodexApp(appPath, executor);
+      : await detectRunningCodexApp(bundleId, executor);
     if (!isRunning) {
       return;
     }

--- a/phodex-bridge/src/desktop-target-controller.js
+++ b/phodex-bridge/src/desktop-target-controller.js
@@ -1,0 +1,140 @@
+// FILE: desktop-target-controller.js
+// Purpose: Transactionally changes the persisted macOS Codex Desktop target.
+// Layer: CLI helper
+// Exports: setMacOSDesktopTarget, resetMacOSDesktopTarget
+// Depends on: ./daemon-state, ./desktop-target, ./macos-launch-agent
+
+const fs = require("fs");
+const os = require("os");
+const {
+  readBridgeStatus,
+  readDaemonConfig,
+  writeDaemonConfig,
+} = require("./daemon-state");
+const {
+  DEFAULT_CODEX_BUNDLE_ID,
+  DEFAULT_CODEX_URL_SCHEME,
+  defaultCodexAppPath,
+  defaultCodexHome,
+  desktopTargetFingerprint,
+  normalizeDesktopTarget,
+  validateDesktopTarget,
+} = require("./desktop-target");
+const {
+  getMacOSBridgeServiceStatus,
+  restartMacOSBridgeService,
+} = require("./macos-launch-agent");
+
+const TARGET_HEALTH_TIMEOUT_MS = 30_000;
+const TARGET_HEALTH_INTERVAL_MS = 100;
+
+async function setMacOSDesktopTarget({
+  target,
+  restart = false,
+  env = process.env,
+  fsImpl = fs,
+  platform = process.platform,
+  validateTargetImpl = validateDesktopTarget,
+  getServiceStatusImpl = getMacOSBridgeServiceStatus,
+  restartServiceImpl = restartMacOSBridgeService,
+  readBridgeStatusImpl = readBridgeStatus,
+  readDaemonConfigImpl = readDaemonConfig,
+  writeDaemonConfigImpl = writeDaemonConfig,
+  waitForHealthyTargetImpl = waitForHealthyTarget,
+} = {}) {
+  if (platform !== "darwin") {
+    throw new Error("Desktop target switching is only available on macOS.");
+  }
+
+  const serviceStatus = getServiceStatusImpl({ env, fsImpl });
+  if (serviceStatus.launchdLoaded && !restart) {
+    throw new Error("The Remodex service is running. Repeat the command with --restart to switch it safely.");
+  }
+
+  const validated = validateTargetImpl(target, { fsImpl, platform });
+  const previousConfig = readDaemonConfigImpl({ env, fsImpl }) || {};
+  const nextConfig = {
+    ...previousConfig,
+    ...validated,
+  };
+  writeDaemonConfigImpl(nextConfig, { env, fsImpl });
+
+  if (!restart) {
+    return { target: validated, restarted: false, rolledBack: false };
+  }
+
+  try {
+    const restartStartedAt = Date.now();
+    await restartServiceImpl({ env, fsImpl, platform });
+    await waitForHealthyTargetImpl(validated.codexTargetFingerprint, {
+      env,
+      fsImpl,
+      notBeforeMs: restartStartedAt,
+      readBridgeStatusImpl,
+    });
+    return { target: validated, restarted: true, rolledBack: false };
+  } catch (error) {
+    writeDaemonConfigImpl(previousConfig, { env, fsImpl });
+    try {
+      await restartServiceImpl({ env, fsImpl, platform });
+    } catch {
+      // The original error remains the actionable failure; status reports whether rollback restarted.
+    }
+    throw new Error(`Could not activate the new Remodex target; the previous configuration was restored. ${error.message}`);
+  }
+}
+
+async function resetMacOSDesktopTarget(options = {}) {
+  const fsImpl = options.fsImpl || fs;
+  const osImpl = options.osImpl || os;
+  const target = normalizeDesktopTarget({
+    codexHome: defaultCodexHome({ osImpl }),
+    codexBundleId: DEFAULT_CODEX_BUNDLE_ID,
+    codexAppPath: defaultCodexAppPath({ fsImpl }),
+    codexUrlScheme: DEFAULT_CODEX_URL_SCHEME,
+    desktopIpcSocketPath: "",
+  }, { fsImpl, osImpl, strictIpc: false });
+  target.codexTargetFingerprint = desktopTargetFingerprint(target);
+  return setMacOSDesktopTarget({
+    ...options,
+    target,
+    validateTargetImpl: options.validateTargetImpl || ((value) => validateDesktopTarget(value, {
+      fsImpl,
+      platform: options.platform || process.platform,
+      strictIpc: false,
+    })),
+  });
+}
+
+async function waitForHealthyTarget(fingerprint, {
+  env = process.env,
+  fsImpl = fs,
+  readBridgeStatusImpl = readBridgeStatus,
+  notBeforeMs = 0,
+  timeoutMs = TARGET_HEALTH_TIMEOUT_MS,
+  intervalMs = TARGET_HEALTH_INTERVAL_MS,
+} = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let latest = null;
+  while (Date.now() <= deadline) {
+    latest = readBridgeStatusImpl({ env, fsImpl });
+    const updatedAtMs = Date.parse(latest?.updatedAt || "");
+    if (latest?.state === "running"
+      && Number.isFinite(updatedAtMs)
+      && updatedAtMs >= notBeforeMs
+      && latest?.codexTargetFingerprint === fingerprint
+      && latest?.codexLaunchState === "connected") {
+      return latest;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(
+    `The restarted bridge did not confirm target ${fingerprint}; Codex state was ${latest?.codexLaunchState || "unknown"}.`
+  );
+}
+
+module.exports = {
+  resetMacOSDesktopTarget,
+  setMacOSDesktopTarget,
+  waitForHealthyTarget,
+};

--- a/phodex-bridge/src/desktop-target.js
+++ b/phodex-bridge/src/desktop-target.js
@@ -1,0 +1,205 @@
+// FILE: desktop-target.js
+// Purpose: Defines and validates the one-per-bridge Codex Desktop target.
+// Layer: CLI helper
+// Exports: target defaults, normalization, deep-link construction, fingerprinting, and macOS bundle validation.
+// Depends on: crypto, child_process, fs, os, path
+
+const { execFileSync } = require("child_process");
+const { createHash } = require("crypto");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const DEFAULT_CODEX_BUNDLE_ID = "com.openai.codex";
+const DEFAULT_CODEX_URL_SCHEME = "codex";
+const LEGACY_CODEX_APP_PATH = "/Applications/Codex.app";
+const CURRENT_CODEX_APP_PATH = "/Applications/ChatGPT.app";
+const BUNDLE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9.-]*$/;
+const URL_SCHEME_PATTERN = /^[A-Za-z][A-Za-z0-9+.-]*$/;
+
+function defaultCodexHome({ osImpl = os } = {}) {
+  return path.join(osImpl.homedir(), ".codex");
+}
+
+function defaultCodexAppPath({ fsImpl = fs } = {}) {
+  if (fsImpl.existsSync(CURRENT_CODEX_APP_PATH)) {
+    return CURRENT_CODEX_APP_PATH;
+  }
+  return LEGACY_CODEX_APP_PATH;
+}
+
+function normalizeDesktopTarget(target = {}, {
+  fsImpl = fs,
+  osImpl = os,
+  strictIpc = false,
+} = {}) {
+  const codexHome = path.resolve(readString(target.codexHome) || defaultCodexHome({ osImpl }));
+  const bundleId = readString(target.codexBundleId) || DEFAULT_CODEX_BUNDLE_ID;
+  const appPath = path.resolve(readString(target.codexAppPath) || defaultCodexAppPath({ fsImpl }));
+  const urlScheme = readString(target.codexUrlScheme) || DEFAULT_CODEX_URL_SCHEME;
+  const configuredSocket = readString(target.desktopIpcSocketPath);
+  const desktopIpcSocketPath = strictIpc
+    ? path.join(codexHome, "ipc", "ipc.sock")
+    : configuredSocket;
+
+  return {
+    codexHome,
+    codexBundleId: bundleId,
+    codexAppPath: appPath,
+    codexUrlScheme: urlScheme,
+    desktopIpcSocketPath,
+  };
+}
+
+function validateDesktopTarget(target, {
+  execFileSyncImpl = execFileSync,
+  fsImpl = fs,
+  platform = process.platform,
+  processImpl = process,
+  strictIpc = true,
+} = {}) {
+  validateConfiguredAbsolutePath(target?.codexHome, "Codex home");
+  validateConfiguredAbsolutePath(target?.codexAppPath, "Codex app");
+  const normalized = normalizeDesktopTarget(target, { fsImpl, strictIpc });
+  validateIdentifier(normalized.codexBundleId, BUNDLE_ID_PATTERN, "bundle identifier");
+  validateIdentifier(normalized.codexUrlScheme, URL_SCHEME_PATTERN, "URL scheme");
+  validateAbsoluteDirectory(normalized.codexHome, "Codex home", { fsImpl, processImpl });
+  validateAbsoluteDirectory(normalized.codexAppPath, "Codex app", {
+    fsImpl,
+    processImpl,
+    requireOwnership: false,
+    requireWritable: false,
+  });
+
+  if (platform === "darwin") {
+    validateMacOSBundleMetadata(normalized, { execFileSyncImpl });
+  }
+
+  return {
+    ...normalized,
+    codexTargetFingerprint: desktopTargetFingerprint(normalized),
+  };
+}
+
+function validateConfiguredAbsolutePath(value, label) {
+  const configured = readString(value);
+  if (configured && !path.isAbsolute(configured)) {
+    throw new Error(`${label} must be an absolute path.`);
+  }
+}
+
+function validateMacOSBundleMetadata(target, { execFileSyncImpl = execFileSync } = {}) {
+  const infoPath = path.join(target.codexAppPath, "Contents", "Info.plist");
+  let bundleId;
+  let plistJSON;
+  try {
+    bundleId = execFileSyncImpl("/usr/bin/plutil", ["-extract", "CFBundleIdentifier", "raw", infoPath], {
+      encoding: "utf8",
+    }).trim();
+    plistJSON = execFileSyncImpl("/usr/bin/plutil", ["-convert", "json", "-o", "-", infoPath], {
+      encoding: "utf8",
+    });
+  } catch (error) {
+    throw new Error(`Could not read the configured Codex app metadata: ${error.message}`);
+  }
+
+  if (bundleId !== target.codexBundleId) {
+    throw new Error(
+      `The configured app bundle is ${bundleId || "unknown"}, not ${target.codexBundleId}.`
+    );
+  }
+
+  const plist = JSON.parse(plistJSON);
+  const schemes = (Array.isArray(plist.CFBundleURLTypes) ? plist.CFBundleURLTypes : [])
+    .flatMap((entry) => Array.isArray(entry?.CFBundleURLSchemes) ? entry.CFBundleURLSchemes : [])
+    .filter((value) => typeof value === "string");
+  if (!schemes.includes(target.codexUrlScheme)) {
+    throw new Error(
+      `The configured app does not register the ${target.codexUrlScheme} URL scheme.`
+    );
+  }
+}
+
+function validateAbsoluteDirectory(value, label, {
+  fsImpl = fs,
+  processImpl = process,
+  requireOwnership = true,
+  requireWritable = true,
+} = {}) {
+  if (!path.isAbsolute(value)) {
+    throw new Error(`${label} must be an absolute path.`);
+  }
+  let stats;
+  try {
+    stats = fsImpl.statSync(value);
+  } catch {
+    throw new Error(`${label} does not exist: ${value}`);
+  }
+  if (!stats.isDirectory()) {
+    throw new Error(`${label} is not a directory: ${value}`);
+  }
+  if (requireOwnership && typeof processImpl.getuid === "function" && typeof stats.uid === "number"
+    && stats.uid !== processImpl.getuid()) {
+    throw new Error(`${label} is not owned by the current user: ${value}`);
+  }
+  if (requireWritable) {
+    try {
+      fsImpl.accessSync(value, fs.constants.R_OK | fs.constants.W_OK | fs.constants.X_OK);
+    } catch {
+      throw new Error(`${label} is not readable and writable by the current user: ${value}`);
+    }
+  }
+}
+
+function validateIdentifier(value, pattern, label) {
+  if (!pattern.test(value)) {
+    throw new Error(`The ${label} is invalid: ${value}`);
+  }
+}
+
+function buildCodexDeepLink(route, urlScheme = DEFAULT_CODEX_URL_SCHEME) {
+  const scheme = readString(urlScheme) || DEFAULT_CODEX_URL_SCHEME;
+  validateIdentifier(scheme, URL_SCHEME_PATTERN, "URL scheme");
+  const normalizedRoute = readString(route).replace(/^\/+/, "");
+  if (!normalizedRoute) {
+    throw new Error("A desktop deep-link route is required.");
+  }
+  return `${scheme}://${normalizedRoute}`;
+}
+
+function desktopTargetFingerprint(target = {}) {
+  const values = [
+    readString(target.codexHome),
+    readString(target.codexBundleId),
+    readString(target.codexAppPath),
+    readString(target.codexUrlScheme),
+    readString(target.desktopIpcSocketPath),
+  ];
+  return createHash("sha256").update(values.join("\0")).digest("hex").slice(0, 16);
+}
+
+function activateCodexHome(target, { env = process.env } = {}) {
+  const codexHome = readString(target?.codexHome);
+  if (codexHome) {
+    env.CODEX_HOME = codexHome;
+  }
+  return env;
+}
+
+function readString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+module.exports = {
+  CURRENT_CODEX_APP_PATH,
+  DEFAULT_CODEX_BUNDLE_ID,
+  DEFAULT_CODEX_URL_SCHEME,
+  LEGACY_CODEX_APP_PATH,
+  activateCodexHome,
+  buildCodexDeepLink,
+  defaultCodexAppPath,
+  defaultCodexHome,
+  desktopTargetFingerprint,
+  normalizeDesktopTarget,
+  validateDesktopTarget,
+};

--- a/phodex-bridge/src/index.js
+++ b/phodex-bridge/src/index.js
@@ -10,6 +10,10 @@ const { openLastActiveThread } = require("./session-state");
 const { watchThreadRollout } = require("./rollout-watch");
 const { readBridgeConfig } = require("./codex-desktop-refresher");
 const {
+  resetMacOSDesktopTarget,
+  setMacOSDesktopTarget,
+} = require("./desktop-target-controller");
+const {
   getMacOSBridgeServiceStatus,
   printMacOSBridgePairingQr,
   printMacOSBridgeServiceStatus,
@@ -28,10 +32,12 @@ module.exports = {
   readBridgeConfig,
   readBridgeDeviceState,
   resetMacOSBridgePairing,
+  resetMacOSDesktopTarget,
   restartMacOSBridgeService,
   startBridge,
   runMacOSBridgeService,
   startMacOSBridgeService,
+  setMacOSDesktopTarget,
   stopMacOSBridgeService,
   uninstallMacOSBridgeService,
   resetBridgePairing: resetBridgeTrustState,

--- a/phodex-bridge/src/macos-launch-agent.js
+++ b/phodex-bridge/src/macos-launch-agent.js
@@ -76,7 +76,10 @@ function runMacOSBridgeService({ env = process.env, platform = process.platform 
     },
     onBridgeStatus(status) {
       writeBridgeStatus(
-        mergeBridgeStatusForDaemon(status, readBridgeStatus({ env })),
+        {
+          ...mergeBridgeStatusForDaemon(status, readBridgeStatus({ env })),
+          codexTargetFingerprint: config.codexTargetFingerprint,
+        },
         { env }
       );
     },

--- a/phodex-bridge/src/session-state.js
+++ b/phodex-bridge/src/session-state.js
@@ -8,10 +8,15 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const { execFileSync } = require("child_process");
+const {
+  DEFAULT_CODEX_BUNDLE_ID,
+  DEFAULT_CODEX_URL_SCHEME,
+  buildCodexDeepLink,
+  defaultCodexAppPath,
+} = require("./desktop-target");
 
 const STATE_DIR = path.join(os.homedir(), ".remodex");
 const STATE_FILE = path.join(STATE_DIR, "last-thread.json");
-const DEFAULT_BUNDLE_ID = "com.openai.codex";
 
 function rememberActiveThread(threadId, source) {
   if (!threadId || typeof threadId !== "string") {
@@ -29,15 +34,24 @@ function rememberActiveThread(threadId, source) {
   return true;
 }
 
-function openLastActiveThread({ bundleId = DEFAULT_BUNDLE_ID } = {}) {
+function openLastActiveThread({
+  bundleId = DEFAULT_CODEX_BUNDLE_ID,
+  appPath = defaultCodexAppPath(),
+  urlScheme = DEFAULT_CODEX_URL_SCHEME,
+  execFileSyncImpl = execFileSync,
+} = {}) {
   const state = readState();
   const threadId = state?.threadId;
   if (!threadId) {
     throw new Error("No remembered Remodex thread found yet.");
   }
 
-  const targetUrl = `codex://threads/${threadId}`;
-  execFileSync("open", ["-b", bundleId, targetUrl], { stdio: "ignore" });
+  const targetUrl = buildCodexDeepLink(`threads/${threadId}`, urlScheme);
+  try {
+    execFileSyncImpl("open", ["-b", bundleId, targetUrl], { stdio: "ignore" });
+  } catch {
+    execFileSyncImpl("open", ["-a", appPath, targetUrl], { stdio: "ignore" });
+  }
   return state;
 }
 

--- a/phodex-bridge/test/codex-desktop-refresher.test.js
+++ b/phodex-bridge/test/codex-desktop-refresher.test.js
@@ -140,6 +140,41 @@ test("readBridgeConfig keeps safe defaults and explicit overrides", () => {
       },
     },
   });
+  const selectedTargetConfig = readBridgeConfig({
+    env: {
+      CODEX_HOME: "/Users/test/Codex Home",
+      REMODEX_CODEX_BUNDLE_ID: "com.openai.codex.secondary",
+      REMODEX_CODEX_APP_PATH: "/Users/test/ChatGPT Personal.app",
+      REMODEX_CODEX_URL_SCHEME: "codex-secondary",
+    },
+    platform: "darwin",
+    runtimeRoot: "/tmp/remodex-package",
+    fsImpl: {
+      existsSync: () => false,
+      readFileSync: () => {
+        throw new Error("unexpected read");
+      },
+    },
+  });
+  const resetPrimaryTargetConfig = readBridgeConfig({
+    env: { REMODEX_DEVICE_STATE_DIR: "/tmp/remodex-primary-state" },
+    platform: "darwin",
+    runtimeRoot: "/tmp/remodex-package",
+    fsImpl: {
+      existsSync(targetPath) {
+        return targetPath === "/tmp/remodex-primary-state/daemon-config.json";
+      },
+      readFileSync(targetPath) {
+        if (targetPath === "/tmp/remodex-primary-state/daemon-config.json") {
+          return JSON.stringify({
+            codexHome: path.join(os.homedir(), ".codex"),
+            desktopIpcSocketPath: "",
+          });
+        }
+        throw new Error("unexpected read");
+      },
+    },
+  });
   assert.equal(macConfig.refreshEnabled, false);
   assert.equal(macConfig.keepMacAwakeEnabled, false);
   assert.equal(macConfig.relayUrl, "");
@@ -160,6 +195,15 @@ test("readBridgeConfig keeps safe defaults and explicit overrides", () => {
   assert.equal(explicitOffConfig.desktopIpcSnapshotDebounceMs, 25);
   assert.equal(explicitOffConfig.keepMacAwakeEnabled, false);
   assert.equal(explicitAutoFollowOffConfig.desktopAutoFollowEnabled, false);
+  assert.equal(selectedTargetConfig.codexHome, "/Users/test/Codex Home");
+  assert.equal(selectedTargetConfig.codexBundleId, "com.openai.codex.secondary");
+  assert.equal(selectedTargetConfig.codexAppPath, "/Users/test/ChatGPT Personal.app");
+  assert.equal(selectedTargetConfig.codexUrlScheme, "codex-secondary");
+  assert.equal(
+    selectedTargetConfig.desktopIpcSocketPath,
+    "/Users/test/Codex Home/ipc/ipc.sock"
+  );
+  assert.equal(resetPrimaryTargetConfig.desktopIpcSocketPath, "");
 });
 
 test("readBridgeConfig uses only the packaged relay default outside a source checkout", () => {

--- a/phodex-bridge/test/desktop-handler.test.js
+++ b/phodex-bridge/test/desktop-handler.test.js
@@ -29,7 +29,7 @@ test("desktop/continueOnMac relaunches Codex for the requested thread", async ()
     appPath: "/Applications/Codex.app",
     executor: async (...args) => {
       executorCalls.push(args);
-      if (args[0] === "pkill") {
+      if (args[0] === "/usr/bin/osascript") {
         running = false;
       }
       return { stdout: "", stderr: "" };
@@ -44,10 +44,15 @@ test("desktop/continueOnMac relaunches Codex for the requested thread", async ()
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   assert.equal(executorCalls.length, 3);
-  assert.equal(executorCalls[0][0], "pkill");
+  assert.equal(executorCalls[0][0], "/usr/bin/osascript");
   assert.deepEqual(executorCalls[0][1], [
-    "-x",
-    "Codex",
+    "-e",
+    "on run argv",
+    "-e",
+    "tell application id (item 1 of argv) to quit",
+    "-e",
+    "end run",
+    "com.openai.codex",
   ]);
   assert.equal(executorCalls[1][0], "open");
   assert.deepEqual(executorCalls[1][1], [
@@ -114,6 +119,33 @@ test("desktop/continueOnMac boots Codex before deep-linking unknown threads", as
   assert.equal(responses[0].result?.relaunched, false);
 });
 
+test("desktop/continueOnMac uses the selected Doppel bundle and scheme", async () => {
+  const calls = [];
+  const responses = [];
+  handleDesktopRequest(JSON.stringify({
+    id: "request-doppel",
+    method: "desktop/continueOnMac",
+    params: { threadId: "thread-doppel" },
+  }), (response) => responses.push(JSON.parse(response)), {
+    platform: "darwin",
+    bundleId: "com.openai.codex.secondary",
+    appPath: "/Users/test/ChatGPT Personal.app",
+    urlScheme: "codex-secondary",
+    executor: async (...args) => { calls.push(args); return { stdout: "", stderr: "" }; },
+    isAppRunning: async () => false,
+    sleepFn: async () => {},
+    threadMaterializeWaitMs: 0,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(calls[0], [
+    "open", ["-b", "com.openai.codex.secondary"], { timeout: 20_000 },
+  ]);
+  assert.deepEqual(calls[1], ["open", [
+    "-b", "com.openai.codex.secondary", "codex-secondary://threads/thread-doppel",
+  ], { timeout: 20_000 }]);
+  assert.equal(responses[0].result.targetUrl, "codex-secondary://threads/thread-doppel");
+});
+
 test("desktop/continueOnMac relaunches when a desktop-known thread is requested and Codex is already open", async () => {
   const executorCalls = [];
   const responses = [];
@@ -155,7 +187,7 @@ test("desktop/continueOnMac relaunches when a desktop-known thread is requested 
     fsModule: fakeFS,
     executor: async (...args) => {
       executorCalls.push(args);
-      if (args[0] === "pkill") {
+      if (args[0] === "/usr/bin/osascript") {
         running = false;
       }
       return { stdout: "", stderr: "" };
@@ -167,10 +199,15 @@ test("desktop/continueOnMac relaunches when a desktop-known thread is requested 
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   assert.equal(executorCalls.length, 3);
-  assert.equal(executorCalls[0][0], "pkill");
+  assert.equal(executorCalls[0][0], "/usr/bin/osascript");
   assert.deepEqual(executorCalls[0][1], [
-    "-x",
-    "Codex",
+    "-e",
+    "on run argv",
+    "-e",
+    "tell application id (item 1 of argv) to quit",
+    "-e",
+    "end run",
+    "com.openai.codex",
   ]);
   assert.equal(executorCalls[1][0], "open");
   assert.deepEqual(executorCalls[1][1], [

--- a/phodex-bridge/test/desktop-target-controller.test.js
+++ b/phodex-bridge/test/desktop-target-controller.test.js
@@ -1,0 +1,117 @@
+// FILE: desktop-target-controller.test.js
+// Purpose: Verifies safe target switching, preservation, and transactional rollback.
+// Layer: Unit test
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  setMacOSDesktopTarget,
+  waitForHealthyTarget,
+} = require("../src/desktop-target-controller");
+
+const selected = {
+  codexHome: "/Users/test/.codex-secondary",
+  codexBundleId: "com.openai.codex.secondary",
+  codexAppPath: "/Users/test/Applications/ChatGPT Personal.app",
+  codexUrlScheme: "codex-secondary",
+  desktopIpcSocketPath: "/Users/test/.codex-secondary/ipc/ipc.sock",
+  codexTargetFingerprint: "secondary-fingerprint",
+};
+
+test("running service requires --restart before changing target", async () => {
+  let wrote = false;
+  await assert.rejects(setMacOSDesktopTarget({
+    target: selected,
+    platform: "darwin",
+    getServiceStatusImpl: () => ({ launchdLoaded: true }),
+    validateTargetImpl: () => selected,
+    writeDaemonConfigImpl: () => { wrote = true; },
+  }), /with --restart/);
+  assert.equal(wrote, false);
+});
+
+test("target switch preserves pairing and relay configuration", async () => {
+  const writes = [];
+  let restarted = 0;
+  const previous = {
+    relayUrl: "wss://relay.example/relay",
+    trustedPhoneId: "phone-1",
+    codexHome: "/Users/test/.codex",
+  };
+  const result = await setMacOSDesktopTarget({
+    target: selected,
+    restart: true,
+    platform: "darwin",
+    getServiceStatusImpl: () => ({ launchdLoaded: true }),
+    validateTargetImpl: () => selected,
+    readDaemonConfigImpl: () => previous,
+    writeDaemonConfigImpl: (value) => writes.push(value),
+    restartServiceImpl: async () => { restarted += 1; },
+    waitForHealthyTargetImpl: async (fingerprint) => {
+      assert.equal(fingerprint, "secondary-fingerprint");
+    },
+  });
+  assert.equal(restarted, 1);
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].relayUrl, previous.relayUrl);
+  assert.equal(writes[0].trustedPhoneId, previous.trustedPhoneId);
+  assert.equal(writes[0].codexHome, selected.codexHome);
+  assert.equal(result.restarted, true);
+});
+
+test("failed startup restores the complete previous configuration", async () => {
+  const writes = [];
+  let restarts = 0;
+  const previous = {
+    relayUrl: "wss://relay.example/relay",
+    trustedPhoneId: "phone-1",
+    codexHome: "/Users/test/.codex",
+    codexTargetFingerprint: "primary-fingerprint",
+  };
+  await assert.rejects(setMacOSDesktopTarget({
+    target: selected,
+    restart: true,
+    platform: "darwin",
+    getServiceStatusImpl: () => ({ launchdLoaded: true }),
+    validateTargetImpl: () => selected,
+    readDaemonConfigImpl: () => previous,
+    writeDaemonConfigImpl: (value) => writes.push({ ...value }),
+    restartServiceImpl: async () => { restarts += 1; },
+    waitForHealthyTargetImpl: async () => { throw new Error("app-server disconnected"); },
+  }), /previous configuration was restored/);
+  assert.equal(restarts, 2);
+  assert.deepEqual(writes, [{ ...previous, ...selected }, previous]);
+});
+
+test("health verification rejects stale and stopped bridge status", async () => {
+  const statuses = [
+    {
+      state: "running",
+      updatedAt: "2026-08-23T12:59:59.000Z",
+      codexTargetFingerprint: "secondary-fingerprint",
+      codexLaunchState: "connected",
+    },
+    {
+      state: "stopped",
+      updatedAt: "2026-08-23T13:00:01.000Z",
+      codexTargetFingerprint: "secondary-fingerprint",
+      codexLaunchState: "connected",
+    },
+    {
+      state: "running",
+      updatedAt: "2026-08-23T13:00:02.000Z",
+      codexTargetFingerprint: "secondary-fingerprint",
+      codexLaunchState: "connected",
+    },
+  ];
+  let reads = 0;
+  const result = await waitForHealthyTarget("secondary-fingerprint", {
+    notBeforeMs: Date.parse("2026-08-23T13:00:00.000Z"),
+    timeoutMs: 100,
+    intervalMs: 0,
+    readBridgeStatusImpl: () => statuses[Math.min(reads++, statuses.length - 1)],
+  });
+  assert.equal(reads, 3);
+  assert.equal(result.state, "running");
+});

--- a/phodex-bridge/test/desktop-target.test.js
+++ b/phodex-bridge/test/desktop-target.test.js
@@ -1,0 +1,125 @@
+// FILE: desktop-target.test.js
+// Purpose: Verifies configurable Codex Desktop target validation and isolation.
+// Layer: Unit test
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  activateCodexHome,
+  buildCodexDeepLink,
+  desktopTargetFingerprint,
+  normalizeDesktopTarget,
+  validateDesktopTarget,
+} = require("../src/desktop-target");
+
+test("legacy configuration retains primary target defaults", () => {
+  const target = normalizeDesktopTarget({}, {
+    osImpl: { homedir: () => "/Users/test" },
+    fsImpl: { existsSync: () => true },
+  });
+  assert.deepEqual(target, {
+    codexHome: "/Users/test/.codex",
+    codexBundleId: "com.openai.codex",
+    codexAppPath: "/Applications/ChatGPT.app",
+    codexUrlScheme: "codex",
+    desktopIpcSocketPath: "",
+  });
+});
+
+function createTargetFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remodex target "));
+  const codexHome = path.join(root, "Codex Home");
+  const codexAppPath = path.join(root, "ChatGPT Personal.app");
+  fs.mkdirSync(codexHome, { recursive: true });
+  fs.mkdirSync(path.join(codexAppPath, "Contents"), { recursive: true });
+  fs.writeFileSync(path.join(codexAppPath, "Contents", "Info.plist"), "fixture");
+  return { root, codexHome, codexAppPath };
+}
+
+test("custom target validation derives IPC strictly from its Codex home", (t) => {
+  const fixture = createTargetFixture();
+  t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));
+  const calls = [];
+  const target = validateDesktopTarget({
+    codexHome: fixture.codexHome,
+    codexBundleId: "com.openai.codex.secondary",
+    codexAppPath: fixture.codexAppPath,
+    codexUrlScheme: "codex-secondary",
+    desktopIpcSocketPath: "/tmp/unsafe-primary.sock",
+  }, {
+    platform: "darwin",
+    execFileSyncImpl(command, args) {
+      calls.push([command, args]);
+      if (args.includes("CFBundleIdentifier")) {
+        return "com.openai.codex.secondary\n";
+      }
+      return JSON.stringify({
+        CFBundleURLTypes: [{ CFBundleURLSchemes: ["codex-secondary"] }],
+      });
+    },
+  });
+
+  assert.equal(target.desktopIpcSocketPath, path.join(fixture.codexHome, "ipc", "ipc.sock"));
+  assert.equal(target.codexTargetFingerprint, desktopTargetFingerprint(target));
+  assert.equal(calls.length, 2);
+});
+
+test("target validation rejects relative homes and app paths", (t) => {
+  const fixture = createTargetFixture();
+  t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));
+  const input = {
+    codexHome: fixture.codexHome,
+    codexBundleId: "com.openai.codex.secondary",
+    codexAppPath: fixture.codexAppPath,
+    codexUrlScheme: "codex-secondary",
+  };
+  assert.throws(
+    () => validateDesktopTarget({ ...input, codexHome: ".codex-secondary" }, { platform: "linux" }),
+    /Codex home must be an absolute path/
+  );
+  assert.throws(
+    () => validateDesktopTarget({ ...input, codexAppPath: "ChatGPT Personal.app" }, { platform: "linux" }),
+    /Codex app must be an absolute path/
+  );
+});
+
+test("target validation rejects mismatched bundle metadata and schemes", (t) => {
+  const fixture = createTargetFixture();
+  t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));
+  const input = {
+    codexHome: fixture.codexHome,
+    codexBundleId: "com.openai.codex.secondary",
+    codexAppPath: fixture.codexAppPath,
+    codexUrlScheme: "codex-secondary",
+  };
+  assert.throws(() => validateDesktopTarget(input, {
+    platform: "darwin",
+    execFileSyncImpl(command, args) {
+      return args.includes("CFBundleIdentifier")
+        ? "com.openai.codex.wrong\n"
+        : JSON.stringify({ CFBundleURLTypes: [] });
+    },
+  }), /not com\.openai\.codex\.secondary/);
+  assert.throws(() => validateDesktopTarget(input, {
+    platform: "darwin",
+    execFileSyncImpl(command, args) {
+      return args.includes("CFBundleIdentifier")
+        ? "com.openai.codex.secondary\n"
+        : JSON.stringify({ CFBundleURLTypes: [{ CFBundleURLSchemes: ["codex"] }] });
+    },
+  }), /does not register the codex-secondary/);
+});
+
+test("deep links and child environment use the selected target", () => {
+  const env = { CODEX_HOME: "/old" };
+  activateCodexHome({ codexHome: "/Users/test/.codex-secondary" }, { env });
+  assert.equal(env.CODEX_HOME, "/Users/test/.codex-secondary");
+  assert.equal(
+    buildCodexDeepLink("threads/thread-123", "codex-secondary"),
+    "codex-secondary://threads/thread-123"
+  );
+});

--- a/phodex-bridge/test/remodex-cli.test.js
+++ b/phodex-bridge/test/remodex-cli.test.js
@@ -94,6 +94,88 @@ test("remodex start refreshes macOS service config and plist", async () => {
   ]);
 });
 
+test("remodex target set forwards exact values without shell interpolation", async () => {
+  const calls = [];
+  const messages = [];
+  await main({
+    argv: [
+      "node", "remodex", "target", "set",
+      "--codex-home", "/Users/test/Codex Home",
+      "--bundle-id", "com.openai.codex.secondary",
+      "--app-path", "/Users/test/ChatGPT Personal.app",
+      "--url-scheme", "codex-secondary",
+      "--restart",
+    ],
+    platform: "darwin",
+    consoleImpl: {
+      log(message) { messages.push(message); },
+      error(message) { throw new Error(`unexpected error: ${message}`); },
+    },
+    exitImpl(code) { throw new Error(`unexpected exit ${code}`); },
+    deps: {
+      async setMacOSDesktopTarget(options) {
+        calls.push(options);
+        return { target: options.target, restarted: true, rolledBack: false };
+      },
+    },
+  });
+  assert.deepEqual(calls, [{
+    target: {
+      codexHome: "/Users/test/Codex Home",
+      codexBundleId: "com.openai.codex.secondary",
+      codexAppPath: "/Users/test/ChatGPT Personal.app",
+      codexUrlScheme: "codex-secondary",
+    },
+    restart: true,
+  }]);
+  assert.deepEqual(messages, ["[remodex] Desktop target updated and service restarted."]);
+});
+
+test("remodex target reset preserves the default contract", async () => {
+  const calls = [];
+  await main({
+    argv: ["node", "remodex", "target", "reset", "--restart"],
+    platform: "darwin",
+    consoleImpl: { log() {}, error(message) { throw new Error(message); } },
+    exitImpl(code) { throw new Error(`unexpected exit ${code}`); },
+    deps: {
+      async resetMacOSDesktopTarget(options) {
+        calls.push(options);
+        return { target: {}, restarted: true, rolledBack: false };
+      },
+    },
+  });
+  assert.deepEqual(calls, [{ restart: true }]);
+});
+
+test("remodex resume forwards the persisted desktop target", async () => {
+  const calls = [];
+  await main({
+    argv: ["node", "remodex", "resume"],
+    platform: "darwin",
+    consoleImpl: { log() {}, error(message) { throw new Error(message); } },
+    exitImpl(code) { throw new Error(`unexpected exit ${code}`); },
+    deps: {
+      readBridgeConfig() {
+        return {
+          codexBundleId: "com.openai.codex.secondary",
+          codexAppPath: "/Users/test/ChatGPT Personal.app",
+          codexUrlScheme: "codex-secondary",
+        };
+      },
+      openLastActiveThread(options) {
+        calls.push(options);
+        return { threadId: "thread-1", source: "phone" };
+      },
+    },
+  });
+  assert.deepEqual(calls, [{
+    bundleId: "com.openai.codex.secondary",
+    appPath: "/Users/test/ChatGPT Personal.app",
+    urlScheme: "codex-secondary",
+  }]);
+});
+
 test("remodex up shows a startup indicator while waiting for the pairing QR", async () => {
   const calls = [];
   const messages = [];


### PR DESCRIPTION
## Summary

- persist and validate a configurable Codex Desktop target
- isolate CODEX_HOME, rollout, worktree, IPC, and deep-link routing
- switch running services transactionally with fresh daemon health verification and rollback
- use bundle-aware macOS launch and quit handling

## Verification

- rebased onto Remodex 3.1.0
- full Node suite: 715 passed
- focused target suite: 59 passed after rebase; 24 passed after final health-gate fixes
- live ChatGPT Personal restart: fresh running daemon, matching fingerprint, connected app-server, isolated IPC socket

## Pending

- paired-iPhone create/resume, bidirectional streaming, approval, and Continue on Mac QA